### PR TITLE
feat(v1.1 Phase 7.1): wall rotation + product resize

### DIFF
--- a/.planning/phases/07.1-rotate-resize/07.1-PLAN.md
+++ b/.planning/phases/07.1-rotate-resize/07.1-PLAN.md
@@ -1,0 +1,59 @@
+---
+phase: 07.1-rotate-resize
+plan: 01
+subsystem: canvas-tools
+tags: [edit-12, edit-14, rotation, resize, data-model]
+requires: [selectTool, cadStore, PlacedProduct type]
+provides: [wall rotation handle, rotateWall action, product resize handles, sizeScale field, resizeProduct action, live size tag]
+affects:
+  - src/types/cad.ts
+  - src/stores/cadStore.ts
+  - src/types/product.ts
+  - src/canvas/wallRotationHandle.ts (new)
+  - src/canvas/resizeHandles.ts (new)
+  - src/canvas/fabricSync.ts
+  - src/canvas/tools/selectTool.ts
+  - src/three/ProductMesh.tsx
+decisions:
+  - "Wall rotation: pivots around wall midpoint, DETACHES from shared endpoints. Per user request: simpler and more predictable than dragging neighbors along."
+  - "Product resize: aspect-ratio preserved via single sizeScale multiplier (not per-axis width/depth overrides). Library dims never mutated; scale applied at read time via effectiveDimensions(p, scale)."
+  - "4 corner handles for products, all behave identically (scale from distance to center). Simpler than edge-specific handles."
+  - "Scale clamped 0.1× – 10× to prevent disappearing or absurd products."
+  - "Live size tag rendered as Fabric Group (Rect+Text) matching the Obsidian theme. Positioned below product, follows rotation."
+metrics:
+  requirements_closed: [EDIT-12, EDIT-14]
+---
+
+# Phase 7.1 Plan: Rotate + Resize
+
+## Goal
+
+Close the two items deferred from Phase 7: users can rotate placed walls (EDIT-12) and resize placed products with a live size tag (EDIT-14).
+
+## Tasks
+
+- [x] Add `sizeScale` optional field to `PlacedProduct` type
+- [x] Update `effectiveDimensions(product, scale=1)` to apply scale when reading dims
+- [x] Update all 3 call sites (selectTool hit-test, fabricSync rendering, ProductMesh 3D)
+- [x] Add `rotateWall` + `rotateWallNoHistory` to cadStore (rotate around midpoint)
+- [x] Add `resizeProduct` + `resizeProductNoHistory` to cadStore (clamped 0.1–10×)
+- [x] Create `src/canvas/wallRotationHandle.ts` with geometry helpers
+- [x] Create `src/canvas/resizeHandles.ts` with 4-corner geometry + hit-test
+- [x] Render rotation handle on selected walls (stem + circle) in fabricSync
+- [x] Render 4 corner resize handles on selected products in fabricSync
+- [x] selectTool hit-test for both new handles, with drag state
+- [x] selectTool drag handler: wall-rotate (uses midpoint→pointer angle delta, shift bypasses 15° snap)
+- [x] selectTool drag handler: product-resize (scale = pointer-distance / initial-distance)
+- [x] Live size tag during product resize, cleaned up on mouseup + tool deactivation
+
+## Verification
+
+- [x] Select a wall → rotation handle appears perpendicular to wall at midpoint
+- [x] Drag handle → wall rotates around midpoint in 15° increments
+- [x] Shift+drag → free rotation
+- [x] Rotating a wall that shared corners detaches it (neighbor walls stay put)
+- [x] Select a product → 4 corner handles appear
+- [x] Drag any corner handle → product scales uniformly (aspect preserved)
+- [x] Size tag shows "W × D" in feet+inches below product during drag
+- [x] Release → tag clears, size persists in store
+- [x] Undo/redo wall rotation and product resize work

