### PR TITLE
Phase 15 — Framed Art Library (ART-01/02/03/04/05/06)

### DIFF
--- a/.planning/phases/15-framed-art-library/15-PLAN.md
+++ b/.planning/phases/15-framed-art-library/15-PLAN.md
@@ -1,0 +1,114 @@
+---
+phase: 15-framed-art-library
+plan: 01
+subsystem: wall-surfaces
+tags: [art-01, art-02, art-03, art-04, art-05, art-06]
+requires: [cadStore, WallMesh, WallSurfacePanel, Sidebar]
+provides: [FramedArtItem type + FRAME_PRESETS, global art library store, 3D frame geometry, from-library placement]
+affects:
+  - src/types/framedArt.ts (new)
+  - src/types/cad.ts
+  - src/stores/framedArtStore.ts (new)
+  - src/three/WallMesh.tsx
+  - src/components/FramedArtLibrary.tsx (new)
+  - src/components/WallSurfacePanel.tsx
+  - src/components/Sidebar.tsx
+  - src/App.tsx
+decisions:
+  - "Framed art items are GLOBAL (like products) — persisted to IndexedDB under key 'room-cad-framed-art', available across all projects."
+  - "FrameStyle is a preset enum with 7 options (none, thin-black, thick-gold, natural-wood, museum-white, floating, ornate) — no custom frame builder in v1."
+  - "Reuse existing WallArt slot on WallSegment — add optional frameStyle field. Backward compat: missing frameStyle = plain plane (current behavior)."
+  - "Placement via existing WallSurfacePanel — new '+ FROM_LIBRARY' button opens a picker; dims come from library item (editable after)."
+  - "3D: frame renders as 4 boxGeometry strips (top/bottom/left/right) around an inset art plane. Frame depth protrudes from the wall face; art sits recessed in the frame opening."
+  - "Library items are reusable but placements are independent copies — editing library item does NOT update existing placements."
+metrics:
+  requirements_closed: [ART-01, ART-02, ART-03, ART-04, ART-05, ART-06]
+---
+
+# Phase 15 Plan: Framed Art Library
+
+## Goal
+
+Jessica uploads art she loves (Pinterest finds, family photos, posters), combines it with a chosen frame preset, saves it to a reusable global library, and places framed pieces on any wall with real 3D frame geometry.
+
+## Tasks
+
+- [ ] Create `src/types/framedArt.ts` — FrameStyle type, FramedArtItem interface, FRAME_PRESETS constant
+- [ ] Add optional `frameStyle?: FrameStyle` + `frameColor?: string` to WallArt in cad.ts
+- [ ] Create `src/stores/framedArtStore.ts` — global library with load/add/remove/update, IndexedDB persistence (mirrors productStore pattern)
+- [ ] Create `src/components/FramedArtLibrary.tsx` — sidebar panel with upload form (name, image, frame picker) + catalog list with delete
+- [ ] Mount FramedArtLibrary in Sidebar.tsx
+- [ ] Load framedArtStore in App.tsx on mount
+- [ ] Update WallMesh.tsx — replace flat art plane with group (inset art + 4 frame strips using FRAME_PRESETS config)
+- [ ] Add "+ FROM_LIBRARY" button to WallSurfacePanel — opens picker modal/dropdown, creates wallArt entry with chosen frameStyle + default 2'×2.5' dims
+
+## Frame Presets
+
+| Style | Width | Depth | Color | Notes |
+|-------|-------|-------|-------|-------|
+| none | 0 | 0 | — | flat plane (back-compat) |
+| thin-black | 0.08 | 0.03 | #0d0d0d | minimalist |
+| thick-gold | 0.25 | 0.08 | #b8912d | classic gallery |
+| natural-wood | 0.15 | 0.06 | #8b6b4a | warm oak tone |
+| museum-white | 0.20 | 0.10 | #f4f2ee | gallery mat |
+| floating | 0.05 | 0.15 | #1a1a1a | deep thin offset |
+| ornate | 0.35 | 0.12 | #c9a04f | wide gold |
+
+All widths + depths in feet.
+
+## Data Model
+
+```ts
+// types/framedArt.ts (NEW)
+export type FrameStyle =
+  | "none" | "thin-black" | "thick-gold" | "natural-wood"
+  | "museum-white" | "floating" | "ornate";
+
+export interface FramedArtItem {
+  id: string;          // "fart_..."
+  name: string;
+  imageUrl: string;    // data URL
+  frameStyle: FrameStyle;
+}
+
+export interface FramePreset {
+  width: number;   // ft
+  depth: number;   // ft
+  color: string;   // hex
+  label: string;
+}
+export const FRAME_PRESETS: Record<FrameStyle, FramePreset> = { ... };
+
+// types/cad.ts (EXTEND WallArt)
+export interface WallArt {
+  id: string;
+  offset: number;
+  centerY: number;
+  width: number;
+  height: number;
+  imageUrl: string;
+  frameStyle?: FrameStyle;  // NEW
+}
+```
+
+## 3D Rendering
+
+Replace the current single `<planeGeometry>` in WallMesh with a group:
+1. **Art plane** — inset at `thickness/2 + depth - 0.005` (just behind the frame front face), dims = (width - 2×frameW) × (height - 2×frameW)
+2. **4 frame strips** — boxGeometry, one each for top/bottom/left/right, depth protruding from wall face
+   - Top/bottom: `(width × frameW × depth)` at top/bottom edges
+   - Left/right: `((height − 2×frameW) × frameW × depth)` between top/bottom strips
+3. If `frameStyle="none"` or undefined → render single plane (current behavior)
+
+## Verification
+
+- [ ] ART_LIBRARY section appears in sidebar (below CUSTOM_ELEMENTS)
+- [ ] Upload image + name + pick frame → CREATE adds to library
+- [ ] Library persists after page refresh (IndexedDB)
+- [ ] Delete button removes from library
+- [ ] In WallSurfacePanel, + FROM_LIBRARY opens picker; clicking an item adds it to wallArt
+- [ ] 2D shows art at correct position (reuses existing 2D rendering if any)
+- [ ] 3D shows art with frame protruding from wall face
+- [ ] All 7 frame presets render with distinct colors/widths/depths
+- [ ] Legacy wall art (no frameStyle) still renders as flat plane — no regression
+- [ ] Same library item placed twice on two different walls works independently

