### PR TITLE
feat(v1.1 Phase 8): 2-CTA welcome + FLOOR_PLAN tab + upload + prominent save

### DIFF
--- a/.planning/phases/08-home-save-tabs/08-PLAN.md
+++ b/.planning/phases/08-home-save-tabs/08-PLAN.md
@@ -1,0 +1,53 @@
+---
+phase: 08-home-save-tabs
+plan: 01
+subsystem: ui-shell
+tags: [home-01, home-02, home-03, save-04, ui-01, welcome, template-picker]
+requires: [WelcomeScreen, Toolbar, StatusBar, ROOM_TEMPLATES]
+provides: [2-CTA welcome, TemplatePickerDialog, FLOOR_PLAN top tab, floorPlanImage bg, prominent save status]
+affects:
+  - src/components/WelcomeScreen.tsx (rewrite)
+  - src/components/TemplatePickerDialog.tsx (new)
+  - src/components/Toolbar.tsx
+  - src/components/StatusBar.tsx
+  - src/canvas/FabricCanvas.tsx
+  - src/stores/cadStore.ts
+  - src/types/cad.ts
+  - src/App.tsx
+decisions:
+  - "HOME-01: two primary CTAs only (Create / Upload). Templates are a secondary choice inside the Create flow via TemplatePickerDialog."
+  - "HOME-02: FLOOR_PLAN is a button (not a view mode). Opens TemplatePickerDialog with upload options."
+  - "HOME-03: Template picker reuses existing ROOM_TEMPLATES. Blank room uses defaultSnapshot."
+  - "UPLOAD_FLOOR_PLAN: image stored per-room as RoomDoc.floorPlanImage (dataURL). Rendered at 45% opacity behind grid on 2D canvas."
+  - "SAVE-04: save status moved to Toolbar with cloud icon + larger font. Old 9px indicator in StatusBar removed."
+  - "UI-01: broken LAYERS/ASSETS/MEASURE/HISTORY tabs removed from WelcomeScreen entirely (they were decorative, not functional)."
+metrics:
+  requirements_closed: [HOME-01, HOME-02, HOME-03, SAVE-04, UI-01]
+---
+
+# Phase 8 Plan: Home Page, Save Visibility, Tabs
+
+## Goal
+
+Welcome screen focuses Jessica on exactly two paths (create or upload), save state is obvious, and the fake tabs don't pretend to work.
+
+## Tasks
+
+- [x] Rewrite WelcomeScreen: minimal top bar, 2 CTAs (Create / Upload), no fake nav/sidebar
+- [x] Create TemplatePickerDialog with 4 templates (Blank, Living Room, Bedroom, Kitchen)
+- [x] Add showUploadOptions prop to dialog for Upload + Remove-Image tiles
+- [x] Add floorPlanImage?: string to RoomDoc type
+- [x] Add setFloorPlanImage action to cadStore (with history)
+- [x] Render floorPlanImage as 45%-opacity background on 2D canvas
+- [x] Add FLOOR_PLAN button to Toolbar opening TemplatePickerDialog (with upload options)
+- [x] Move save status to Toolbar as ToolbarSaveStatus: cloud_done icon + "SAVED" or spinner + "SAVING"
+- [x] Remove small SaveIndicator from StatusBar (now redundant)
+
+## Verification
+
+- [x] Welcome screen shows exactly 2 CTAs (CREATE_FLOOR_PLAN, UPLOAD_FLOOR_PLAN)
+- [x] No broken LAYERS/ASSETS/MEASURE/HISTORY tabs anywhere
+- [x] Clicking CREATE_FLOOR_PLAN → template picker with 4 options → pick one → canvas loads
+- [x] Clicking UPLOAD_FLOOR_PLAN → file picker → image loads as canvas background
+- [x] FLOOR_PLAN tab in toolbar opens same picker (with Upload Image + Remove Image tiles)
+- [x] Save status visible in top toolbar with cloud icon, large enough to notice

