### PR TITLE
feat(v1.2 Phase 11): ceilings — polygon surfaces with editable height + material

### DIFF
--- a/.planning/phases/11-ceilings/11-PLAN.md
+++ b/.planning/phases/11-ceilings/11-PLAN.md
@@ -1,0 +1,64 @@
+---
+phase: 11-ceilings
+plan: 01
+subsystem: elements
+tags: [ceil-01, ceil-02, ceil-03, ceil-04, polygon, overhead]
+requires: [cadStore, FabricCanvas, ThreeViewport]
+provides: [Ceiling type, ceiling tool, 2D polygon rendering, 3D ShapeGeometry rendering]
+affects:
+  - src/types/cad.ts
+  - src/stores/cadStore.ts
+  - src/canvas/tools/ceilingTool.ts (new)
+  - src/canvas/fabricSync.ts
+  - src/canvas/FabricCanvas.tsx
+  - src/three/CeilingMesh.tsx (new)
+  - src/three/ThreeViewport.tsx
+  - src/components/Toolbar.tsx
+  - src/components/StatusBar.tsx
+  - src/App.tsx
+decisions:
+  - "Ceilings stored per-room on RoomDoc.ceilings (optional Record<string, Ceiling>)"
+  - "Ceiling = polygon (array of Points) + height + material. Height defaults to room.wallHeight."
+  - "Drawing: click-click polygon tool (similar to wall tool). Close by clicking first vertex, double-clicking, or pressing Enter. Escape cancels."
+  - "Auto-revert to Select after closing the polygon."
+  - "2D render: translucent dashed polygon with wall-color fill."
+  - "3D render: THREE.ShapeGeometry + mesh at height with DoubleSide material."
+  - "Material is string — hex color or catalog id (stubbed for now; full catalog comes in Phase 12/13)."
+  - "Tool palette gets new CEILING button (roofing icon) with C keyboard shortcut."
+metrics:
+  requirements_closed: [CEIL-01, CEIL-02, CEIL-03, CEIL-04]
+---
+
+# Phase 11 Plan: Ceilings
+
+## Goal
+
+Jessica can draw ceilings as independent polygon surfaces with editable height + material, and see them overhead in 3D.
+
+## Tasks
+
+- [x] Add `Ceiling` interface to src/types/cad.ts
+- [x] Add `ceilings?: Record<string, Ceiling>` to RoomDoc
+- [x] Add `ceiling` to ToolType union
+- [x] Add addCeiling/updateCeiling/removeCeiling actions to cadStore
+- [x] Add useActiveCeilings selector with stable empty-object default (avoid infinite render loop)
+- [x] Create src/canvas/tools/ceilingTool.ts (click to add vertices, close via first-click/dblclick/Enter)
+- [x] Wire ceilingTool into FabricCanvas activateCurrentTool + deactivateAllTools
+- [x] renderCeilings(fc, ceilings, scale, origin, selectedIds) in fabricSync
+- [x] Call renderCeilings in FabricCanvas redraw
+- [x] Create src/three/CeilingMesh.tsx (ShapeGeometry + horizontal mesh)
+- [x] Render ceilings in ThreeViewport
+- [x] Add CEILING button to ToolPalette + TOOL_SHORTCUTS
+- [x] Wire `c` key in App.tsx keyboard handler
+- [x] Add ceiling status message to StatusBar
+
+## Verification
+
+- [x] Click CEILING tool → cursor changes to crosshair, status bar shows instructions
+- [x] Click points on canvas → vertices appear as purple circles, solid edges between them, dashed closing edge back to first vertex
+- [x] Click near first vertex → polygon closes, ceiling created, tool reverts to Select
+- [x] Double-click or Enter → closes polygon too
+- [x] Escape → cancels, no ceiling created
+- [x] Ceiling renders in 2D as translucent dashed polygon
+- [x] Ceiling renders in 3D as horizontal surface at stored height
+- [x] Ceiling height defaults to room.wallHeight when created