--- a/.planning/phases/15-framed-art-library/15-SUMMARY.md
+++ b/.planning/phases/15-framed-art-library/15-SUMMARY.md
@@ -1,0 +1,83 @@
+---
+phase: 15-framed-art-library
+plan: 01
+subsystem: wall-surfaces
+tags: [art-01, art-02, art-03, art-04, art-05, art-06]
+requirements_closed: [ART-01, ART-02, ART-03, ART-04, ART-05, ART-06]
+affects:
+  - src/types/framedArt.ts
+  - src/types/cad.ts
+  - src/stores/framedArtStore.ts
+  - src/three/WallMesh.tsx
+  - src/components/FramedArtLibrary.tsx
+  - src/components/WallSurfacePanel.tsx
+  - src/components/Sidebar.tsx
+  - src/App.tsx
+metrics:
+  completed: 2026-04-05
+  duration: ~20m
+---
+
+# Phase 15 Summary
+
+Closes ART-01/02/03/04/05/06 — global framed art library with real 3D frame geometry.
+
+## What shipped
+
+**Global library:** FramedArtItem persisted to IndexedDB under key
+`room-cad-framed-art`. Mirrors productStore: load on mount, subscribe
+to persist. Reusable across all projects, not per-project.
+
+**7 frame presets:** none, thin-black, thick-gold, natural-wood,
+museum-white, floating, ornate. Each preset configures frame width,
+depth (protrusion from wall), and color.
+
+**Sidebar ART_LIBRARY section:** Upload image + name + pick frame
+style from dropdown → SAVE_TO_LIBRARY adds it. Cards show scaled
+frame preview around the image thumbnail.
+
+**+ LIB button** in WallSurfacePanel (when a wall is selected):
+opens inline picker listing all library items. Clicking an item
+creates a wallArt entry on that wall at default 2'×2.5' with the
+item's frameStyle preserved.
+
+**Real 3D frame geometry in WallMesh.tsx:** replaces the flat
+plane with a 4-strip boxGeometry group (top/bottom/left/right)
+plus an inset art plane. Frame strips protrude from the wall face
+at configured depth; art sits recessed in the frame opening.
+
+**Backward compat:** WallArt entries without `frameStyle` render as
+flat planes (current behavior). No migration needed.
+
+## Data model
+
+```ts
+// NEW: types/framedArt.ts
+type FrameStyle = "none" | "thin-black" | "thick-gold"
+                | "natural-wood" | "museum-white" | "floating" | "ornate";
+
+interface FramedArtItem {
+  id: string;
+  name: string;
+  imageUrl: string;
+  frameStyle: FrameStyle;
+}
+
+const FRAME_PRESETS: Record<FrameStyle, { width, depth, color, label }>;
+
+// EXTENDED: types/cad.ts
+interface WallArt {
+  // ...existing fields...
+  frameStyle?: FrameStyle; // NEW, optional
+}
+```
+
+## Deferred
+
+- **Dims editor on placed art:** can edit width/height via direct
+  wallArt manipulation but no slick UI yet; default drop is 2'×2.5'
+- **Frame color override:** presets are fixed; per-placement color
+  tweaks will land in v1.3 (color system milestone)
+- **Position editor:** offset + centerY aren't exposed in UI yet
+- **Library item preview in 3D:** placing from library uses stock
+  dims, not the image's natural aspect ratio

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { ToolType } from "@/types/cad";
 import { useUIStore } from "@/stores/uiStore";
 import { useCADStore, useActiveWalls } from "@/stores/cadStore";
 import { useProductStore } from "@/stores/productStore";
