### PR TITLE
feat(v1.2 Phase 12): floor materials — 8 presets + custom upload

### DIFF
--- a/.planning/phases/12-floor-materials/12-PLAN.md
+++ b/.planning/phases/12-floor-materials/12-PLAN.md
@@ -1,0 +1,54 @@
+---
+phase: 12-floor-materials
+plan: 01
+subsystem: materials
+tags: [floor-01, floor-02, floor-03, materials, texture-upload]
+requires: [cadStore, ThreeViewport, Sidebar]
+provides: [FloorMaterial type, 8 presets, custom upload, scale/rotation controls, FloorMesh]
+affects:
+  - src/data/floorMaterials.ts (new)
+  - src/types/cad.ts
+  - src/stores/cadStore.ts
+  - src/three/FloorMesh.tsx (new)
+  - src/three/ThreeViewport.tsx
+  - src/components/FloorMaterialPicker.tsx (new)
+  - src/components/Sidebar.tsx
+decisions:
+  - "Floor material stored per-room on RoomDoc.floorMaterial (optional). Default = undefined = procedural wood floor from v1.0."
+  - "FloorMaterial supports kind='preset' (8 curated solid-color presets) or kind='custom' (user-uploaded image as data URL)."
+  - "Presets are solid-color baselines with per-material roughness. Real textures can be added in v1.3 without breaking the data model."
+  - "Custom texture applies repeat = width/scaleFt and rotation from the FloorMaterial fields."
+  - "FloorMesh component handles all three rendering paths (fallback wood, preset color, custom texture) so ThreeViewport stays clean."
+  - "Scale stored as repeat-distance in feet (easier to reason about than Three.js UV repeat counts)."
+metrics:
+  requirements_closed: [FLOOR-01, FLOOR-02, FLOOR-03]
+---
+
+# Phase 12 Plan: Floor Materials
+
+## Goal
+
+Jessica can pick a floor material from a preset catalog or upload her own texture, with scale + rotation controls so tile patterns read at the right size.
+
+## Tasks
+
+- [x] Create src/data/floorMaterials.ts with 8 presets (WOOD_OAK, WOOD_WALNUT, TILE_WHITE, TILE_BLACK, CONCRETE, CARPET, MARBLE, STONE)
+- [x] Add FloorMaterial type to src/types/cad.ts
+- [x] Add floorMaterial?: FloorMaterial to RoomDoc
+- [x] Add setFloorMaterial action to cadStore (with history)
+- [x] Create src/three/FloorMesh.tsx (handles fallback/preset/custom rendering paths)
+- [x] Swap ThreeViewport's inline floor mesh for <FloorMesh />
+- [x] Create src/components/FloorMaterialPicker.tsx (preset dropdown + upload + scale/rotation inputs + reset)
+- [x] Mount FloorMaterialPicker in Sidebar
+
+## Verification
+
+- [x] FLOOR_MATERIAL section appears in sidebar between LAYERS and SNAP
+- [x] Dropdown lists DEFAULT_WOOD + 8 presets + UPLOAD_IMAGE
+- [x] Pick a preset → 3D floor switches to that solid color with matching roughness
+- [x] Color swatch preview appears under dropdown when preset selected
+- [x] Select UPLOAD_IMAGE → file picker opens → choose image → floor updates with texture
+- [x] SCALE input changes pattern repeat distance in feet
+- [x] ROTATION input rotates texture in degrees
+- [x] RESET_TO_DEFAULT clears material → returns to procedural wood floor
+- [x] State persists in store + survives reload via auto-save