--- a/.planning/phases/07.1-rotate-resize/07.1-SUMMARY.md
+++ b/.planning/phases/07.1-rotate-resize/07.1-SUMMARY.md
@@ -1,0 +1,61 @@
+---
+phase: 07.1-rotate-resize
+plan: 01
+subsystem: canvas-tools
+tags: [edit-12, edit-14]
+provides: [wall-rotate handle, product-resize handles, sizeScale, live size tag]
+affects:
+  - src/types/cad.ts
+  - src/stores/cadStore.ts
+  - src/types/product.ts
+  - src/canvas/wallRotationHandle.ts
+  - src/canvas/resizeHandles.ts
+  - src/canvas/fabricSync.ts
+  - src/canvas/tools/selectTool.ts
+  - src/three/ProductMesh.tsx
+decisions:
+  - "sizeScale = single aspect-preserving multiplier; library dims never mutated"
+  - "Wall rotation detaches shared corners (no neighbor tracking)"
+  - "4-corner resize handles, all identical behavior"
+  - "Scale clamped 0.1× to 10×"
+metrics:
+  completed: 2026-04-05
+  duration: ~25m
+  requirements_closed: [EDIT-12, EDIT-14]
+---
+
+# Phase 7.1 Summary
+
+Closes EDIT-12 (rotate placed walls) and EDIT-14 (resize products with size tag).
+
+## What shipped
+
+**Wall rotation:** Select any wall → rotation handle (circle) appears
+1.2 ft perpendicular to the wall at its midpoint, connected by a stem
+line. Drag to rotate around the midpoint. 15° snap by default, hold
+Shift for free rotation. Rotating detaches shared corners from
+neighbors — simpler than dragging neighbors along.
+
+**Product resize:** Select any product → 4 corner handles (purple
+squares with dark fill) appear at the product's corners in world
+space (respecting rotation). Drag any corner to scale the product
+uniformly. Size is stored as a single multiplier (`sizeScale`) on
+PlacedProduct, so library dimensions are never mutated — just scaled
+at read time via `effectiveDimensions(product, scale)`.
+
+**Live size tag:** During resize drag, a small Obsidian-themed tag
+appears below the product showing current W × D in feet+inches.
+Clears on mouse up.
+
+## Data model change
+
+Added `sizeScale?: number` to `PlacedProduct`. Defaults to 1 when
+absent. Clamped 0.1× to 10× to prevent absurd scaling. All 3 callers
+of `effectiveDimensions` updated: selectTool hit-test, fabricSync
+2D rendering, ProductMesh 3D rendering.
+
+## Undo/redo
+
+Both actions push history on drag start (via `resizeProduct` /
+`rotateWall`) then use `*NoHistory` variants during drag. One undo
+step per drag, matching the existing product rotation pattern.

--- a/src/canvas/fabricSync.ts
+++ b/src/canvas/fabricSync.ts
@@ -3,9 +3,11 @@ import type { WallSegment, PlacedProduct } from "@/types/cad";
 import type { Product } from "@/types/product";
 import { effectiveDimensions, hasDimensions } from "@/types/product";
 import { wallCorners, angle as wallAngle } from "@/lib/geometry";
+import { getWallHandleWorldPos } from "./wallRotationHandle";
 import { drawWallDimension } from "./dimensions";
 import { getCachedImage } from "./productImageCache";
 import { getHandleWorldPos } from "./rotationHandle";
+import { getResizeHandles } from "./resizeHandles";
 
 const WALL_FILL = "#343440";
 const WALL_STROKE = "#484554";
@@ -112,6 +114,39 @@ export function renderWalls(
 
     // Dimension label
     drawWallDimension(fc, wall, scale, origin);
+
+    // Rotation handle for selected walls (EDIT-12)
+    if (isSelected) {
+      const h = getWallHandleWorldPos(wall);
+      const hx = origin.x + h.x * scale;
+      const hy = origin.y + h.y * scale;
+      // Stem line from wall midpoint to handle
+      const cx = origin.x + ((wall.start.x + wall.end.x) / 2) * scale;
+      const cy = origin.y + ((wall.start.y + wall.end.y) / 2) * scale;
+      fc.add(
+        new fabric.Line([cx, cy, hx, hy], {
+          stroke: WALL_SELECTED_STROKE,
+          strokeWidth: 1,
+          selectable: false,
+          evented: false,
+        })
+      );
+      fc.add(
+        new fabric.Circle({
+          left: hx,
+          top: hy,
+          radius: 5,
+          fill: WALL_SELECTED_STROKE,
+          stroke: "#ffffff",
+          strokeWidth: 1,
+          originX: "center",
+          originY: "center",
+          selectable: false,
+          evented: false,
+          data: { type: "wall-rotate-handle", wallId: wall.id },
+        })
+      );
+    }
   }
 
   // For each shared endpoint with exactly two walls meeting, compute the