--- a/.planning/phases/11-ceilings/11-SUMMARY.md
+++ b/.planning/phases/11-ceilings/11-SUMMARY.md
@@ -1,0 +1,68 @@
+---
+phase: 11-ceilings
+plan: 01
+subsystem: elements
+tags: [ceil-01, ceil-02, ceil-03, ceil-04]
+requirements_closed: [CEIL-01, CEIL-02, CEIL-03, CEIL-04]
+affects:
+  - src/types/cad.ts
+  - src/stores/cadStore.ts
+  - src/canvas/tools/ceilingTool.ts
+  - src/canvas/fabricSync.ts
+  - src/canvas/FabricCanvas.tsx
+  - src/three/CeilingMesh.tsx
+  - src/three/ThreeViewport.tsx
+  - src/components/Toolbar.tsx
+  - src/components/StatusBar.tsx
+  - src/App.tsx
+metrics:
+  completed: 2026-04-05
+  duration: ~20m
+---
+
+# Phase 11 Summary
+
+Closes CEIL-01/02/03/04 — first v1.2 phase.
+
+## What shipped
+
+**Ceiling data model:** New `Ceiling` type (points polygon + height +
+material) added to RoomDoc as an optional record. Store actions
+addCeiling/updateCeiling/removeCeiling with history.
+
+**Ceiling drawing tool:** New CEILING tool activates with C key or
+tool palette button. Click-click to add polygon vertices. Close the
+polygon by:
+- Clicking near the first vertex (within 0.75 ft)
+- Double-clicking anywhere
+- Pressing Enter with 3+ vertices
+
+Escape cancels without saving. Auto-reverts to Select after closing.
+
+**2D rendering:** Translucent dashed polygon overlay on the canvas,
+stroke color reflects selection state.
+
+**3D rendering:** THREE.ShapeGeometry extruded from the polygon
+vertices, rotated to horizontal, positioned at stored height,
+DoubleSide material so Jessica can look up at it from walk mode.
+
+**Material:** Simple string field — hex color or preset id. Full
+material catalog lands in Phase 12/13. Default is a neutral
+off-white (#f5f5f5).
+
+## Notable implementation detail
+
+`useActiveCeilings` selector uses a module-level `EMPTY_CEILINGS`
+frozen object as the fallback, not a literal `{}`. Returning `{}`
+literal from a Zustand selector creates a new reference every call,
+which triggers infinite render loops when the parent effect depends
+on the selector output. Lesson learned for future optional
+RoomDoc fields.
+
+## Not included (deferred to later phases)
+
+- Material catalog (solid color picker + presets like plaster,
+  wood ceiling, acoustic tile) — Phase 12/13
+- Edit handles for ceilings (move vertices, change height, delete) —
+  will land as part of the edit-handles pattern from v1.1 Phase 10
+- Per-ceiling height display label on 2D canvas

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,7 @@ export default function App() {
       if (useUIStore.getState().showHelp) return;
 
       const shortcuts: Record<string, ToolType> = {
-        v: "select", w: "wall", d: "door", n: "window",
+        v: "select", w: "wall", d: "door", n: "window", c: "ceiling",
       };
       const tool = shortcuts[e.key.toLowerCase()];
       if (tool && viewMode !== "library") setTool(tool);

--- a/src/canvas/FabricCanvas.tsx
+++ b/src/canvas/FabricCanvas.tsx
@@ -6,17 +6,19 @@ import {
   useActiveRoomDoc,
   useActiveWalls,
   useActivePlacedProducts,
+  useActiveCeilings,
   getActiveRoomDoc,
 } from "@/stores/cadStore";
 import { useUIStore } from "@/stores/uiStore";
 import { drawGrid } from "./grid";
 import { drawRoomDimensions } from "./dimensions";
-import { renderWalls, renderProducts } from "./fabricSync";
+import { renderWalls, renderProducts, renderCeilings } from "./fabricSync";
 import { activateWallTool, deactivateWallTool } from "./tools/wallTool";
 import { activateSelectTool, deactivateSelectTool, setSelectToolProductLibrary } from "./tools/selectTool";
 import { activateProductTool, deactivateProductTool } from "./tools/productTool";
 import { activateDoorTool, deactivateDoorTool } from "./tools/doorTool";
 import { activateWindowTool, deactivateWindowTool } from "./tools/windowTool";
+import { activateCeilingTool, deactivateCeilingTool } from "./tools/ceilingTool";
 import { attachDragDropHandlers } from "./dragDrop";
 import { computeLabelPx, hitTestDimLabel, validateInput } from "./dimensionEditor";
 import type { Product } from "@/types/product";
@@ -70,6 +72,7 @@ export default function FabricCanvas({ productLibrary }: Props) {
   const placedProducts = useActivePlacedProducts();
   const activeDoc = useActiveRoomDoc();
   const floorPlanImage = activeDoc?.floorPlanImage;
+  const ceilings = useActiveCeilings();
   const activeTool = useUIStore((s) => s.activeTool);
   const selectedIds = useUIStore((s) => s.selectedIds);
   const showGrid = useUIStore((s) => s.showGrid);
@@ -136,12 +139,15 @@ export default function FabricCanvas({ productLibrary }: Props) {
     // 4. Products
     renderProducts(fc, placedProducts, productLibrary, scale, origin, selectedIds);
 
+    // 5. Ceilings (translucent overlays)
+    renderCeilings(fc, ceilings, scale, origin, selectedIds);
+
     fc.renderAll();
 
     // Re-activate current tool with new scale/origin
     deactivateAllTools(fc);
     activateCurrentTool(fc, activeTool, scale, origin);
-  }, [room, walls, placedProducts, productLibrary, activeTool, selectedIds, showGrid, userZoom, panOffset, floorPlanImage]);
+  }, [room, walls, placedProducts, productLibrary, activeTool, selectedIds, showGrid, userZoom, panOffset, floorPlanImage, ceilings]);
 
   // Init canvas
   useEffect(() => {
@@ -401,6 +407,7 @@ function deactivateAllTools(fc: fabric.Canvas) {
   deactivateProductTool(fc);
   deactivateDoorTool(fc);
   deactivateWindowTool(fc);
+  deactivateCeilingTool(fc);
 }
 
 function activateCurrentTool(
@@ -424,6 +431,9 @@ function activateCurrentTool(
       break;
     case "window":
       activateWindowTool(fc, scale, origin);
+      break;
+    case "ceiling":
+      activateCeilingTool(fc, scale, origin);
       break;
   }
 }

--- a/src/canvas/fabricSync.ts
+++ b/src/canvas/fabricSync.ts
@@ -1,5 +1,5 @@
 import * as fabric from "fabric";
-import type { WallSegment, PlacedProduct } from "@/types/cad";
+import type { WallSegment, PlacedProduct, Ceiling } from "@/types/cad";
 import type { Product } from "@/types/product";
 import { effectiveDimensions, hasDimensions } from "@/types/product";
 import { wallCorners, angle as wallAngle } from "@/lib/geometry";
@@ -10,6 +10,34 @@ import { getHandleWorldPos } from "./rotationHandle";
 import { getResizeHandles } from "./resizeHandles";
 import { getWallEndpointHandles, getWallThicknessHandle } from "./wallEditHandles";
 import { getOpeningHandles } from "./openingEditHandles";
+
+/** Render ceiling polygons as translucent overlays on the 2D canvas. */
+export function renderCeilings(
+  fc: fabric.Canvas,
+  ceilings: Record<string, Ceiling>,
+  scale: number,
+  origin: { x: number; y: number },
+  selectedIds: string[],
+) {
+  for (const c of Object.values(ceilings)) {
+    const pts = c.points.map((p) => ({
+      x: origin.x + p.x * scale,
+      y: origin.y + p.y * scale,
+    }));
+    const isSelected = selectedIds.includes(c.id);
+    fc.add(
+      new fabric.Polygon(pts, {
+        fill: c.material.startsWith("#") ? c.material + "30" : "rgba(124,91,240,0.08)",
+        stroke: isSelected ? "#7c5bf0" : "#938ea0",
+        strokeWidth: isSelected ? 2 : 1,
+        strokeDashArray: [4, 4],
+        selectable: false,
+        evented: false,
+        data: { type: "ceiling", ceilingId: c.id },
+      }),
+    );
+  }
+}
 
 const WALL_FILL = "#343440";
 const WALL_STROKE = "#484554";

--- a/src/canvas/tools/ceilingTool.ts
+++ b/src/canvas/tools/ceilingTool.ts
@@ -1,0 +1,206 @@
+import * as fabric from "fabric";
+import { useCADStore, getActiveRoomDoc } from "@/stores/cadStore";
+import { useUIStore } from "@/stores/uiStore";
+import { snapPoint } from "@/lib/geometry";
+import type { Point } from "@/types/cad";
+
+interface CeilingToolState {
+  points: Point[];
+  previewLine: fabric.Line | null;
+  vertexMarkers: fabric.Circle[];
+  closingEdge: fabric.Line | null;
+}
+
+const state: CeilingToolState = {
+  points: [],
+  previewLine: null,
+  vertexMarkers: [],
+  closingEdge: null,
+};
+
+function pxToFeet(
+  px: { x: number; y: number },
+  origin: { x: number; y: number },
+  scale: number,
+): Point {
+  return {
+    x: (px.x - origin.x) / scale,
+    y: (px.y - origin.y) / scale,
+  };
+}
+
+/** Hit-test if pointer is close to the first vertex — user is trying to close. */
+function nearFirstVertex(feet: Point, first: Point, scale: number): boolean {
+  const HIT_RADIUS_FT = 0.75;
+  const dx = feet.x - first.x;
+  const dy = feet.y - first.y;
+  void scale;
+  return Math.sqrt(dx * dx + dy * dy) <= HIT_RADIUS_FT;
+}
+
+export function activateCeilingTool(
+  fc: fabric.Canvas,
+  scale: number,
+  origin: { x: number; y: number },
+) {
+  deactivateCeilingTool(fc);
+
+  const onMouseDown = (opt: fabric.TEvent) => {
+    const pointer = fc.getViewportPoint(opt.e);
+    const gridSnap = useUIStore.getState().gridSnap;
+    const feet = pxToFeet(pointer, origin, scale);
+    const snapped = gridSnap > 0 ? snapPoint(feet, gridSnap) : feet;
+
+    // If >= 3 points and user clicked near the first, close the polygon
+    if (state.points.length >= 3 && nearFirstVertex(snapped, state.points[0], scale)) {
+      commitCeiling(fc);
+      return;
+    }
+
+    state.points.push(snapped);
+
+    const vx = origin.x + snapped.x * scale;
+    const vy = origin.y + snapped.y * scale;
+    const marker = new fabric.Circle({
+      left: vx,
+      top: vy,
+      radius: 5,
+      fill: "#7c5bf0",
+      originX: "center",
+      originY: "center",
+      selectable: false,
+      evented: false,
+    });
+    state.vertexMarkers.push(marker);
+    fc.add(marker);
+
+    // Solidify edges between placed points
+    if (state.points.length >= 2) {
+      const prev = state.points[state.points.length - 2];
+      const px = origin.x + prev.x * scale;
+      const py = origin.y + prev.y * scale;
+      fc.add(
+        new fabric.Line([px, py, vx, vy], {
+          stroke: "#7c5bf0",
+          strokeWidth: 2,
+          selectable: false,
+          evented: false,
+          data: { type: "ceiling-edge-preview" },
+        }),
+      );
+    }
+    fc.renderAll();
+  };
+
+  const onMouseMove = (opt: fabric.TEvent) => {
+    if (state.points.length === 0) return;
+    const pointer = fc.getViewportPoint(opt.e);
+    const gridSnap = useUIStore.getState().gridSnap;
+    const feet = pxToFeet(pointer, origin, scale);
+    const snapped = gridSnap > 0 ? snapPoint(feet, gridSnap) : feet;
+
+    const last = state.points[state.points.length - 1];
+    const sx = origin.x + last.x * scale;
+    const sy = origin.y + last.y * scale;
+    const ex = origin.x + snapped.x * scale;
+    const ey = origin.y + snapped.y * scale;
+
+    if (state.previewLine) {
+      state.previewLine.set({ x1: sx, y1: sy, x2: ex, y2: ey });
+    } else {
+      state.previewLine = new fabric.Line([sx, sy, ex, ey], {
+        stroke: "#7c5bf0",
+        strokeWidth: 2,
+        strokeDashArray: [6, 4],
+        selectable: false,
+        evented: false,
+      });
+      fc.add(state.previewLine);
+    }
+
+    // Show dashed closing edge back to first vertex when >= 2 points placed
+    if (state.points.length >= 2) {
+      const first = state.points[0];
+      const fx = origin.x + first.x * scale;
+      const fy = origin.y + first.y * scale;
+      if (state.closingEdge) {
+        state.closingEdge.set({ x1: ex, y1: ey, x2: fx, y2: fy });
+      } else {
+        state.closingEdge = new fabric.Line([ex, ey, fx, fy], {
+          stroke: "#7c5bf0",
+          strokeWidth: 1,
+          strokeDashArray: [3, 3],
+          opacity: 0.5,
+          selectable: false,
+          evented: false,
+        });
+        fc.add(state.closingEdge);
+      }
+    }
+
+    fc.renderAll();
+  };
+
+  const onDblClick = () => {
+    if (state.points.length >= 3) commitCeiling(fc);
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" && state.points.length >= 3) commitCeiling(fc);
+    if (e.key === "Escape") {
+      cleanup(fc);
+      useUIStore.getState().setTool("select");
+    }
+  };
+
+  fc.on("mouse:down", onMouseDown);
+  fc.on("mouse:move", onMouseMove);
+  fc.on("mouse:dblclick", onDblClick);
+  document.addEventListener("keydown", onKeyDown);
+
+  (fc as any).__ceilingToolCleanup = () => {
+    fc.off("mouse:down", onMouseDown);
+    fc.off("mouse:move", onMouseMove);
+    fc.off("mouse:dblclick", onDblClick);
+    document.removeEventListener("keydown", onKeyDown);
+    cleanup(fc);
+  };
+}
+
+function commitCeiling(fc: fabric.Canvas) {
+  if (state.points.length < 3) return;
+  const doc = getActiveRoomDoc();
+  const height = doc?.room.wallHeight ?? 8;
+  useCADStore.getState().addCeiling(state.points.slice(), height);
+  cleanup(fc);
+  // Auto-revert to Select after placing
+  useUIStore.getState().setTool("select");
+}
+
+function cleanup(fc: fabric.Canvas) {
+  if (state.previewLine) {
+    fc.remove(state.previewLine);
+    state.previewLine = null;
+  }
+  if (state.closingEdge) {
+    fc.remove(state.closingEdge);
+    state.closingEdge = null;
+  }
+  for (const m of state.vertexMarkers) fc.remove(m);
+  state.vertexMarkers = [];
+  // Remove edge previews tagged with data.type=ceiling-edge-preview
+  const toRemove = fc.getObjects().filter(
+    (o: any) => o.data?.type === "ceiling-edge-preview",
+  );
+  for (const o of toRemove) fc.remove(o);
+  state.points = [];
+  fc.renderAll();
+}
+
+export function deactivateCeilingTool(fc: fabric.Canvas) {
+  const fn = (fc as any).__ceilingToolCleanup;
+  if (fn) {
+    fn();
+    delete (fc as any).__ceilingToolCleanup;
+  }
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -7,6 +7,7 @@ const STATUS_MESSAGES: Record<string, string> = {
   door: "CLICK ON WALL TO PLACE DOOR",
   window: "CLICK ON WALL TO PLACE WINDOW",
   product: "CLICK ON CANVAS TO PLACE PRODUCT · ESC TO CANCEL",
+  ceiling: "CLICK TO ADD VERTICES · CLICK FIRST POINT OR DBL-CLICK TO CLOSE · ESC TO CANCEL",
 };
 
 export default function StatusBar() {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -10,6 +10,7 @@ const tools: { id: ToolType; label: string; icon: string }[] = [
   { id: "wall", label: "WALL", icon: "horizontal_rule" },
   { id: "door", label: "DOOR", icon: "door_front" },
   { id: "window", label: "WINDOW", icon: "window" },
+  { id: "ceiling", label: "CEILING", icon: "roofing" },
 ];
 
 interface Props {
@@ -160,6 +161,7 @@ const TOOL_SHORTCUTS: Record<ToolType, string> = {
   wall: "W",
   door: "D",
   window: "N",
+  ceiling: "C",
   product: "",
 };
 

--- a/src/stores/cadStore.ts
+++ b/src/stores/cadStore.ts
@@ -8,6 +8,7 @@ import type {
   Point,
   Opening,
   RoomDoc,
+  Ceiling,
 } from "@/types/cad";
 import { uid, resizeWall } from "@/lib/geometry";
 import { ROOM_TEMPLATES, type RoomTemplateId } from "@/data/roomTemplates";
@@ -41,6 +42,9 @@ interface CADState {
   resizeProduct: (id: string, scale: number) => void;
   resizeProductNoHistory: (id: string, scale: number) => void;
   setFloorPlanImage: (dataUrl: string | undefined) => void;
+  addCeiling: (points: Point[], height: number, material?: string) => string;
+  updateCeiling: (id: string, changes: Partial<Ceiling>) => void;
+  removeCeiling: (id: string) => void;
   removeProduct: (id: string) => void;
   removeSelected: (ids: string[]) => void;
   undo: () => void;
@@ -334,6 +338,40 @@ export const useCADStore = create<CADState>()((set) => ({
       })
     ),
 
+  addCeiling: (points, height, material = "#f5f5f5") => {
+    const id = `ceiling_${uid()}`;
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc) return;
+        pushHistory(s);
+        if (!doc.ceilings) doc.ceilings = {};
+        doc.ceilings[id] = { id, points, height, material };
+      })
+    );
+    return id;
+  },
+
+  updateCeiling: (id, changes) =>
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc || !doc.ceilings || !doc.ceilings[id]) return;
+        pushHistory(s);
+        Object.assign(doc.ceilings[id], changes);
+      })
+    ),
+
+  removeCeiling: (id) =>
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc || !doc.ceilings || !doc.ceilings[id]) return;
+        pushHistory(s);
+        delete doc.ceilings[id];
+      })
+    ),
+
   removeProduct: (id) =>
     set(
       produce((s: CADState) => {
@@ -453,6 +491,10 @@ export const useActiveWalls = () =>
 
 export const useActivePlacedProducts = () =>
   useCADStore((s) => (s.activeRoomId ? s.rooms[s.activeRoomId]?.placedProducts ?? {} : {}));
+
+const EMPTY_CEILINGS: Record<string, Ceiling> = Object.freeze({});
+export const useActiveCeilings = () =>
+  useCADStore((s) => (s.activeRoomId ? s.rooms[s.activeRoomId]?.ceilings ?? EMPTY_CEILINGS : EMPTY_CEILINGS));
 
 // Non-hook for imperative paths (tools)
 export function getActiveRoomDoc(): RoomDoc | undefined {

--- a/src/three/CeilingMesh.tsx
+++ b/src/three/CeilingMesh.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import * as THREE from "three";
+import type { Ceiling } from "@/types/cad";
+
+interface Props {
+  ceiling: Ceiling;
+  isSelected: boolean;
+}
+
+/** Ceiling rendered as a horizontal polygon mesh at its height, facing down. */
+export default function CeilingMesh({ ceiling, isSelected }: Props) {
+  const geometry = useMemo(() => {
+    const shape = new THREE.Shape();
+    if (ceiling.points.length === 0) return new THREE.ShapeGeometry(shape);
+    shape.moveTo(ceiling.points[0].x, ceiling.points[0].y);
+    for (let i = 1; i < ceiling.points.length; i++) {
+      shape.lineTo(ceiling.points[i].x, ceiling.points[i].y);
+    }
+    shape.closePath();
+    const geom = new THREE.ShapeGeometry(shape);
+    // ShapeGeometry sits in XY; rotate to XZ (ground plane), then flip normal to face down
+    geom.rotateX(Math.PI / 2);
+    return geom;
+  }, [ceiling.points]);
+
+  const color = ceiling.material.startsWith("#") ? ceiling.material : "#f5f5f5";
+
+  return (
+    <mesh
+      geometry={geometry}
+      position={[0, ceiling.height, 0]}
+      receiveShadow
+    >
+      <meshStandardMaterial
+        color={color}
+        side={THREE.DoubleSide}
+        roughness={0.8}
+        metalness={0}
+        emissive={isSelected ? "#7c5bf0" : "#000000"}
+        emissiveIntensity={isSelected ? 0.2 : 0}
+      />
+    </mesh>
+  );
+}

--- a/src/three/ThreeViewport.tsx
+++ b/src/three/ThreeViewport.tsx
@@ -2,11 +2,12 @@ import * as THREE from "three";
 import { Suspense, useRef, useEffect, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Environment, PointerLockControls } from "@react-three/drei";
-import { useActiveRoom, useActiveWalls, useActivePlacedProducts } from "@/stores/cadStore";
+import { useActiveRoom, useActiveWalls, useActivePlacedProducts, useActiveCeilings } from "@/stores/cadStore";
 import { useUIStore } from "@/stores/uiStore";
 import type { Product } from "@/types/product";
 import WallMesh from "./WallMesh";
 import ProductMesh from "./ProductMesh";
+import CeilingMesh from "./CeilingMesh";
 import Lighting from "./Lighting";
 import WalkCameraController from "./WalkCameraController";
 import { getFloorTexture } from "./floorTexture";
@@ -19,6 +20,7 @@ function Scene({ productLibrary }: Props) {
   const room = useActiveRoom() ?? { width: 20, length: 16, wallHeight: 8 };
   const walls = useActiveWalls();
   const placedProducts = useActivePlacedProducts();
+  const ceilings = useActiveCeilings();
   const selectedIds = useUIStore((s) => s.selectedIds);
   const cameraMode = useUIStore((s) => s.cameraMode);
 
@@ -88,6 +90,11 @@ function Scene({ productLibrary }: Props) {
           />
         );
       })}
+
+      {/* Ceilings — overhead polygon surfaces */}
+      {Object.values(ceilings).map((c) => (
+        <CeilingMesh key={c.id} ceiling={c} isSelected={selectedIds.includes(c.id)} />
+      ))}
 
       {cameraMode === "orbit" ? (
         <OrbitControls

--- a/src/types/cad.ts
+++ b/src/types/cad.ts
@@ -38,6 +38,16 @@ export interface Room {
   wallHeight: number;
 }
 
+export interface Ceiling {
+  id: string;
+  /** Polygon vertices in feet, CCW winding. */
+  points: Point[];
+  /** Height above floor in feet. Defaults to room.wallHeight. */
+  height: number;
+  /** Solid hex color (e.g. "#f5f5f5") or material preset id (e.g. "mat-plaster"). */
+  material: string;
+}
+
 export interface RoomDoc {
   id: string;
   name: string;
@@ -47,6 +57,8 @@ export interface RoomDoc {
   /** Optional reference image (data URL) shown as background on the 2D canvas.
    *  Useful for tracing an existing floor plan (e.g., an architect's drawing). */
   floorPlanImage?: string;
+  /** Ceilings drawn as independent polygon surfaces overhead. */
+  ceilings?: Record<string, Ceiling>;
 }
 
 export interface CADSnapshot {
@@ -62,4 +74,4 @@ export interface LegacySnapshotV1 {
   placedProducts: Record<string, PlacedProduct>;
 }
 
-export type ToolType = "select" | "wall" | "door" | "window" | "product";
+export type ToolType = "select" | "wall" | "door" | "window" | "product" | "ceiling";


### PR DESCRIPTION
# Phase 11 — Ceilings

First phase of v1.2 New Element Types. Closes **CEIL-01, CEIL-02, CEIL-03, CEIL-04**.

---

## What's new

### Ceiling tool

New **CEILING** tool in the tool palette (🏠 icon) with keyboard shortcut **C**. Click to add polygon vertices, then:

- **Click the first vertex** → polygon closes
- **Double-click anywhere** → polygon closes
- **Press Enter** (with 3+ vertices) → polygon closes
- **Press Escape** → cancels without saving

Tool auto-reverts to Select after closing (same pattern as walls/doors/windows).

### 2D rendering

Ceilings show on the 2D canvas as **translucent dashed polygons** — visible but non-intrusive. Stroke color reflects selection state.

### 3D rendering

Ceilings render as **horizontal polygon surfaces at their stored height**, with the DoubleSide material so Jessica can look up at them from walk mode. Default height matches room.wallHeight.

### Data model

New `Ceiling` type stored per-room:

\`\`\`ts
interface Ceiling {
  id: string;
  points: Point[];        // polygon vertices, CCW
  height: number;         // feet from floor
  material: string;       // hex color or material preset id
}
\`\`\`

Store actions: \`addCeiling\`, \`updateCeiling\`, \`removeCeiling\` (all with history).

---

## Notable implementation detail

\`useActiveCeilings\` selector uses a module-level frozen \`EMPTY_CEILINGS\` object as its fallback, NOT a literal \`{}\`. Returning a literal from a Zustand selector creates a new reference every call, which triggered an infinite render loop when the FabricCanvas \`useEffect\` depended on the selector output. Same bug could bite future optional RoomDoc fields — worth remembering.

---

## Not yet

- **Material catalog** (solid color picker + presets like plaster, wood ceiling, acoustic tile) — lands in Phase 12/13 (floors/walls material infrastructure)
- **Edit handles for ceilings** (move vertices, change height, delete) — future phase, reusing Phase 10's handle pattern
- **Per-ceiling height label** on the 2D canvas — nice-to-have

---

## Files touched

**New:**
- \`src/canvas/tools/ceilingTool.ts\` — polygon drawing tool
- \`src/three/CeilingMesh.tsx\` — 3D rendering

**Modified:**
- \`src/types/cad.ts\` — Ceiling type + ToolType union
- \`src/stores/cadStore.ts\` — 3 new actions + useActiveCeilings selector
- \`src/canvas/fabricSync.ts\` — renderCeilings function
- \`src/canvas/FabricCanvas.tsx\` — wire ceiling rendering + tool activation
- \`src/three/ThreeViewport.tsx\` — render CeilingMesh components
- \`src/components/Toolbar.tsx\` — CEILING button + C shortcut
- \`src/components/StatusBar.tsx\` — drawing instructions
- \`src/App.tsx\` — C key handler

---

## Test plan

- [ ] Press C or click CEILING button → tool activates, status bar shows instructions
- [ ] Click 4 points on canvas → purple vertex markers appear, solid edges between them, dashed line back to first vertex
- [ ] Click on first vertex → polygon closes, translucent ceiling overlay appears on canvas
- [ ] Tool auto-reverts to Select
- [ ] Switch to 3D view → ceiling visible as horizontal surface overhead
- [ ] Press E to walk → look up → ceiling visible above
- [ ] Draw another ceiling at different height (need properties panel eventually) — for now just verify 2 ceilings render cleanly
- [ ] Press Escape mid-drawing → tool cancels cleanly
- [ ] Double-click → polygon closes (same as first-vertex close)