--- a/.planning/phases/12-floor-materials/12-SUMMARY.md
+++ b/.planning/phases/12-floor-materials/12-SUMMARY.md
@@ -1,0 +1,74 @@
+---
+phase: 12-floor-materials
+plan: 01
+subsystem: materials
+tags: [floor-01, floor-02, floor-03]
+requirements_closed: [FLOOR-01, FLOOR-02, FLOOR-03]
+affects:
+  - src/data/floorMaterials.ts
+  - src/types/cad.ts
+  - src/stores/cadStore.ts
+  - src/three/FloorMesh.tsx
+  - src/three/ThreeViewport.tsx
+  - src/components/FloorMaterialPicker.tsx
+  - src/components/Sidebar.tsx
+metrics:
+  completed: 2026-04-05
+  duration: ~15m
+---
+
+# Phase 12 Summary
+
+Closes FLOOR-01/02/03 — floor material picking, custom texture upload,
+and scale/rotation controls.
+
+## What shipped
+
+**8-preset catalog:** WOOD_OAK, WOOD_WALNUT, TILE_WHITE, TILE_BLACK,
+CONCRETE, CARPET, MARBLE, STONE. Each preset is a solid-color
+baseline with its own roughness (concrete 0.85, marble 0.2, etc.).
+Real procedural/image textures can land in v1.3 without changing
+the data model.
+
+**Custom texture upload:** Jessica uploads an image file → stored as
+data URL in `RoomDoc.floorMaterial.imageUrl`. Rendered on the floor
+with `repeat = width / scaleFt` and rotation applied via texture UV.
+Module-level cache (`customTextureCache`) prevents re-loading on
+every redraw.
+
+**Scale + rotation controls:** Stored as feet (`scaleFt`) and
+degrees (`rotationDeg`). Scale is the pattern's repeat distance in
+feet — more intuitive than Three.js UV repeat counts.
+
+**FloorMesh component:** Encapsulates all three rendering paths
+(fallback procedural wood, preset color, custom texture). Keeps
+ThreeViewport clean.
+
+**Sidebar UI:** FloorMaterialPicker component between LAYERS and
+SNAP. Dropdown, color swatch preview, file upload, scale/rotation
+inputs, reset button.
+
+## Data model
+
+```ts
+interface FloorMaterial {
+  kind: "preset" | "custom";
+  presetId?: string;   // preset kind only
+  imageUrl?: string;   // custom kind only
+  scaleFt: number;
+  rotationDeg: number;
+}
+
+interface RoomDoc {
+  // ... existing
+  floorMaterial?: FloorMaterial;
+}
+```
+
+Default (undefined) = procedural wood floor from v1.0.
+
+## Not yet
+
+- Procedural patterns for tile presets (grout lines, herringbone)
+- Bump/normal maps for presets (depth perception)
+- Floor material preview swatches on the dropdown itself