@@ -228,7 +263,7 @@ export function renderProducts(
 ) {
   for (const pp of Object.values(placedProducts)) {
     const product = productLibrary.find((p) => p.id === pp.productId);
-    const { width, depth, isPlaceholder } = effectiveDimensions(product);
+    const { width, depth, isPlaceholder } = effectiveDimensions(product, pp.sizeScale);
     const orphan = !product;
     const showPlaceholder = orphan || isPlaceholder;
 
@@ -340,6 +375,30 @@ export function renderProducts(
       });
       fc.add(line);
       fc.add(circle);
+    }
+
+    // Corner resize handles for selected products (EDIT-14)
+    if (isSelected && selectedIds.length === 1) {
+      const handles = getResizeHandles(pp, width, depth);
+      for (const key of ["ne", "nw", "sw", "se"] as const) {
+        const h = handles[key];
+        fc.add(
+          new fabric.Rect({
+            left: origin.x + h.x * scale,
+            top: origin.y + h.y * scale,
+            width: 10,
+            height: 10,
+            fill: "#12121d",
+            stroke: "#7c5bf0",
+            strokeWidth: 2,
+            originX: "center",
+            originY: "center",
+            selectable: false,
+            evented: false,
+            data: { type: "resize-handle", corner: key, placedProductId: pp.id },
+          })
+        );
+      }
     }
   }
 }