+import { useFramedArtStore } from "@/stores/framedArtStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useAutoSave } from "@/hooks/useAutoSave";
 import { useHelpRouteSync } from "@/hooks/useHelpRouteSync";
@@ -47,6 +48,7 @@ export default function App() {
   // Single load on mount — fixes dual-loader race
   useEffect(() => {
     useProductStore.getState().load();
+    useFramedArtStore.getState().load();
   }, []);
 
   // Hydrate last-saved project on mount (SAVE-02 reload support)

--- a/src/components/FramedArtLibrary.tsx
+++ b/src/components/FramedArtLibrary.tsx
@@ -1,0 +1,138 @@
+import { useState, useRef } from "react";
+import { useFramedArtStore } from "@/stores/framedArtStore";
+import { FRAME_PRESETS, FRAME_STYLES, type FrameStyle } from "@/types/framedArt";
+
+export default function FramedArtLibrary() {
+  const items = useFramedArtStore((s) => s.items);
+  const addItem = useFramedArtStore((s) => s.addItem);
+  const removeItem = useFramedArtStore((s) => s.removeItem);
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("");
+  const [imageUrl, setImageUrl] = useState<string>("");
+  const [frameStyle, setFrameStyle] = useState<FrameStyle>("thin-black");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => setImageUrl(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handleCreate = () => {
+    if (!name.trim() || !imageUrl) return;
+    addItem({ name: name.trim(), imageUrl, frameStyle });
+    setName("");
+    setImageUrl("");
+    setFrameStyle("thin-black");
+    setCreating(false);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="font-mono text-[10px] text-text-ghost tracking-widest uppercase">
+          ART_LIBRARY
+        </h3>
+        <button
+          onClick={() => setCreating((v) => !v)}
+          className="font-mono text-[9px] text-accent-light hover:text-accent tracking-widest"
+        >
+          {creating ? "CANCEL" : "+ NEW"}
+        </button>
+      </div>
+
+      {creating && (
+        <div className="space-y-1.5 bg-obsidian-high rounded-sm p-2 mb-2">
+          <input
+            type="text"
+            placeholder="NAME..."
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full font-mono text-[10px] bg-obsidian-base text-text-primary border border-outline-variant/30 px-2 py-1 rounded-sm placeholder:text-text-ghost"
+          />
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+            }}
+            className="hidden"
+          />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="w-full font-mono text-[9px] tracking-widest py-1 bg-obsidian-base text-text-dim border border-outline-variant/30 rounded-sm hover:text-text-primary"
+          >
+            {imageUrl ? "CHANGE_IMAGE" : "+ UPLOAD_IMAGE"}
+          </button>
+          {imageUrl && (
+            <div className="w-full aspect-video bg-obsidian-base rounded-sm border border-outline-variant/30 overflow-hidden">
+              <img src={imageUrl} alt="preview" className="w-full h-full object-contain" />
+            </div>
+          )}
+          <select
+            value={frameStyle}
+            onChange={(e) => setFrameStyle(e.target.value as FrameStyle)}
+            className="w-full font-mono text-[10px] bg-obsidian-base text-accent-light border border-outline-variant/30 px-2 py-1 rounded-sm"
+          >
+            {FRAME_STYLES.map((s) => (
+              <option key={s} value={s}>
+                {FRAME_PRESETS[s].label}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={handleCreate}
+            disabled={!name.trim() || !imageUrl}
+            className="w-full font-mono text-[10px] tracking-widest py-1 bg-accent text-white rounded-sm hover:opacity-90 disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            SAVE_TO_LIBRARY
+          </button>
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="font-mono text-[9px] text-text-ghost text-center py-2">
+          NO_ART_YET
+        </div>
+      ) : (
+        <ul className="space-y-1">
+          {items.map((it) => {
+            const preset = FRAME_PRESETS[it.frameStyle];
+            return (
+              <li
+                key={it.id}
+                className="flex items-center justify-between bg-obsidian-high rounded-sm px-2 py-1.5"
+              >
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <div
+                    className="w-6 h-6 rounded-sm overflow-hidden shrink-0 border"
+                    style={{ borderColor: preset.color, borderWidth: Math.max(1, preset.width * 8) }}
+                  >
+                    <img src={it.imageUrl} alt={it.name} className="w-full h-full object-cover" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-mono text-[10px] text-text-primary truncate">
+                      {it.name.toUpperCase()}
+                    </div>
+                    <div className="font-mono text-[8px] text-text-ghost">
+                      {preset.label}
+                    </div>
+                  </div>
+                </div>
+                <button
+                  onClick={() => removeItem(it.id)}
+                  title="Delete from library"
+                  className="font-mono text-[9px] text-text-ghost hover:text-text-primary px-1 shrink-0"
+                >
+                  ✕
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import RoomSettings from "./RoomSettings";
 import SidebarProductPicker from "./SidebarProductPicker";
 import FloorMaterialPicker from "./FloorMaterialPicker";
 import CustomElementsPanel from "./CustomElementsPanel";
+import FramedArtLibrary from "./FramedArtLibrary";
 
 interface Props {
   productLibrary: Product[];
@@ -95,6 +96,9 @@ export default function Sidebar({ productLibrary: _productLibrary }: Props) {
 
         {/* Custom Elements (Phase 14) */}
         <CustomElementsPanel />
+
+        {/* Framed Art Library (Phase 15) */}
+        <FramedArtLibrary />
 
         {/* Product picker (LIB-05) */}
         <div>

--- a/src/components/WallSurfacePanel.tsx
+++ b/src/components/WallSurfacePanel.tsx
@@ -1,7 +1,9 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useCADStore, useActiveWalls } from "@/stores/cadStore";
 import { useUIStore } from "@/stores/uiStore";
+import { useFramedArtStore } from "@/stores/framedArtStore";
 import type { Wallpaper } from "@/types/cad";
+import { FRAME_PRESETS } from "@/types/framedArt";
 
 /** Appears in PropertiesPanel when exactly one wall is selected. */
 export default function WallSurfacePanel() {
@@ -14,6 +16,8 @@ export default function WallSurfacePanel() {
   const removeWallArt = useCADStore((s) => s.removeWallArt);
   const wallpaperFileRef = useRef<HTMLInputElement>(null);
   const artFileRef = useRef<HTMLInputElement>(null);
+  const framedArtItems = useFramedArtStore((s) => s.items);
+  const [showLibrary, setShowLibrary] = useState(false);
 
   if (selectedIds.length !== 1) return null;
   const wall = walls[selectedIds[0]];
@@ -62,6 +66,20 @@ export default function WallSurfacePanel() {
       });
     };
     reader.readAsDataURL(file);
+  };
+
+  const handleAddFromLibrary = (itemId: string) => {
+    const item = framedArtItems.find((i) => i.id === itemId);
+    if (!item) return;
+    addWallArt(wall.id, {
+      offset: 2,
+      centerY: wall.height / 2,
+      width: 2,
+      height: 2.5,
+      imageUrl: item.imageUrl,
+      frameStyle: item.frameStyle,
+    });
+    setShowLibrary(false);
   };
 
   return (
@@ -198,13 +216,58 @@ export default function WallSurfacePanel() {
       <div>
         <div className="flex items-center justify-between mb-1">
           <span className="font-mono text-[9px] text-text-dim tracking-wider">WALL_ART ({artItems.length})</span>
-          <button
-            onClick={() => artFileRef.current?.click()}
-            className="font-mono text-[9px] text-accent-light hover:text-accent tracking-widest"
-          >
-            + ADD
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowLibrary((v) => !v)}
+              className="font-mono text-[9px] text-accent-light hover:text-accent tracking-widest"
+            >
+              {showLibrary ? "CLOSE" : "+ LIB"}
+            </button>
+            <button
+              onClick={() => artFileRef.current?.click()}
+              className="font-mono text-[9px] text-accent-light hover:text-accent tracking-widest"
+            >
+              + ADD
+            </button>
+          </div>
         </div>
+        {showLibrary && (
+          <div className="bg-obsidian-high rounded-sm p-2 mb-1 max-h-40 overflow-y-auto">
+            {framedArtItems.length === 0 ? (
+              <div className="font-mono text-[9px] text-text-ghost text-center py-1">
+                ART_LIBRARY_EMPTY
+              </div>
+            ) : (
+              <ul className="space-y-1">
+                {framedArtItems.map((it) => (
+                  <li key={it.id}>
+                    <button
+                      onClick={() => handleAddFromLibrary(it.id)}
+                      className="w-full flex items-center gap-2 px-1 py-1 hover:bg-obsidian-highest rounded-sm"
+                    >
+                      <div
+                        className="w-5 h-5 rounded-sm overflow-hidden shrink-0 border"
+                        style={{
+                          borderColor: FRAME_PRESETS[it.frameStyle].color,
+                          borderWidth: Math.max(1, FRAME_PRESETS[it.frameStyle].width * 8),
+                        }}
+                      >
+                        <img
+                          src={it.imageUrl}
+                          alt={it.name}
+                          className="w-full h-full object-cover"
+                        />
+                      </div>
+                      <div className="font-mono text-[9px] text-text-dim truncate">
+                        {it.name.toUpperCase()}
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
         {artItems.length > 0 && (
           <ul className="space-y-1">
             {artItems.map((a) => (

--- a/src/stores/framedArtStore.ts
+++ b/src/stores/framedArtStore.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+import { produce } from "immer";
+import { get, set } from "idb-keyval";
+import type { FramedArtItem, FrameStyle } from "@/types/framedArt";
+
+const FRAMED_ART_KEY = "room-cad-framed-art";
+
+interface FramedArtState {
+  items: FramedArtItem[];
+  loaded: boolean;
+  load: () => Promise<void>;
+  addItem: (item: Omit<FramedArtItem, "id">) => string;
+  removeItem: (id: string) => void;
+  updateItem: (id: string, changes: Partial<FramedArtItem>) => void;
+}
+
+function uid() {
+  return `fart_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export const useFramedArtStore = create<FramedArtState>()((setState) => ({
+  items: [],
+  loaded: false,
+
+  load: async () => {
+    const stored = await get<FramedArtItem[]>(FRAMED_ART_KEY);
+    if (stored && Array.isArray(stored)) {
+      // Coerce any legacy records to current shape
+      const migrated: FramedArtItem[] = stored.map((i) => ({
+        id: i.id,
+        name: i.name ?? "UNTITLED",
+        imageUrl: i.imageUrl ?? "",
+        frameStyle: (i.frameStyle ?? "thin-black") as FrameStyle,
+      }));
+      setState({ items: migrated, loaded: true });
+    } else {
+      setState({ loaded: true });
+    }
+  },
+
+  addItem: (item) => {
+    const id = uid();
+    setState(
+      produce((s: FramedArtState) => {
+        s.items.push({ id, ...item });
+      })
+    );
+    return id;
+  },
+
+  removeItem: (id) =>
+    setState(
+      produce((s: FramedArtState) => {
+        s.items = s.items.filter((x) => x.id !== id);
+      })
+    ),
+
+  updateItem: (id, changes) =>
+    setState(
+      produce((s: FramedArtState) => {
+        const it = s.items.find((x) => x.id === id);
+        if (it) Object.assign(it, changes);
+      })
+    ),
+}));
+
+// Persist to IndexedDB after load() completes (prevents wiping on initial render)
+useFramedArtStore.subscribe((state, prev) => {
+  if (state.loaded && state.items !== prev.items) {
+    set(FRAMED_ART_KEY, state.items).catch(() => {});
+  }
+});

--- a/src/three/WallMesh.tsx
+++ b/src/three/WallMesh.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import * as THREE from "three";
 import type { WallSegment } from "@/types/cad";
 import { wallLength, angle } from "@/lib/geometry";
+import { FRAME_PRESETS } from "@/types/framedArt";
 
 interface Props {
   wall: WallSegment;
@@ -282,19 +283,67 @@ export default function WallMesh({ wall, isSelected }: Props) {
         </mesh>
       )}
 
-      {/* Wall art items — textured planes on interior face (never tiled) */}
+      {/* Wall art items — framed or flat, on interior face */}
       {(wall.wallArt ?? []).map((art) => {
         const tex = getWallArtTexture(art.imageUrl);
         const artX = art.offset - halfLen + art.width / 2;
         const artY = art.centerY - halfH;
+        const preset = art.frameStyle ? FRAME_PRESETS[art.frameStyle] : null;
+        const frameW = preset?.width ?? 0;
+        const frameD = preset?.depth ?? 0;
+        const baseZ = thickness / 2 + bandOffset * 2;
+
+        // No frame (or frameStyle="none") → flat plane (legacy behavior)
+        if (!preset || art.frameStyle === "none" || frameW === 0) {
+          return (
+            <mesh key={art.id} position={[artX, artY, baseZ]}>
+              <planeGeometry args={[art.width, art.height]} />
+              <meshStandardMaterial map={tex} roughness={0.5} metalness={0} side={THREE.DoubleSide} />
+            </mesh>
+          );
+        }
+
+        // Framed: inset art plane + 4 frame strips protruding from wall
+        const innerW = Math.max(0.01, art.width - 2 * frameW);
+        const innerH = Math.max(0.01, art.height - 2 * frameW);
+        // Art plane sits at the BACK of the frame (so frame depth appears to recess it)
+        const artZ = baseZ + 0.002;
+        const frameCenterZ = baseZ + frameD / 2;
+
         return (
-          <mesh
-            key={art.id}
-            position={[artX, artY, thickness / 2 + bandOffset * 2]}
-          >
-            <planeGeometry args={[art.width, art.height]} />
-            <meshStandardMaterial map={tex} roughness={0.5} metalness={0} side={THREE.DoubleSide} />
-          </mesh>
+          <group key={art.id} position={[artX, artY, 0]}>
+            {/* Art plane (recessed inside frame) */}
+            <mesh position={[0, 0, artZ]}>
+              <planeGeometry args={[innerW, innerH]} />
+              <meshStandardMaterial
+                map={tex}
+                roughness={0.5}
+                metalness={0}
+                side={THREE.DoubleSide}
+              />
+            </mesh>
+
+            {/* Top frame strip */}
+            <mesh position={[0, art.height / 2 - frameW / 2, frameCenterZ]} castShadow>
+              <boxGeometry args={[art.width, frameW, frameD]} />
+              <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
+            </mesh>
+            {/* Bottom frame strip */}
+            <mesh position={[0, -(art.height / 2 - frameW / 2), frameCenterZ]} castShadow>
+              <boxGeometry args={[art.width, frameW, frameD]} />
+              <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
+            </mesh>
+            {/* Left frame strip */}
+            <mesh position={[-(art.width / 2 - frameW / 2), 0, frameCenterZ]} castShadow>
+              <boxGeometry args={[frameW, innerH, frameD]} />
+              <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
+            </mesh>
+            {/* Right frame strip */}
+            <mesh position={[art.width / 2 - frameW / 2, 0, frameCenterZ]} castShadow>
+              <boxGeometry args={[frameW, innerH, frameD]} />
+              <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
+            </mesh>
+          </group>
         );
       })}
     </group>

--- a/src/types/cad.ts
+++ b/src/types/cad.ts
@@ -47,6 +47,8 @@ export interface WallArt {
   height: number;
   /** Image data URL. */
   imageUrl: string;
+  /** Frame style (Phase 15). Missing = no frame (flat plane, legacy). */
+  frameStyle?: import("./framedArt").FrameStyle;
 }
 
 export interface Opening {

--- a/src/types/framedArt.ts
+++ b/src/types/framedArt.ts
@@ -1,0 +1,42 @@
+export type FrameStyle =
+  | "none"
+  | "thin-black"
+  | "thick-gold"
+  | "natural-wood"
+  | "museum-white"
+  | "floating"
+  | "ornate";
+
+export interface FramedArtItem {
+  id: string; // "fart_..."
+  name: string;
+  imageUrl: string; // data URL
+  frameStyle: FrameStyle;
+}
+
+export interface FramePreset {
+  width: number; // ft
+  depth: number; // ft (protrusion from wall face)
+  color: string; // hex
+  label: string;
+}
+
+export const FRAME_PRESETS: Record<FrameStyle, FramePreset> = {
+  none: { width: 0, depth: 0, color: "#000000", label: "NO_FRAME" },
+  "thin-black": { width: 0.08, depth: 0.03, color: "#0d0d0d", label: "THIN_BLACK" },
+  "thick-gold": { width: 0.25, depth: 0.08, color: "#b8912d", label: "THICK_GOLD" },
+  "natural-wood": { width: 0.15, depth: 0.06, color: "#8b6b4a", label: "NATURAL_WOOD" },
+  "museum-white": { width: 0.2, depth: 0.1, color: "#f4f2ee", label: "MUSEUM_WHITE" },
+  floating: { width: 0.05, depth: 0.15, color: "#1a1a1a", label: "FLOATING" },
+  ornate: { width: 0.35, depth: 0.12, color: "#c9a04f", label: "ORNATE_GOLD" },
+};
+
+export const FRAME_STYLES: FrameStyle[] = [
+  "none",
+  "thin-black",
+  "thick-gold",
+  "natural-wood",
+  "museum-white",
+  "floating",
+  "ornate",
+];


### PR DESCRIPTION
## Summary
- Global framed art library (IndexedDB, like products) — upload image, pick frame style, save, reuse across projects
- 7 frame presets: none, thin-black, thick-gold, natural-wood, museum-white, floating, ornate
- Real 3D frame geometry (4 protruding box strips + inset art plane) — no more flat decals
- \`+ LIB\` button in WallSurfacePanel drops a library item onto the selected wall with its frameStyle

## What to test
- [ ] ART_LIBRARY section appears in sidebar (below CUSTOM_ELEMENTS)
- [ ] Upload image + name + pick frame → SAVE_TO_LIBRARY adds card
- [ ] Card shows thumbnail with scaled frame border in preset color
- [ ] Library persists after page refresh
- [ ] Delete button removes from library
- [ ] Select a wall, click + LIB, pick a library item → art appears on wall
- [ ] 3D view shows frame protruding from wall with correct color/depth per preset
- [ ] All 7 presets render distinctly in 3D
- [ ] Legacy wall art (no frameStyle) still renders as flat plane — no regression
- [ ] Same library item placed on multiple walls works independently

## Deferred
- Dims editor on placed art (stock 2'×2.5' drop)
- Per-placement frame color override
- Position editor UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)