--- a/src/components/FloorMaterialPicker.tsx
+++ b/src/components/FloorMaterialPicker.tsx
@@ -1,0 +1,143 @@
+import { useRef } from "react";
+import { useCADStore, useActiveRoomDoc } from "@/stores/cadStore";
+import { FLOOR_PRESETS, FLOOR_PRESET_IDS, type FloorPresetId } from "@/data/floorMaterials";
+import type { FloorMaterial } from "@/types/cad";
+
+export default function FloorMaterialPicker() {
+  const doc = useActiveRoomDoc();
+  const setFloorMaterial = useCADStore((s) => s.setFloorMaterial);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const current = doc?.floorMaterial;
+  const isCustom = current?.kind === "custom";
+  const currentPresetId: string =
+    current?.kind === "preset" && current.presetId ? current.presetId : "DEFAULT";
+
+  const handlePreset = (presetId: FloorPresetId | "DEFAULT") => {
+    if (presetId === "DEFAULT") {
+      setFloorMaterial(undefined);
+      return;
+    }
+    const preset = FLOOR_PRESETS[presetId];
+    const material: FloorMaterial = {
+      kind: "preset",
+      presetId,
+      scaleFt: current?.scaleFt ?? preset.defaultScaleFt,
+      rotationDeg: current?.rotationDeg ?? 0,
+    };
+    setFloorMaterial(material);
+  };
+
+  const handleUpload = (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      alert("Please choose an image file.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const material: FloorMaterial = {
+        kind: "custom",
+        imageUrl: reader.result as string,
+        scaleFt: current?.scaleFt ?? 2,
+        rotationDeg: current?.rotationDeg ?? 0,
+      };
+      setFloorMaterial(material);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleScaleChange = (value: number) => {
+    if (!current) return;
+    setFloorMaterial({ ...current, scaleFt: Math.max(0.1, value) });
+  };
+
+  const handleRotationChange = (value: number) => {
+    if (!current) return;
+    setFloorMaterial({ ...current, rotationDeg: value });
+  };
+
+  return (
+    <div>
+      <h3 className="font-mono text-[10px] text-text-ghost tracking-widest uppercase mb-2">
+        FLOOR_MATERIAL
+      </h3>
+
+      {/* Preset dropdown */}
+      <select
+        value={isCustom ? "CUSTOM" : currentPresetId}
+        onChange={(e) => {
+          const v = e.target.value;
+          if (v === "CUSTOM") fileInputRef.current?.click();
+          else handlePreset(v as FloorPresetId | "DEFAULT");
+        }}
+        className="w-full font-mono text-[10px] bg-obsidian-high text-text-primary border border-outline-variant/30 px-2 py-1 rounded-sm mb-2"
+      >
+        <option value="DEFAULT">DEFAULT_WOOD</option>
+        {FLOOR_PRESET_IDS.map((id) => (
+          <option key={id} value={id}>
+            {FLOOR_PRESETS[id].label}
+          </option>
+        ))}
+        <option value="CUSTOM">{isCustom ? "CUSTOM_IMAGE ✓" : "UPLOAD_IMAGE..."}</option>
+      </select>
+
+      {/* Color swatch preview */}
+      {!isCustom && currentPresetId !== "DEFAULT" && (
+        <div className="flex items-center gap-2 mb-2">
+          <div
+            className="w-4 h-4 rounded-sm border border-outline-variant/30"
+            style={{ backgroundColor: FLOOR_PRESETS[currentPresetId as FloorPresetId].color }}
+          />
+          <span className="font-mono text-[9px] text-text-dim">
+            {FLOOR_PRESETS[currentPresetId as FloorPresetId].color}
+          </span>
+        </div>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) handleUpload(f);
+          e.target.value = "";
+        }}
+      />
+
+      {/* Scale + rotation controls (only when a material is chosen) */}
+      {current && (
+        <div className="space-y-1.5 mt-2">
+          <label className="block">
+            <span className="font-mono text-[9px] text-text-dim block">SCALE (ft)</span>
+            <input
+              type="number"
+              step="0.5"
+              min="0.1"
+              value={current.scaleFt}
+              onChange={(e) => handleScaleChange(parseFloat(e.target.value) || 1)}
+              className="w-full font-mono text-[10px] bg-obsidian-high text-accent-light border border-outline-variant/30 px-2 py-1 rounded-sm"
+            />
+          </label>
+          <label className="block">
+            <span className="font-mono text-[9px] text-text-dim block">ROTATION (°)</span>
+            <input
+              type="number"
+              step="15"
+              value={current.rotationDeg}
+              onChange={(e) => handleRotationChange(parseFloat(e.target.value) || 0)}
+              className="w-full font-mono text-[10px] bg-obsidian-high text-accent-light border border-outline-variant/30 px-2 py-1 rounded-sm"
+            />
+          </label>
+          <button
+            onClick={() => setFloorMaterial(undefined)}
+            className="w-full font-mono text-[9px] text-text-ghost hover:text-text-primary tracking-widest uppercase py-1 mt-1"
+          >
+            RESET_TO_DEFAULT
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useActiveRoom, useActiveWalls, useActivePlacedProducts } from "@/stores
 import { useUIStore } from "@/stores/uiStore";
 import RoomSettings from "./RoomSettings";
 import SidebarProductPicker from "./SidebarProductPicker";
+import FloorMaterialPicker from "./FloorMaterialPicker";
 
 interface Props {
   productLibrary: Product[];
@@ -70,6 +71,9 @@ export default function Sidebar({ productLibrary: _productLibrary }: Props) {
             </label>
           </div>
         </div>
+
+        {/* Floor material (FLOOR-01/02/03) */}
+        <FloorMaterialPicker />
 
         {/* Grid snap */}
         <div>

--- a/src/data/floorMaterials.ts
+++ b/src/data/floorMaterials.ts
@@ -1,0 +1,90 @@
+/** Curated preset floor materials for Phase 12. Each preset is a solid color
+ *  baseline — in a future phase we'll add procedural patterns + texture files. */
+
+export type FloorPresetId =
+  | "WOOD_OAK"
+  | "WOOD_WALNUT"
+  | "TILE_WHITE"
+  | "TILE_BLACK"
+  | "CONCRETE"
+  | "CARPET"
+  | "MARBLE"
+  | "STONE";
+
+export interface FloorPreset {
+  id: FloorPresetId;
+  label: string;
+  color: string; // hex color
+  roughness: number; // 0 = glossy, 1 = matte
+  defaultScaleFt: number; // natural pattern repeat in feet (used if we later add textures)
+}
+
+export const FLOOR_PRESETS: Record<FloorPresetId, FloorPreset> = {
+  WOOD_OAK: {
+    id: "WOOD_OAK",
+    label: "WOOD_OAK",
+    color: "#b08158",
+    roughness: 0.7,
+    defaultScaleFt: 0.5,
+  },
+  WOOD_WALNUT: {
+    id: "WOOD_WALNUT",
+    label: "WOOD_WALNUT",
+    color: "#5a3a28",
+    roughness: 0.7,
+    defaultScaleFt: 0.5,
+  },
+  TILE_WHITE: {
+    id: "TILE_WHITE",
+    label: "TILE_WHITE",
+    color: "#efefef",
+    roughness: 0.3,
+    defaultScaleFt: 1,
+  },
+  TILE_BLACK: {
+    id: "TILE_BLACK",
+    label: "TILE_BLACK",
+    color: "#1c1c1c",
+    roughness: 0.3,
+    defaultScaleFt: 1,
+  },
+  CONCRETE: {
+    id: "CONCRETE",
+    label: "CONCRETE",
+    color: "#8a8a8a",
+    roughness: 0.85,
+    defaultScaleFt: 4,
+  },
+  CARPET: {
+    id: "CARPET",
+    label: "CARPET",
+    color: "#c4b294",
+    roughness: 0.95,
+    defaultScaleFt: 1,
+  },
+  MARBLE: {
+    id: "MARBLE",
+    label: "MARBLE",
+    color: "#ece5d6",
+    roughness: 0.2,
+    defaultScaleFt: 2,
+  },
+  STONE: {
+    id: "STONE",
+    label: "STONE",
+    color: "#7a6f60",
+    roughness: 0.8,
+    defaultScaleFt: 1.5,
+  },
+};
+
+export const FLOOR_PRESET_IDS: FloorPresetId[] = [
+  "WOOD_OAK",
+  "WOOD_WALNUT",
+  "TILE_WHITE",
+  "TILE_BLACK",
+  "CONCRETE",
+  "CARPET",
+  "MARBLE",
+  "STONE",
+];

--- a/src/stores/cadStore.ts
+++ b/src/stores/cadStore.ts
@@ -9,6 +9,7 @@ import type {
   Opening,
   RoomDoc,
   Ceiling,
+  FloorMaterial,
 } from "@/types/cad";
 import { uid, resizeWall } from "@/lib/geometry";
 import { ROOM_TEMPLATES, type RoomTemplateId } from "@/data/roomTemplates";
@@ -45,6 +46,7 @@ interface CADState {
   addCeiling: (points: Point[], height: number, material?: string) => string;
   updateCeiling: (id: string, changes: Partial<Ceiling>) => void;
   removeCeiling: (id: string) => void;
+  setFloorMaterial: (material: FloorMaterial | undefined) => void;
   removeProduct: (id: string) => void;
   removeSelected: (ids: string[]) => void;
   undo: () => void;
@@ -369,6 +371,17 @@ export const useCADStore = create<CADState>()((set) => ({
         if (!doc || !doc.ceilings || !doc.ceilings[id]) return;
         pushHistory(s);
         delete doc.ceilings[id];
+      })
+    ),
+
+  setFloorMaterial: (material) =>
+    set(
+      produce((s: CADState) => {
+        const doc = activeDoc(s);
+        if (!doc) return;
+        pushHistory(s);
+        if (material) doc.floorMaterial = material;
+        else delete doc.floorMaterial;
       })
     ),
 

--- a/src/three/FloorMesh.tsx
+++ b/src/three/FloorMesh.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from "react";
+import * as THREE from "three";
+import type { FloorMaterial } from "@/types/cad";
+import { FLOOR_PRESETS, type FloorPresetId } from "@/data/floorMaterials";
+
+interface Props {
+  width: number;
+  length: number;
+  halfW: number;
+  halfL: number;
+  material: FloorMaterial | undefined;
+  fallbackTexture: THREE.Texture;
+}
+
+/** Module-level texture cache for uploaded custom floor images (data URLs). */
+const customTextureCache = new Map<string, THREE.Texture>();
+
+function getCustomTexture(dataUrl: string, scaleFt: number, rotationDeg: number, width: number, length: number): THREE.Texture {
+  let tex = customTextureCache.get(dataUrl);
+  if (!tex) {
+    const loader = new THREE.TextureLoader();
+    tex = loader.load(dataUrl);
+    tex.wrapS = THREE.RepeatWrapping;
+    tex.wrapT = THREE.RepeatWrapping;
+    customTextureCache.set(dataUrl, tex);
+  }
+  // Apply repeat + rotation each render
+  const repeatX = width / Math.max(0.1, scaleFt);
+  const repeatY = length / Math.max(0.1, scaleFt);
+  tex.repeat.set(repeatX, repeatY);
+  tex.center.set(0.5, 0.5);
+  tex.rotation = (rotationDeg * Math.PI) / 180;
+  tex.needsUpdate = true;
+  return tex;
+}
+
+export default function FloorMesh({ width, length, halfW, halfL, material, fallbackTexture }: Props) {
+  // Determine rendering path
+  const { texture, color, roughness } = useMemo(() => {
+    if (!material) {
+      // No material chosen → default procedural wood
+      return { texture: fallbackTexture, color: "#ffffff", roughness: 0.75 };
+    }
+    if (material.kind === "custom" && material.imageUrl) {
+      const tex = getCustomTexture(material.imageUrl, material.scaleFt, material.rotationDeg, width, length);
+      return { texture: tex, color: "#ffffff", roughness: 0.75 };
+    }
+    if (material.kind === "preset" && material.presetId) {
+      const preset = FLOOR_PRESETS[material.presetId as FloorPresetId];
+      if (preset) {
+        return { texture: null as THREE.Texture | null, color: preset.color, roughness: preset.roughness };
+      }
+    }
+    return { texture: fallbackTexture, color: "#ffffff", roughness: 0.75 };
+  }, [material, fallbackTexture, width, length]);
+
+  return (
+    <mesh
+      position={[halfW, 0, halfL]}
+      rotation={[-Math.PI / 2, 0, 0]}
+      receiveShadow
+    >
+      <planeGeometry args={[width, length]} />
+      <meshStandardMaterial
+        map={texture ?? undefined}
+        color={color}
+        roughness={roughness}
+        metalness={0}
+      />
+    </mesh>
+  );
+}

--- a/src/three/ThreeViewport.tsx
+++ b/src/three/ThreeViewport.tsx
@@ -2,12 +2,13 @@ import * as THREE from "three";
 import { Suspense, useRef, useEffect, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Environment, PointerLockControls } from "@react-three/drei";
-import { useActiveRoom, useActiveWalls, useActivePlacedProducts, useActiveCeilings } from "@/stores/cadStore";
+import { useActiveRoom, useActiveRoomDoc, useActiveWalls, useActivePlacedProducts, useActiveCeilings } from "@/stores/cadStore";
 import { useUIStore } from "@/stores/uiStore";
 import type { Product } from "@/types/product";
 import WallMesh from "./WallMesh";
 import ProductMesh from "./ProductMesh";
 import CeilingMesh from "./CeilingMesh";
+import FloorMesh from "./FloorMesh";
 import Lighting from "./Lighting";
 import WalkCameraController from "./WalkCameraController";
 import { getFloorTexture } from "./floorTexture";
@@ -21,6 +22,8 @@ function Scene({ productLibrary }: Props) {
   const walls = useActiveWalls();
   const placedProducts = useActivePlacedProducts();
   const ceilings = useActiveCeilings();
+  const activeDoc = useActiveRoomDoc();
+  const floorMaterial = activeDoc?.floorMaterial;
   const selectedIds = useUIStore((s) => s.selectedIds);
   const cameraMode = useUIStore((s) => s.cameraMode);
 
@@ -48,15 +51,15 @@ function Scene({ productLibrary }: Props) {
     <>
       <Lighting />
 
-      {/* Floor — D-05 wood-plank procedural texture */}
-      <mesh
-        position={[halfW, 0, halfL]}
-        rotation={[-Math.PI / 2, 0, 0]}
-        receiveShadow
-      >
-        <planeGeometry args={[room.width, room.length]} />
-        <meshStandardMaterial map={floorTexture} roughness={0.75} metalness={0.0} />
-      </mesh>
+      {/* Floor — procedural wood by default, or user-chosen material (FLOOR-01/02/03) */}
+      <FloorMesh
+        width={room.width}
+        length={room.length}
+        halfW={halfW}
+        halfL={halfL}
+        material={floorMaterial}
+        fallbackTexture={floorTexture}
+      />
 
       {/* Ambient PBR bounce — D-08 */}
       <Suspense fallback={null}>

--- a/src/types/cad.ts
+++ b/src/types/cad.ts
@@ -48,6 +48,18 @@ export interface Ceiling {
   material: string;
 }
 
+export interface FloorMaterial {
+  kind: "preset" | "custom";
+  /** Present when kind === "preset". From FLOOR_PRESET_IDS. */
+  presetId?: string;
+  /** Present when kind === "custom". Data URL. */
+  imageUrl?: string;
+  /** Texture tile repeat distance in feet (e.g. 2 = pattern repeats every 2ft). */
+  scaleFt: number;
+  /** Texture rotation in degrees. */
+  rotationDeg: number;
+}
+
 export interface RoomDoc {
   id: string;
   name: string;
@@ -59,6 +71,8 @@ export interface RoomDoc {
   floorPlanImage?: string;
   /** Ceilings drawn as independent polygon surfaces overhead. */
   ceilings?: Record<string, Ceiling>;
+  /** Floor material (preset or custom upload). Per-room. */
+  floorMaterial?: FloorMaterial;
 }
 
 export interface CADSnapshot {


### PR DESCRIPTION
# Phase 12 — Floor Materials

Closes **FLOOR-01, FLOOR-02, FLOOR-03** of v1.2.

---

## What's new

### 8-preset material catalog (FLOOR-01)

Pick from the FLOOR_MATERIAL dropdown in the sidebar:

- **WOOD_OAK** / **WOOD_WALNUT** (two wood tones)
- **TILE_WHITE** / **TILE_BLACK**
- **CONCRETE** (matte, high roughness)
- **CARPET** (warm beige)
- **MARBLE** (low roughness — slightly glossy)
- **STONE** (slate-ish)

Each preset has its own color + roughness so the 3D render reflects how the material would actually look.

### Custom texture upload (FLOOR-02)

Select **UPLOAD_IMAGE...** from the dropdown → file picker opens → pick any image → it becomes your floor texture. Tiles across the whole floor, respects scale + rotation.

### Scale + rotation controls (FLOOR-03)

- **SCALE (ft)**: pattern repeat distance. 2 = pattern repeats every 2 feet.
- **ROTATION (°)**: rotate the texture.

Stored as feet and degrees (intuitive) instead of Three.js UV repeat counts.

### Reset to default

RESET_TO_DEFAULT button → restores the procedural wood floor from v1.0. No material chosen = default.

---

## Data model

\`\`\`ts
interface FloorMaterial {
  kind: "preset" | "custom";
  presetId?: string;   // when preset
  imageUrl?: string;   // when custom
  scaleFt: number;
  rotationDeg: number;
}

interface RoomDoc {
  // ... existing fields
  floorMaterial?: FloorMaterial;
}
\`\`\`

Stored per-room. Undefined = procedural wood.

---

## Files touched

**New:**
- \`src/data/floorMaterials.ts\` — 8 preset definitions
- \`src/three/FloorMesh.tsx\` — handles all 3 rendering paths
- \`src/components/FloorMaterialPicker.tsx\` — sidebar UI

**Modified:**
- \`src/types/cad.ts\` — FloorMaterial + RoomDoc field
- \`src/stores/cadStore.ts\` — setFloorMaterial action
- \`src/three/ThreeViewport.tsx\` — use FloorMesh component
- \`src/components/Sidebar.tsx\` — mount picker

---

## Test plan

- [ ] Sidebar shows FLOOR_MATERIAL section between LAYERS and SNAP
- [ ] Dropdown lists DEFAULT_WOOD + 8 presets + UPLOAD_IMAGE
- [ ] Pick MARBLE → 3D floor goes light cream, looks slightly glossy
- [ ] Pick CONCRETE → floor goes grey, matte
- [ ] Select UPLOAD_IMAGE → file picker opens → pick any image → floor updates
- [ ] Change SCALE from 2 to 4 → pattern repeats further apart
- [ ] Change ROTATION to 45 → pattern rotates
- [ ] Click RESET_TO_DEFAULT → original wood floor returns
- [ ] Reload the page → material choice persists (auto-save works)