--- a/src/canvas/resizeHandles.ts
+++ b/src/canvas/resizeHandles.ts
@@ -1,0 +1,59 @@
+import type { Point, PlacedProduct } from "@/types/cad";
+
+export const RESIZE_HANDLE_HIT_RADIUS_FT = 0.5;
+
+/** Return the 4 corner handle positions in world feet, accounting for the
+ *  product's rotation (so handles rotate with the product). */
+export function getResizeHandles(
+  pp: PlacedProduct,
+  widthFt: number,
+  depthFt: number,
+): { ne: Point; nw: Point; se: Point; sw: Point } {
+  const hw = widthFt / 2;
+  const hd = depthFt / 2;
+  // Local corners (before rotation), counterclockwise from NE
+  const local = {
+    ne: { x: hw, y: -hd },
+    nw: { x: -hw, y: -hd },
+    sw: { x: -hw, y: hd },
+    se: { x: hw, y: hd },
+  };
+  const rad = (pp.rotation * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const toWorld = (p: Point): Point => ({
+    x: pp.position.x + p.x * cos - p.y * sin,
+    y: pp.position.y + p.x * sin + p.y * cos,
+  });
+  return {
+    ne: toWorld(local.ne),
+    nw: toWorld(local.nw),
+    sw: toWorld(local.sw),
+    se: toWorld(local.se),
+  };
+}
+
+/** Test whether pointerFt hits any corner handle. Returns the corner id or null. */
+export function hitTestResizeHandle(
+  pointerFt: Point,
+  pp: PlacedProduct,
+  widthFt: number,
+  depthFt: number,
+): "ne" | "nw" | "sw" | "se" | null {
+  const handles = getResizeHandles(pp, widthFt, depthFt);
+  for (const key of ["ne", "nw", "sw", "se"] as const) {
+    const h = handles[key];
+    const dx = pointerFt.x - h.x;
+    const dy = pointerFt.y - h.y;
+    if (Math.sqrt(dx * dx + dy * dy) <= RESIZE_HANDLE_HIT_RADIUS_FT) {
+      return key;
+    }
+  }
+  return null;
+}
+
+/** Diagonal distance from product center to a corner (in local coords),
+ *  in feet. Used to compute scale factor from pointer distance. */
+export function cornerDiagonalFt(widthFt: number, depthFt: number): number {
+  return Math.sqrt((widthFt / 2) ** 2 + (depthFt / 2) ** 2);
+}

--- a/src/canvas/tools/selectTool.ts
+++ b/src/canvas/tools/selectTool.ts
@@ -1,18 +1,29 @@
 import * as fabric from "fabric";
 import { useCADStore, getActiveRoomDoc } from "@/stores/cadStore";
 import { useUIStore } from "@/stores/uiStore";
-import { snapPoint, distance, closestPointOnWall } from "@/lib/geometry";
+import { snapPoint, distance, closestPointOnWall, formatFeet } from "@/lib/geometry";
 import type { Point, WallSegment, PlacedProduct } from "@/types/cad";
 import type { Product } from "@/types/product";
 import { effectiveDimensions } from "@/types/product";
 import { hitTestHandle, snapAngle, angleFromCenterToPointer } from "../rotationHandle";
+import {
+  hitTestWallHandle,
+  angleFromMidpointToPointer,
+  wallAngleDeg,
+  snapWallAngle,
+} from "../wallRotationHandle";
+import { hitTestResizeHandle } from "../resizeHandles";
 
 interface SelectState {
   dragging: boolean;
   dragId: string | null;
-  dragType: "wall" | "product" | "rotate" | null;
+  dragType: "wall" | "product" | "rotate" | "wall-rotate" | "product-resize" | null;
   dragOffsetFeet: Point | null;
   rotateInitialAngle: number | null;
+  wallRotateInitialAngleDeg: number | null;
+  wallRotatePointerStartDeg: number | null;
+  resizeInitialScale: number | null;
+  resizeInitialDiagFt: number | null;
 }
 
 const state: SelectState = {
@@ -21,6 +32,10 @@ const state: SelectState = {
   dragType: null,
   dragOffsetFeet: null,
   rotateInitialAngle: null,
+  wallRotateInitialAngleDeg: null,
+  wallRotatePointerStartDeg: null,
+  resizeInitialScale: null,
+  resizeInitialDiagFt: null,
 };
 
 function pxToFeet(
@@ -48,7 +63,7 @@ function hitTestStore(
   // Check products first (they're on top) — orphan + null-dim use 2x2 AABB
   for (const pp of Object.values(doc.placedProducts)) {
     const product = productLibrary.find((p) => p.id === pp.productId);
-    const { width, depth } = effectiveDimensions(product);
+    const { width, depth } = effectiveDimensions(product, pp.sizeScale);
     const halfW = width / 2;
     const halfD = depth / 2;
     // Simple AABB check (ignoring rotation for now)
@@ -86,6 +101,71 @@ function hitTestStore(
 // Product library reference — set by the canvas component
 let _productLibrary: Product[] = [];
 
+// Live size-tag shown during product resize
+let sizeTag: fabric.Group | null = null;
+
+function updateSizeTag(
+  fc: fabric.Canvas,
+  pp: PlacedProduct,
+  widthFt: number,
+  depthFt: number,
+  viewScale: number,
+  viewOrigin: { x: number; y: number },
+) {
+  const label = `${formatFeet(widthFt)} × ${formatFeet(depthFt)}`;
+  // Position the tag just below the product
+  const hw = widthFt / 2;
+  const hd = depthFt / 2;
+  const rad = (pp.rotation * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  // Bottom-center of product in local coords → world
+  const localBottom = { x: 0, y: hd + 0.5 };
+  const worldX = pp.position.x + localBottom.x * cos - localBottom.y * sin;
+  const worldY = pp.position.y + localBottom.x * sin + localBottom.y * cos;
+  const px = viewOrigin.x + worldX * viewScale;
+  const py = viewOrigin.y + worldY * viewScale;
+
+  if (sizeTag) fc.remove(sizeTag);
+  const bg = new fabric.Rect({
+    width: 80,
+    height: 20,
+    fill: "#12121d",
+    stroke: "#7c5bf0",
+    strokeWidth: 1,
+    rx: 2,
+    ry: 2,
+    originX: "center",
+    originY: "center",
+  });
+  const text = new fabric.Text(label, {
+    fontFamily: "IBM Plex Mono",
+    fontSize: 10,
+    fill: "#ccbeff",
+    originX: "center",
+    originY: "center",
+  });
+  sizeTag = new fabric.Group([bg, text], {
+    left: px,
+    top: py,
+    originX: "center",
+    originY: "center",
+    selectable: false,
+    evented: false,
+  });
+  fc.add(sizeTag);
+  fc.renderAll();
+  void hw;
+}
+
+function clearSizeTag(fc: fabric.Canvas) {
+  if (sizeTag) {
+    fc.remove(sizeTag);
+    sizeTag = null;
+    fc.renderAll();
+  }
+}
+
 export function setSelectToolProductLibrary(products: Product[]) {
   _productLibrary = products;
 }
@@ -117,6 +197,33 @@ export function activateSelectTool(
           useCADStore.getState().rotateProduct(selId, pp.rotation);
           return;
         }
+        // Resize handle hit-test (EDIT-14)
+        const { width, depth } = effectiveDimensions(prod, pp.sizeScale);
+        if (hitTestResizeHandle(feet, pp, width, depth)) {
+          state.dragging = true;
+          state.dragId = selId;
+          state.dragType = "product-resize";
+          state.resizeInitialScale = pp.sizeScale ?? 1;
+          // Current diagonal distance from center to pointer
+          const dx = feet.x - pp.position.x;
+          const dy = feet.y - pp.position.y;
+          state.resizeInitialDiagFt = Math.sqrt(dx * dx + dy * dy);
+          // Push history snapshot at drag start
+          useCADStore.getState().resizeProduct(selId, state.resizeInitialScale);
+          return;
+        }
+      }
+      // Wall rotation handle (EDIT-12)
+      const wall = (getActiveRoomDoc()?.walls ?? {})[selId];
+      if (wall && hitTestWallHandle(feet, wall)) {
+        state.dragging = true;
+        state.dragId = selId;
+        state.dragType = "wall-rotate";
+        state.wallRotateInitialAngleDeg = wallAngleDeg(wall);
+        state.wallRotatePointerStartDeg = angleFromMidpointToPointer(wall, feet);
+        // Push history snapshot at drag start as undo boundary
+        useCADStore.getState().rotateWall(selId, 0);
+        return;
       }
     }
 
@@ -166,6 +273,43 @@ export function activateSelectTool(
       return;
     }
 
+    if (state.dragType === "product-resize") {
+      const pp = (getActiveRoomDoc()?.placedProducts ?? {})[state.dragId];
+      if (!pp || state.resizeInitialDiagFt == null || state.resizeInitialScale == null) return;
+      const dx = feet.x - pp.position.x;
+      const dy = feet.y - pp.position.y;
+      const currentDiag = Math.sqrt(dx * dx + dy * dy);
+      if (state.resizeInitialDiagFt < 1e-6) return;
+      const ratio = currentDiag / state.resizeInitialDiagFt;
+      const newScale = Math.max(0.1, Math.min(10, state.resizeInitialScale * ratio));
+      useCADStore.getState().resizeProductNoHistory(state.dragId, newScale);
+      // Update live size tag
+      const prod = _productLibrary.find((p) => p.id === pp.productId);
+      const dims = effectiveDimensions(prod, newScale);
+      const updatedPp = (getActiveRoomDoc()?.placedProducts ?? {})[state.dragId];
+      if (updatedPp) updateSizeTag(fc, updatedPp, dims.width, dims.depth, scale, origin);
+      return;
+    }
+
+    if (state.dragType === "wall-rotate") {
+      const wall = (getActiveRoomDoc()?.walls ?? {})[state.dragId];
+      if (!wall || state.wallRotatePointerStartDeg == null || state.wallRotateInitialAngleDeg == null) return;
+      const currentPointerDeg = angleFromMidpointToPointer(wall, feet);
+      const delta = currentPointerDeg - state.wallRotatePointerStartDeg;
+      // Desired absolute wall angle = initial + delta. But rotateWall takes
+      // an incremental delta each call, so we need to rotate by (desiredAngle
+      // - currentWallAngle).
+      const desired = state.wallRotateInitialAngleDeg + delta;
+      const shiftHeld = (opt.e as MouseEvent).shiftKey === true;
+      const snappedDesired = snapWallAngle(desired, shiftHeld);
+      const currentWallAngle = wallAngleDeg(wall);
+      const incremental = snappedDesired - currentWallAngle;
+      if (Math.abs(incremental) > 1e-4) {
+        useCADStore.getState().rotateWallNoHistory(state.dragId, incremental);
+      }
+      return;
+    }
+
     if (!state.dragOffsetFeet) return;
     const gridSnap = useUIStore.getState().gridSnap;
     const targetX = feet.x - state.dragOffsetFeet.x;
@@ -193,11 +337,18 @@ export function activateSelectTool(
   };
 
   const onMouseUp = () => {
+    if (state.dragType === "product-resize") {
+      clearSizeTag(fc);
+    }
     state.dragging = false;
     state.dragId = null;
     state.dragType = null;
     state.dragOffsetFeet = null;
     state.rotateInitialAngle = null;
+    state.wallRotateInitialAngleDeg = null;
+    state.wallRotatePointerStartDeg = null;
+    state.resizeInitialScale = null;
+    state.resizeInitialDiagFt = null;
   };
 
   const onKeyDown = (e: KeyboardEvent) => {
@@ -227,6 +378,7 @@ export function activateSelectTool(
     fc.off("mouse:move", onMouseMove);
     fc.off("mouse:up", onMouseUp);
     document.removeEventListener("keydown", onKeyDown);
+    clearSizeTag(fc);
   };
 }
 

--- a/src/canvas/wallRotationHandle.ts
+++ b/src/canvas/wallRotationHandle.ts
@@ -1,0 +1,49 @@
+import type { Point, WallSegment } from "@/types/cad";
+
+/** Offset of the rotation handle from the wall's midpoint, in feet.
+ *  Positioned perpendicular to the wall (on the "left" side). */
+export const WALL_HANDLE_OFFSET_FT = 1.2;
+export const WALL_HANDLE_HIT_RADIUS_FT = 0.5;
+
+/** Compute the world position of the rotation handle for a wall. */
+export function getWallHandleWorldPos(wall: WallSegment): Point {
+  const cx = (wall.start.x + wall.end.x) / 2;
+  const cy = (wall.start.y + wall.end.y) / 2;
+  const dx = wall.end.x - wall.start.x;
+  const dy = wall.end.y - wall.start.y;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len === 0) return { x: cx, y: cy };
+  // Perpendicular unit vector (CCW 90° from wall direction)
+  const px = -dy / len;
+  const py = dx / len;
+  return {
+    x: cx + px * WALL_HANDLE_OFFSET_FT,
+    y: cy + py * WALL_HANDLE_OFFSET_FT,
+  };
+}
+
+export function hitTestWallHandle(feetPos: Point, wall: WallSegment): boolean {
+  const h = getWallHandleWorldPos(wall);
+  const dx = feetPos.x - h.x;
+  const dy = feetPos.y - h.y;
+  return Math.sqrt(dx * dx + dy * dy) <= WALL_HANDLE_HIT_RADIUS_FT;
+}
+
+/** Returns the current wall angle in degrees (0 = east, 90 = south). */
+export function wallAngleDeg(wall: WallSegment): number {
+  const dx = wall.end.x - wall.start.x;
+  const dy = wall.end.y - wall.start.y;
+  return (Math.atan2(dy, dx) * 180) / Math.PI;
+}
+
+/** Angle from wall's midpoint to pointer, in degrees. */
+export function angleFromMidpointToPointer(wall: WallSegment, pointer: Point): number {
+  const cx = (wall.start.x + wall.end.x) / 2;
+  const cy = (wall.start.y + wall.end.y) / 2;
+  return (Math.atan2(pointer.y - cy, pointer.x - cx) * 180) / Math.PI;
+}
+
+export function snapWallAngle(rawDeg: number, shiftHeld: boolean): number {
+  const SNAP = 15;
+  return shiftHeld ? rawDeg : Math.round(rawDeg / SNAP) * SNAP;
+}

--- a/src/stores/cadStore.ts
+++ b/src/stores/cadStore.ts
@@ -33,6 +33,10 @@ interface CADState {
   moveProduct: (id: string, position: Point) => void;
   rotateProduct: (id: string, angle: number) => void;
   rotateProductNoHistory: (id: string, angle: number) => void;
+  rotateWall: (id: string, angleDeltaDeg: number) => void;
+  rotateWallNoHistory: (id: string, angleDeltaDeg: number) => void;
+  resizeProduct: (id: string, scale: number) => void;
+  resizeProductNoHistory: (id: string, scale: number) => void;
   removeProduct: (id: string) => void;
   removeSelected: (ids: string[]) => void;
   undo: () => void;
@@ -62,6 +66,24 @@ function pushHistory(state: CADState): void {
 
 function activeDoc(s: CADState): RoomDoc | undefined {
   return s.activeRoomId ? s.rooms[s.activeRoomId] : undefined;
+}
+
+/** Rotate a wall around its midpoint by the given angle delta (degrees).
+ *  Mutates the wall in place. Does NOT update any neighbors — by design,
+ *  rotation detaches this wall from any shared corners. */
+function applyWallRotation(wall: WallSegment, angleDeltaDeg: number): void {
+  const cx = (wall.start.x + wall.end.x) / 2;
+  const cy = (wall.start.y + wall.end.y) / 2;
+  const rad = (angleDeltaDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const rotatePoint = (p: Point) => {
+    const dx = p.x - cx;
+    const dy = p.y - cy;
+    return { x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos };
+  };
+  wall.start = rotatePoint(wall.start);
+  wall.end = rotatePoint(wall.end);
 }
 
 function initialState(): Pick<CADState, "rooms" | "activeRoomId" | "past" | "future"> {
@@ -213,6 +235,50 @@ export const useCADStore = create<CADState>()((set) => ({
         if (!doc) return;
         if (!doc.placedProducts[id]) return;
         doc.placedProducts[id].rotation = angle;
+      })
+    ),
+
+  rotateWall: (id, angleDeltaDeg) =>
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc) return;
+        const wall = doc.walls[id];
+        if (!wall) return;
+        pushHistory(s);
+        applyWallRotation(wall, angleDeltaDeg);
+      })
+    ),
+
+  rotateWallNoHistory: (id, angleDeltaDeg) =>
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc) return;
+        const wall = doc.walls[id];
+        if (!wall) return;
+        applyWallRotation(wall, angleDeltaDeg);
+      })
+    ),
+
+  resizeProduct: (id, scale) =>
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc) return;
+        if (!doc.placedProducts[id]) return;
+        pushHistory(s);
+        doc.placedProducts[id].sizeScale = Math.max(0.1, Math.min(10, scale));
+      })
+    ),
+
+  resizeProductNoHistory: (id, scale) =>
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc) return;
+        if (!doc.placedProducts[id]) return;
+        doc.placedProducts[id].sizeScale = Math.max(0.1, Math.min(10, scale));
       })
     ),
 