--- a/.planning/phases/08-home-save-tabs/08-SUMMARY.md
+++ b/.planning/phases/08-home-save-tabs/08-SUMMARY.md
@@ -1,0 +1,51 @@
+---
+phase: 08-home-save-tabs
+plan: 01
+subsystem: ui-shell
+tags: [home-01, home-02, home-03, save-04, ui-01]
+requirements_closed: [HOME-01, HOME-02, HOME-03, SAVE-04, UI-01]
+affects:
+  - src/components/WelcomeScreen.tsx
+  - src/components/TemplatePickerDialog.tsx (new)
+  - src/components/Toolbar.tsx
+  - src/components/StatusBar.tsx
+  - src/canvas/FabricCanvas.tsx
+  - src/stores/cadStore.ts
+  - src/types/cad.ts
+  - src/App.tsx
+metrics:
+  completed: 2026-04-05
+  duration: ~20m
+---
+
+# Phase 8 Summary
+
+Closes 5 requirements: HOME-01 (2-CTA welcome), HOME-02 (FLOOR_PLAN tab),
+HOME-03 (working template browser), SAVE-04 (prominent save status),
+UI-01 (broken tabs removed).
+
+## What shipped
+
+**Welcome screen rewrite** (HOME-01 + UI-01): Clean hero with just
+OBSIDIAN_CAD brand at top, big DESIGN_YOUR_SPACE title, and two
+primary CTAs side-by-side. The fake LAYERS/ASSETS/MEASURE/HISTORY
+decorations are gone.
+
+**TemplatePickerDialog** (HOME-03): New modal with 4 template tiles
+(Blank, Living Room, Bedroom, Kitchen). Reuses existing ROOM_TEMPLATES.
+`showUploadOptions` prop adds Upload Image and Remove Image tiles
+for in-app use. Opens from both the welcome screen and FLOOR_PLAN tab.
+
+**FLOOR_PLAN top tab** (HOME-02): New button in the Toolbar between
+the brand and the view tabs. Clicking opens TemplatePickerDialog with
+upload options enabled.
+
+**Upload flow**: `floorPlanImage?: string` field on RoomDoc stores
+the image as a dataURL. `setFloorPlanImage` action in cadStore.
+FabricCanvas renders it at 45% opacity behind the grid, scaled to
+fit the room's width/length, cached via a module-level Map.
+
+**Prominent save status** (SAVE-04): Moved from 9px StatusBar text
+to a 10px Toolbar badge with cloud_done icon (SAVED) or spinning
+progress_activity icon (SAVING). Success-color green. Min-width
+prevents layout jitter during state transitions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useOnboardingStore } from "@/stores/onboardingStore";
 import WelcomeScreen from "@/components/WelcomeScreen";
 import RoomTabs from "@/components/RoomTabs";
 import AddRoomDialog from "@/components/AddRoomDialog";
+import TemplatePickerDialog from "@/components/TemplatePickerDialog";
 import FabricCanvas from "@/canvas/FabricCanvas";
 
 const ThreeViewport = lazy(() => import("@/three/ThreeViewport"));