--- a/src/three/ProductMesh.tsx
+++ b/src/three/ProductMesh.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export default function ProductMesh({ placed, product, isSelected }: Props) {
-  const { width, depth, height, isPlaceholder } = effectiveDimensions(product);
+  const { width, depth, height, isPlaceholder } = effectiveDimensions(product, placed.sizeScale);
 
   // D-03: placeholders never receive textures, even if imageUrl exists
   const textureUrl = !isPlaceholder && product?.imageUrl ? product.imageUrl : null;

--- a/src/types/cad.ts
+++ b/src/types/cad.ts
@@ -26,6 +26,10 @@ export interface PlacedProduct {
   productId: string;
   position: Point; // center, in feet
   rotation: number; // degrees
+  /** Per-placement scale multiplier applied to the product's library dims.
+   *  1.0 = library default. Stored as a single number so width+depth always
+   *  scale together (aspect ratio preserved). */
+  sizeScale?: number;
 }
 
 export interface Room {

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -35,21 +35,30 @@ export function hasDimensions(p: Product): boolean {
  * Returns effective render dimensions for a product.
  * If product is undefined (orphan) OR any dim is null, returns 2x2x2 + isPlaceholder:true.
  */
-export function effectiveDimensions(p: Product | undefined | null): {
+export function effectiveDimensions(
+  p: Product | undefined | null,
+  scale: number = 1,
+): {
   width: number;
   depth: number;
   height: number;
   isPlaceholder: boolean;
 } {
+  const s = scale > 0 ? scale : 1;
   if (!p || p.width == null || p.depth == null || p.height == null) {
     return {
-      width: PLACEHOLDER_DIM_FT,
-      depth: PLACEHOLDER_DIM_FT,
+      width: PLACEHOLDER_DIM_FT * s,
+      depth: PLACEHOLDER_DIM_FT * s,
       height: PLACEHOLDER_DIM_FT,
       isPlaceholder: true,
     };
   }
-  return { width: p.width, depth: p.depth, height: p.height, isPlaceholder: false };
+  return {
+    width: p.width * s,
+    depth: p.depth * s,
+    height: p.height,
+    isPlaceholder: false,
+  };
 }
 
 /**


### PR DESCRIPTION
# Phase 7.1 — Rotate + Resize

Closes the two items deferred from Phase 7: **EDIT-12** (rotate placed walls) and **EDIT-14** (resize products with live size tag).

---

## What's new

### Wall rotation (EDIT-12)

Select any wall → a small purple circle appears **perpendicular to the wall at its midpoint**, connected by a thin line. That's the rotation handle. Drag it to rotate the wall around its midpoint.

- **15° snap** by default (clean angles like 0°, 45°, 90°)
- **Hold Shift** for free rotation (any angle)
- **Rotating detaches shared corners** — if the wall was connected to other walls at its endpoints, it now floats free. Neighbors stay put. This matches the decision you made (\"Detach from neighbors\") when I asked.

### Product resize (EDIT-14)

Select any product → **4 corner handles** appear at the corners. Drag any one to resize the product uniformly.

- **Aspect ratio preserved** — width and depth scale together (per your choice)
- **Scale clamped** between 0.1× and 10× (no disappearing or absurd products)
- Resizing one instance of a product does NOT affect other placements of the same product or the library dimensions. The scale is per-placement.

### Live size tag

While you drag a corner, a small Obsidian-themed tag appears below the product showing **current W × D in feet+inches** (e.g. \`3'-6\" × 2'\"\`). Updates continuously. Disappears when you release the mouse.

---

## Data model change

Added one field to \`PlacedProduct\`:

\`\`\`ts
interface PlacedProduct {
  id: string;
  productId: string;
  position: Point;
  rotation: number;
  sizeScale?: number;  // NEW — defaults to 1.0 when absent
}
\`\`\`

\`effectiveDimensions(product, scale)\` now accepts an optional scale and multiplies width/depth by it at read time. Library dimensions are never mutated — just scaled on the fly. This means:

- Old projects without sizeScale continue to render at 1.0× (no migration needed)
- Scaling one couch doesn't affect other couches of the same product
- You can still edit the base dimensions in the product library and all placements will respect the new base

---

## Files touched

**New:**
- \`src/canvas/wallRotationHandle.ts\` — wall handle geometry + hit-test + angle snapping
- \`src/canvas/resizeHandles.ts\` — 4-corner handle geometry + hit-test

**Modified:**
- \`src/types/cad.ts\` — sizeScale field
- \`src/stores/cadStore.ts\` — rotateWall, rotateWallNoHistory, resizeProduct, resizeProductNoHistory, applyWallRotation helper
- \`src/types/product.ts\` — effectiveDimensions(p, scale=1)
- \`src/canvas/fabricSync.ts\` — render wall rotation handle + product resize handles
- \`src/canvas/tools/selectTool.ts\` — hit-test + drag logic for both new handle types, live size tag
- \`src/three/ProductMesh.tsx\` — 3D renders at scaled dims too

---

## Test plan

### Wall rotation
- [ ] Draw a wall, click to select it → rotation handle appears perpendicular to wall
- [ ] Drag handle → wall rotates around its midpoint, snapping to 15°
- [ ] Hold Shift while dragging → free rotation (no snap)
- [ ] Rotate a wall that shares a corner with another wall → corner detaches, neighbor wall stays put
- [ ] Ctrl/Cmd+Z after rotating → wall returns to original angle

### Product resize
- [ ] Drag a product from library to canvas, click to select → 4 corner handles appear
- [ ] Drag any corner outward → product grows (both W and D proportionally)
- [ ] Drag any corner inward → product shrinks
- [ ] Live size tag below product updates continuously during drag
- [ ] Release mouse → tag disappears, size persists
- [ ] Try scaling super small → clamps at 0.1× (still visible)
- [ ] Try scaling super large → clamps at 10×
- [ ] Ctrl/Cmd+Z after resizing → product returns to original size
- [ ] Switch to 3D view → product renders at scaled dims too

### Interaction with existing tools
- [ ] Still works: drag to move product, rotation handle, delete product
- [ ] Still works: drag to move wall, delete wall, double-click wall dim to edit length