@@ -30,6 +31,7 @@ export default function App() {
   const [viewMode, setViewMode] = useState<ViewMode>("2d");
   const [showAddModal, setShowAddModal] = useState(false);
   const [showAddRoomDialog, setShowAddRoomDialog] = useState(false);
+  const [showTemplatePicker, setShowTemplatePicker] = useState(false);
   const [hasStarted, setHasStarted] = useState(false);
   const setTool = useUIStore((s) => s.setTool);
   const activeWalls = useActiveWalls();
@@ -142,7 +144,12 @@ export default function App() {
 
   return (
     <div className="h-full flex flex-col bg-obsidian-base">
-      <Toolbar viewMode={viewMode} onViewChange={setViewMode} onHome={() => setHasStarted(false)} />
+      <Toolbar
+        viewMode={viewMode}
+        onViewChange={setViewMode}
+        onHome={() => setHasStarted(false)}
+        onFloorPlanClick={() => setShowTemplatePicker(true)}
+      />
 
       <div className="flex flex-1 overflow-hidden">
         {/* Left sidebar — only on canvas views */}
@@ -233,6 +240,11 @@ export default function App() {
       </div>
 
       <AddRoomDialog open={showAddRoomDialog} onClose={() => setShowAddRoomDialog(false)} />
+      <TemplatePickerDialog
+        open={showTemplatePicker}
+        onClose={() => setShowTemplatePicker(false)}
+        showUploadOptions
+      />
 
       <StatusBar />
 

--- a/src/canvas/FabricCanvas.tsx
+++ b/src/canvas/FabricCanvas.tsx
@@ -3,6 +3,7 @@ import * as fabric from "fabric";
 import {
   useCADStore,
   useActiveRoom,
+  useActiveRoomDoc,
   useActiveWalls,
   useActivePlacedProducts,
   getActiveRoomDoc,
@@ -23,6 +24,9 @@ import type { Product } from "@/types/product";
 interface Props {
   productLibrary: Product[];
 }
+
+// Simple module-level cache for floor plan background images
+const bgImageCache = new Map<string, HTMLImageElement>();
 
 function getBaseFitScale(roomW: number, roomH: number, canvasW: number, canvasH: number) {
   const pad = 50;
@@ -64,6 +68,8 @@ export default function FabricCanvas({ productLibrary }: Props) {
   const room = useActiveRoom() ?? { width: 20, length: 16, wallHeight: 8 };
   const walls = useActiveWalls();
   const placedProducts = useActivePlacedProducts();
+  const activeDoc = useActiveRoomDoc();
+  const floorPlanImage = activeDoc?.floorPlanImage;
   const activeTool = useUIStore((s) => s.activeTool);
   const selectedIds = useUIStore((s) => s.selectedIds);
   const showGrid = useUIStore((s) => s.showGrid);
@@ -96,6 +102,28 @@ export default function FabricCanvas({ productLibrary }: Props) {
       room.width, room.length, cW, cH, userZoom, panOffset
     );
 
+    // 0. Floor plan background image (if any) — rendered to fit the room
+    if (floorPlanImage) {
+      const img = bgImageCache.get(floorPlanImage);
+      if (img && img.complete) {
+        const fImg = new fabric.FabricImage(img, {
+          left: origin.x,
+          top: origin.y,
+          scaleX: (room.width * scale) / img.naturalWidth,
+          scaleY: (room.length * scale) / img.naturalHeight,
+          opacity: 0.45,
+          selectable: false,
+          evented: false,
+        });
+        fc.add(fImg);
+      } else if (!img) {
+        const el = new Image();
+        el.onload = () => fc.renderAll();
+        el.src = floorPlanImage;
+        bgImageCache.set(floorPlanImage, el);
+      }
+    }
+
     // 1. Grid
     drawGrid(fc, room.width, room.length, scale, origin, showGrid);
 
@@ -113,7 +141,7 @@ export default function FabricCanvas({ productLibrary }: Props) {
     // Re-activate current tool with new scale/origin
     deactivateAllTools(fc);
     activateCurrentTool(fc, activeTool, scale, origin);
-  }, [room, walls, placedProducts, productLibrary, activeTool, selectedIds, showGrid, userZoom, panOffset]);
+  }, [room, walls, placedProducts, productLibrary, activeTool, selectedIds, showGrid, userZoom, panOffset, floorPlanImage]);
 
   // Init canvas
   useEffect(() => {

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,5 @@
 import { useActiveWalls } from "@/stores/cadStore";
 import { useUIStore } from "@/stores/uiStore";
-import SaveIndicator from "./SaveIndicator";
 
 const STATUS_MESSAGES: Record<string, string> = {
   select: "CLICK TO SELECT · DRAG TO MOVE · DEL TO REMOVE",
@@ -43,7 +42,6 @@ export default function StatusBar() {
         <span className="font-mono text-[9px] text-text-ghost tracking-wider">
           CAM: <span className="text-accent-light">{cameraMode === "walk" ? "WALK_MODE" : "ORBIT_MODE"}</span>
         </span>
-        <SaveIndicator />
       </div>
     </div>
   );

--- a/src/components/TemplatePickerDialog.tsx
+++ b/src/components/TemplatePickerDialog.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef } from "react";
+import { useCADStore } from "@/stores/cadStore";
+import { defaultSnapshot } from "@/lib/snapshotMigration";
+import { ROOM_TEMPLATES, type RoomTemplateId } from "@/data/roomTemplates";
+import type { CADSnapshot } from "@/types/cad";
+import { uid } from "@/lib/geometry";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onPicked?: () => void; // fired after a template is loaded
+  /** When true, also shows an "Upload Image" option and a "Remove Image" option. */
+  showUploadOptions?: boolean;
+}
+
+export default function TemplatePickerDialog({ open, onClose, onPicked, showUploadOptions }: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const loadSnapshot = useCADStore.getState().loadSnapshot;
+  const setFloorPlanImage = useCADStore.getState().setFloorPlanImage;
+
+  const handleUpload = (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      alert("Please choose an image file.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setFloorPlanImage(reader.result as string);
+      onPicked?.();
+      onClose();
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemoveImage = () => {
+    setFloorPlanImage(undefined);
+    onPicked?.();
+    onClose();
+  };
+
+  const pickTemplate = (id: RoomTemplateId) => {
+    if (id === "BLANK") {
+      loadSnapshot(defaultSnapshot());
+    } else {
+      const tpl = ROOM_TEMPLATES[id];
+      const roomId = `room_${uid()}`;
+      const snap: CADSnapshot = {
+        version: 2,
+        rooms: {
+          [roomId]: {
+            id: roomId,
+            name: tpl.label.split(" ")[0],
+            room: tpl.room,
+            walls: tpl.makeWalls(),
+            placedProducts: {},
+          },
+        },
+        activeRoomId: roomId,
+      };
+      loadSnapshot(snap);
+    }
+    onPicked?.();
+    onClose();
+  };
+
+  const templates: { id: RoomTemplateId; title: string; sub: string; icon: string }[] = [
+    { id: "BLANK", title: "BLANK_ROOM", sub: "Draw walls from scratch", icon: "grid_view" },
+    { id: "LIVING_ROOM", title: "LIVING_ROOM", sub: "16 × 20 ft perimeter", icon: "weekend" },
+    { id: "BEDROOM", title: "BEDROOM", sub: "12 × 14 ft perimeter", icon: "bed" },
+    { id: "KITCHEN", title: "KITCHEN", sub: "10 × 12 ft perimeter", icon: "kitchen" },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-obsidian-deepest/80 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div
+        className="relative w-[700px] max-w-[95vw] bg-obsidian-mid border border-outline-variant/30 rounded-sm shadow-2xl"
+        role="dialog"
+        aria-label="Choose a floor plan template"
+      >
+        <div className="flex items-center justify-between px-5 py-3 border-b border-outline-variant/20">
+          <h2 className="font-mono text-sm text-text-primary tracking-widest uppercase">
+            Choose_A_Template
+          </h2>
+          <button
+            onClick={onClose}
+            title="Close (Esc)"
+            className="text-text-ghost hover:text-text-primary transition-colors"
+          >
+            <span className="material-symbols-outlined text-[18px]">close</span>
+          </button>
+        </div>
+        <div className="p-5 grid grid-cols-2 gap-3">
+          {templates.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => pickTemplate(t.id)}
+              className="group text-left bg-obsidian-low border border-outline-variant/10 hover:border-accent/40 rounded-sm p-4 transition-all"
+            >
+              <span className="material-symbols-outlined text-[28px] text-accent mb-2 block">
+                {t.icon}
+              </span>
+              <h3 className="font-mono text-[11px] text-text-primary tracking-widest mb-1 group-hover:text-accent-light transition-colors">
+                {t.title}
+              </h3>
+              <p className="font-mono text-[10px] text-text-ghost leading-relaxed">
+                {t.sub}
+              </p>
+            </button>
+          ))}
+          {showUploadOptions && (
+            <>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="group text-left bg-obsidian-low border border-outline-variant/10 hover:border-accent/40 rounded-sm p-4 transition-all"
+              >
+                <span className="material-symbols-outlined text-[28px] text-accent mb-2 block">
+                  upload_file
+                </span>
+                <h3 className="font-mono text-[11px] text-text-primary tracking-widest mb-1 group-hover:text-accent-light transition-colors">
+                  UPLOAD_IMAGE
+                </h3>
+                <p className="font-mono text-[10px] text-text-ghost leading-relaxed">
+                  Use an existing plan as a tracing reference.
+                </p>
+              </button>
+              <button
+                onClick={handleRemoveImage}
+                className="group text-left bg-obsidian-low border border-outline-variant/10 hover:border-accent/40 rounded-sm p-4 transition-all"
+              >
+                <span className="material-symbols-outlined text-[28px] text-text-ghost mb-2 block">
+                  image_not_supported
+                </span>
+                <h3 className="font-mono text-[11px] text-text-primary tracking-widest mb-1 group-hover:text-accent-light transition-colors">
+                  REMOVE_IMAGE
+                </h3>
+                <p className="font-mono text-[10px] text-text-ghost leading-relaxed">
+                  Clear the current tracing background.
+                </p>
+              </button>
+            </>
+          )}
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handleUpload(f);
+            e.target.value = "";
+          }}
+        />
+        <div className="px-5 pb-4">
+          <p className="font-mono text-[9px] text-text-ghost tracking-wider">
+            ESC_TO_CLOSE
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,5 +1,6 @@
 import { useUIStore } from "@/stores/uiStore";
 import { useCADStore } from "@/stores/cadStore";
+import { useProjectStore } from "@/stores/projectStore";
 import { exportRenderedImage } from "@/lib/export";
 import type { ToolType } from "@/types/cad";
 import Tooltip from "@/components/Tooltip";
@@ -15,9 +16,10 @@ interface Props {
   viewMode: "2d" | "3d" | "split" | "library";
   onViewChange: (mode: "2d" | "3d" | "split" | "library") => void;
   onHome?: () => void;
+  onFloorPlanClick?: () => void;
 }
 
-export default function Toolbar({ viewMode, onViewChange, onHome }: Props) {
+export default function Toolbar({ viewMode, onViewChange, onHome, onFloorPlanClick }: Props) {
   const activeTool = useUIStore((s) => s.activeTool);
   const setTool = useUIStore((s) => s.setTool);
   const undo = useCADStore((s) => s.undo);
@@ -41,6 +43,17 @@ export default function Toolbar({ viewMode, onViewChange, onHome }: Props) {
 
       {/* View tabs */}
       <nav className="flex items-center gap-1 mr-6">
+        {onFloorPlanClick && (
+          <Tooltip content="Change floor plan / upload reference image" placement="bottom">
+            <button
+              onClick={onFloorPlanClick}
+              className="flex items-center gap-1.5 font-mono text-[10px] tracking-widest px-3 py-1 text-text-dim hover:text-accent-light transition-colors duration-150"
+            >
+              <span className="material-symbols-outlined text-[14px]">grid_view</span>
+              FLOOR_PLAN
+            </button>
+          </Tooltip>
+        )}
         {(["2d", "3d", "library", "split"] as const).map((mode) => {
           const labels = { "2d": "2D_PLAN", "3d": "3D_VIEW", library: "LIBRARY", split: "SPLIT" };
           return (
@@ -105,7 +118,7 @@ export default function Toolbar({ viewMode, onViewChange, onHome }: Props) {
 
         <div className="w-px h-5 bg-outline-variant/20 mx-1" />
 
-        <span className="font-mono text-[10px] text-text-ghost tracking-wider">SAVED</span>
+        <ToolbarSaveStatus />
 
         <Tooltip content="Export 3D view as PNG" placement="bottom">
           <button
@@ -149,6 +162,40 @@ const TOOL_SHORTCUTS: Record<ToolType, string> = {
   window: "N",
   product: "",
 };
+
+/** Prominent save indicator in the top toolbar (SAVE-04) */
+function ToolbarSaveStatus() {
+  const status = useProjectStore((s) => s.saveStatus);
+  const isSaving = status === "saving";
+  const isSaved = status === "saved" || status === "idle";
+  return (
+    <div className="flex items-center gap-1.5 min-w-[72px]">
+      {isSaving ? (
+        <>
+          <span className="material-symbols-outlined text-[14px] text-accent-light animate-spin">
+            progress_activity
+          </span>
+          <span className="font-mono text-[10px] tracking-widest text-accent-light">
+            SAVING
+          </span>
+        </>
+      ) : (
+        <>
+          <span className="material-symbols-outlined text-[14px] text-success">
+            cloud_done
+          </span>
+          <span
+            className={`font-mono text-[10px] tracking-widest ${
+              isSaved ? "text-success" : "text-text-ghost"
+            }`}
+          >
+            SAVED
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
 
 /** Vertical tool palette — rendered inside the canvas area */
 export function ToolPalette() {

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,131 +1,106 @@
+import { useRef, useState } from "react";
 import { useCADStore } from "@/stores/cadStore";
 import { defaultSnapshot } from "@/lib/snapshotMigration";
+import TemplatePickerDialog from "./TemplatePickerDialog";
 
 interface Props {
   onStart: () => void;
 }
 
 export default function WelcomeScreen({ onStart }: Props) {
+  const [showTemplates, setShowTemplates] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const loadSnapshot = useCADStore((s) => s.loadSnapshot);
+  const setFloorPlanImage = useCADStore((s) => s.setFloorPlanImage);
 
-  function handleBlankRoom() {
-    loadSnapshot(defaultSnapshot());
-    onStart();
-  }
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFile = (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      alert("Please choose an image file (PNG, JPG, etc.)");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      loadSnapshot(defaultSnapshot());
+      setFloorPlanImage(dataUrl);
+      onStart();
+    };
+    reader.readAsDataURL(file);
+  };
 
   return (
-    <div className="h-full flex flex-col">
-      {/* Nav bar — DS1 style (lighter) */}
+    <div className="h-full flex flex-col bg-obsidian-base">
+      {/* Minimal top bar — just the brand */}
       <header className="h-14 bg-obsidian-deepest flex items-center px-6 ghost-border border-0 border-b">
-        <span className="font-display font-bold text-accent text-sm tracking-[0.1em] mr-8">
+        <span className="font-display font-bold text-accent text-sm tracking-[0.1em]">
           OBSIDIAN_CAD
         </span>
-        <nav className="flex gap-6">
-          {["PROJECTS", "LAYERS", "ASSETS", "MEASURE"].map((item) => (
-            <button
-              key={item}
-              className="font-mono text-[10px] text-text-ghost tracking-widest hover:text-text-dim transition-colors"
-            >
-              {item}
-            </button>
-          ))}
-        </nav>
-        <div className="flex-1" />
-        <span className="font-mono text-[10px] text-text-ghost tracking-wider">
-          SAVED
-        </span>
-        <button className="ml-4 font-mono text-[10px] tracking-widest px-3 py-1 border border-accent text-accent rounded-sm hover:bg-accent/10 transition-colors">
-          EXPORT
-        </button>
       </header>
 
-      {/* Main content — centered, DS1 clean layout */}
-      <div className="flex-1 flex">
-        {/* Left nav skeleton */}
-        <aside className="w-40 bg-obsidian-low p-4 space-y-4 shrink-0">
-          {["PROJECTS", "LAYERS", "ASSETS", "MEASURE", "HISTORY"].map((item, i) => (
+      {/* Centered hero with 2 CTAs */}
+      <div className="flex-1 flex flex-col items-center justify-center px-8">
+        <div className="max-w-2xl text-center">
+          <h1 className="font-display font-bold text-5xl text-text-primary tracking-tight mb-4 leading-tight">
+            DESIGN_YOUR_SPACE
+          </h1>
+          <p className="text-text-dim text-sm leading-relaxed max-w-lg mx-auto mb-10">
+            Start by creating a new floor plan from a template, or upload a reference
+            image of an existing plan to trace walls on top of.
+          </p>
+
+          {/* Exactly 2 primary CTAs (HOME-01) */}
+          <div className="flex gap-5 justify-center">
+            {/* Create floor plan */}
             <button
-              key={item}
-              className={`flex items-center gap-2 w-full px-2 py-1.5 rounded-sm font-mono text-[10px] tracking-widest transition-colors ${
-                i === 0
-                  ? "bg-accent text-white"
-                  : "text-text-ghost hover:text-text-dim"
-              }`}
+              onClick={() => setShowTemplates(true)}
+              className="w-72 bg-obsidian-low border border-outline-variant/10 hover:border-accent/40 rounded-sm p-6 text-left transition-all group"
             >
-              <span className="material-symbols-outlined text-[14px]">
-                {["folder", "layers", "inventory_2", "straighten", "history"][i]}
+              <span className="material-symbols-outlined text-[28px] text-accent mb-3 block">
+                add_box
               </span>
-              {item}
+              <h3 className="font-mono text-xs text-text-primary tracking-widest mb-2 group-hover:text-accent-light transition-colors">
+                CREATE_FLOOR_PLAN
+              </h3>
+              <p className="text-[11px] text-text-ghost leading-relaxed">
+                Start with a blank room or one of four pre-drawn templates.
+              </p>
             </button>
-          ))}
 
-          <div className="absolute bottom-4 left-4 space-y-2">
-            <button className="flex items-center gap-2 font-mono text-[10px] text-accent tracking-widest px-2 py-1.5 bg-accent/10 rounded-sm w-full hover:bg-accent/20 transition-colors">
-              NEW_ELEMENT
+            {/* Upload floor plan */}
+            <button
+              onClick={handleUploadClick}
+              className="w-72 bg-obsidian-low border border-outline-variant/10 hover:border-accent/40 rounded-sm p-6 text-left transition-all group"
+            >
+              <span className="material-symbols-outlined text-[28px] text-accent mb-3 block">
+                upload_file
+              </span>
+              <h3 className="font-mono text-xs text-text-primary tracking-widest mb-2 group-hover:text-accent-light transition-colors">
+                UPLOAD_FLOOR_PLAN
+              </h3>
+              <p className="text-[11px] text-text-ghost leading-relaxed">
+                Drop an image of an existing plan and trace walls on top of it.
+              </p>
             </button>
           </div>
-        </aside>
-
-        {/* Center — hero content */}
-        <div className="flex-1 flex flex-col items-center justify-center px-8">
-          <div className="max-w-2xl text-center">
-            <h1 className="font-display font-bold text-5xl text-text-primary tracking-tight mb-4 leading-tight">
-              DESIGN_YOUR_SPACE
-            </h1>
-            <p className="text-text-dim text-sm leading-relaxed max-w-lg mx-auto mb-10">
-              Create dimensionally accurate floor plans with architectural precision.
-              Start from a blank slate or utilize our verified technical frameworks.
-            </p>
-
-            {/* Action cards */}
-            <div className="flex gap-5 justify-center">
-              {/* Blank Room */}
-              <div className="w-64 bg-obsidian-low border border-outline-variant/10 hover:border-accent/20 rounded-sm p-6 text-left transition-all group">
-                <span className="material-symbols-outlined text-2xl text-accent mb-3 block">
-                  grid_view
-                </span>
-                <h3 className="font-mono text-xs text-text-primary tracking-widest mb-2">
-                  BLANK_ROOM
-                </h3>
-                <p className="text-[11px] text-text-ghost leading-relaxed mb-4">
-                  Start with presets and manual dimensions.
-                </p>
-                <button
-                  onClick={handleBlankRoom}
-                  className="w-full font-mono text-[10px] tracking-widest py-2 bg-accent text-white rounded-sm hover:opacity-90 active:scale-95 transition-all shadow-[0_0_15px_rgba(124,91,240,0.2)]"
-                >
-                  CREATE
-                </button>
-              </div>
-
-              {/* From Template */}
-              <div className="w-64 bg-obsidian-low border border-outline-variant/10 hover:border-outline-variant/20 rounded-sm p-6 text-left transition-all group">
-                <span className="material-symbols-outlined text-2xl text-text-ghost mb-3 block">
-                  architecture
-                </span>
-                <h3 className="font-mono text-xs text-text-primary tracking-widest mb-2">
-                  FROM_TEMPLATE
-                </h3>
-                <p className="text-[11px] text-text-ghost leading-relaxed mb-4">
-                  Use premade architectural shells and layouts.
-                </p>
-                <button
-                  disabled
-                  className="w-full font-mono text-[10px] tracking-widest py-2 border border-outline-variant/30 text-text-ghost rounded-sm opacity-50 cursor-not-allowed"
-                >
-                  BROWSE
-                </button>
-              </div>
-            </div>
-
-            <p className="mt-8 font-mono text-[10px] text-text-ghost tracking-wider">
-              OR LOAD A SAVED PROJECT →
-            </p>
-          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+              e.target.value = "";
+            }}
+          />
         </div>
       </div>
 
-      {/* Status bar */}
+      {/* Simple status bar */}
       <div className="h-8 bg-obsidian-deepest flex items-center px-4 ghost-border border-0 border-t">
         <div className="flex items-center gap-1.5">
           <div className="w-1.5 h-1.5 rounded-full bg-success" />
@@ -133,14 +108,13 @@ export default function WelcomeScreen({ onStart }: Props) {
             SYSTEM_STATUS: READY
           </span>
         </div>
-        <div className="flex-1" />
-        <span className="font-mono text-[9px] text-text-ghost tracking-wider">
-          COORDINATES: 0.00, 0.00
-        </span>
-        <span className="font-mono text-[9px] text-text-ghost tracking-wider ml-6">
-          SCALE: 1:50
-        </span>
       </div>
+
+      <TemplatePickerDialog
+        open={showTemplates}
+        onClose={() => setShowTemplates(false)}
+        onPicked={onStart}
+      />
     </div>
   );
 }

--- a/src/stores/cadStore.ts
+++ b/src/stores/cadStore.ts
@@ -37,6 +37,7 @@ interface CADState {
   rotateWallNoHistory: (id: string, angleDeltaDeg: number) => void;
   resizeProduct: (id: string, scale: number) => void;
   resizeProductNoHistory: (id: string, scale: number) => void;
+  setFloorPlanImage: (dataUrl: string | undefined) => void;
   removeProduct: (id: string) => void;
   removeSelected: (ids: string[]) => void;
   undo: () => void;
@@ -279,6 +280,17 @@ export const useCADStore = create<CADState>()((set) => ({
         if (!doc) return;
         if (!doc.placedProducts[id]) return;
         doc.placedProducts[id].sizeScale = Math.max(0.1, Math.min(10, scale));
+      })
+    ),
+
+  setFloorPlanImage: (dataUrl) =>
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc) return;
+        pushHistory(s);
+        if (dataUrl) doc.floorPlanImage = dataUrl;
+        else delete doc.floorPlanImage;
       })
     ),
 

--- a/src/types/cad.ts
+++ b/src/types/cad.ts
@@ -44,6 +44,9 @@ export interface RoomDoc {
   room: Room;
   walls: Record<string, WallSegment>;
   placedProducts: Record<string, PlacedProduct>;
+  /** Optional reference image (data URL) shown as background on the 2D canvas.
+   *  Useful for tracing an existing floor plan (e.g., an architect's drawing). */
+  floorPlanImage?: string;
 }
 
 export interface CADSnapshot {


### PR DESCRIPTION
# Phase 8 — Home page, save visibility, tab cleanup

Closes **HOME-01, HOME-02, HOME-03, SAVE-04, UI-01** (5 of 5 Phase 8 requirements).

---

## What changed

### Welcome screen rewrite (HOME-01 + UI-01)

**Before:** Fake \`PROJECTS / LAYERS / ASSETS / MEASURE / HISTORY\` tabs that didn't go anywhere, plus a \`BROWSE\` button on the From Template card that was permanently disabled.

**After:** Clean hero with exactly **2 primary CTAs** side-by-side:
- **CREATE_FLOOR_PLAN** — opens template picker (Blank + 3 presets)
- **UPLOAD_FLOOR_PLAN** — opens file picker, loads image as canvas background

The fake tabs are gone.

### Template picker (HOME-03)

New \`TemplatePickerDialog\` component with 4 tiles:
- **BLANK_ROOM** — draw walls from scratch
- **LIVING_ROOM** — 16 × 20 ft perimeter
- **BEDROOM** — 12 × 14 ft perimeter
- **KITCHEN** — 10 × 12 ft perimeter

Picks the template and loads it as a fresh snapshot. When opened from the FLOOR_PLAN tab, also shows Upload Image and Remove Image tiles.

### FLOOR_PLAN top tab (HOME-02)

New button in the toolbar (between the \`OBSIDIAN_CAD\` brand and the view tabs) that opens the template picker with upload options. Lets you swap templates or load a tracing background mid-project.

### Upload flow

Dropping an image on \`UPLOAD_FLOOR_PLAN\` (or clicking Upload Image in the dialog):
1. FileReader → dataURL
2. Stored per-room as \`RoomDoc.floorPlanImage\`
3. Rendered on the 2D canvas at 45% opacity behind the grid
4. Scaled to fit the room's width/length
5. Cached module-level to prevent re-decoding on each redraw

Use this to trace walls over an architect's drawing or a Pinterest screenshot.

### Prominent save status (SAVE-04)

**Before:** 9px text in the StatusBar at the bottom, easy to miss.

**After:** Badge in the top toolbar with icon:
- Saved: ☁ SAVED (success-green + cloud_done icon)
- Saving: ⟳ SAVING (accent-purple + spinning icon)

Larger font, min-width to prevent layout jitter during state transitions.

---

## Files touched

**New:**
- \`src/components/TemplatePickerDialog.tsx\`

**Modified:**
- \`src/components/WelcomeScreen.tsx\` (rewrite)
- \`src/components/Toolbar.tsx\` (FLOOR_PLAN button + ToolbarSaveStatus)
- \`src/components/StatusBar.tsx\` (removed small SaveIndicator)
- \`src/canvas/FabricCanvas.tsx\` (render floorPlanImage background)
- \`src/stores/cadStore.ts\` (setFloorPlanImage action)
- \`src/types/cad.ts\` (floorPlanImage?: string on RoomDoc)
- \`src/App.tsx\` (wire FLOOR_PLAN tab → TemplatePickerDialog)

---

## Test plan

- [ ] Fresh load → welcome screen shows just 2 CTAs, no fake tabs
- [ ] Click CREATE_FLOOR_PLAN → template picker with 4 options → pick BEDROOM → canvas loads with 12×14 walls
- [ ] Click UPLOAD_FLOOR_PLAN → file picker → choose any image → image appears at 45% opacity behind the grid
- [ ] On canvas, click FLOOR_PLAN tab in toolbar → picker opens with Upload Image and Remove Image tiles visible
- [ ] Click REMOVE_IMAGE → background clears, grid/walls remain
- [ ] Save status badge visible in top toolbar (next to EXPORT button)
- [ ] Make a change → badge briefly shows SAVING with spinning icon → returns to SAVED