### PR TITLE
Phase 17 — Per-Side Wall Treatments (SIDE-01/02/03)

### DIFF
--- a/.planning/phases/17-per-side-wall-treatments/17-PLAN.md
+++ b/.planning/phases/17-per-side-wall-treatments/17-PLAN.md
@@ -1,0 +1,74 @@
+---
+phase: 17-per-side-wall-treatments
+plan: 01
+subsystem: wall-surfaces
+tags: [side-01, side-02, side-03]
+requires: [cadStore, WallMesh, WallSurfacePanel, uiStore, snapshotMigration]
+provides: [WallSide type, side-aware wall treatments, SIDE toggle UI, dual-face 3D rendering]
+affects:
+  - src/types/cad.ts
+  - src/stores/cadStore.ts
+  - src/stores/uiStore.ts
+  - src/lib/snapshotMigration.ts
+  - src/components/WallSurfacePanel.tsx
+  - src/three/WallMesh.tsx
+decisions:
+  - "Each treatment wraps its config in { A?, B? } (Option A from discussion). Min schema churn, clean back-compat via migration."
+  - "SIDE_A / SIDE_B neutral labels (not INSIDE/OUTSIDE) — works for divider walls between rooms."
+  - "Wainscoting + crown + wallpaper are all per-side independently."
+  - "WallArt items tagged with side field (defaults to 'A' if missing)."
+  - "activeWallSide lives in uiStore — persists until explicit toggle, not per-wall selection."
+  - "3D: side B wrapped in a group rotated 180° around Y — same decor code runs for both faces with natural X/Z flip."
+  - "Base wall mesh gets neutral drywall color; wallpaper moves to per-face overlay planes (fixes bleed-to-all-faces bug)."
+  - "Migration detects legacy singleton shape (presence of .kind/.enabled) and wraps in { A: <legacy> }."
+metrics:
+  requirements_closed: [SIDE-01, SIDE-02, SIDE-03]
+---
+
+# Phase 17 Plan: Per-Side Wall Treatments
+
+## Goal
+
+Every wall treatment (wallpaper, wainscoting, crown molding, wall art) becomes side-aware. User picks SIDE_A or SIDE_B and applies independently. Divider walls between rooms can have totally different treatments on each face.
+
+## Tasks
+
+- [x] Add `WallSide` type + named `WainscotConfig` / `CrownConfig` interfaces
+- [x] Wrap `wallpaper`, `wainscoting`, `crownMolding` on WallSegment in `{ A?, B? }` shape
+- [x] Add `side?: WallSide` field to WallArt
+- [x] Migration in snapshotMigration.ts: detect legacy singleton shape + wrap in `{ A: <old> }`
+- [x] Add `activeWallSide` + `setActiveWallSide` to uiStore
+- [x] Update 3 store actions to take `side: WallSide` param: setWallpaper, toggleWainscoting, toggleCrownMolding
+- [x] WallSurfacePanel: SIDE_A / SIDE_B toggle, all reads/writes route through activeSide
+- [x] WallMesh.tsx: neutral base wall + per-face wallpaper overlays + both-sides decor rendering
+
+## Data Model
+
+```ts
+type WallSide = "A" | "B";
+
+interface WallSegment {
+  // BEFORE: wallpaper?: Wallpaper
+  wallpaper?: { A?: Wallpaper; B?: Wallpaper };
+
+  // BEFORE: wainscoting?: { enabled, heightFt, color }
+  wainscoting?: { A?: WainscotConfig; B?: WainscotConfig };
+
+  // BEFORE: crownMolding?: { enabled, heightFt, color }
+  crownMolding?: { A?: CrownConfig; B?: CrownConfig };
+
+  // WallArt array unchanged; items gain side field
+  wallArt?: WallArt[];  // each: side?: WallSide (defaults to "A")
+}
+```
+
+## Verification
+
+- [x] SIDE_A / SIDE_B toggle appears in WallSurfacePanel when wall selected
+- [x] Wallpaper applies to chosen side only — 3D shows the other face as plain drywall
+- [x] Wainscoting + crown molding render independently per side
+- [x] Wall art items tagged with correct side; art panel shows only items for active side
+- [x] Legacy snapshots auto-migrate (wrap singleton treatments in `{ A: ... }`)
+- [x] Undo/redo preserves per-side state correctly
+- [x] Save/load roundtrips per-side treatments
+- [x] Build clean, no typecheck errors

--- a/.planning/phases/17-per-side-wall-treatments/17-SUMMARY.md
+++ b/.planning/phases/17-per-side-wall-treatments/17-SUMMARY.md
@@ -1,0 +1,73 @@
+---
+phase: 17-per-side-wall-treatments
+plan: 01
+subsystem: wall-surfaces
+tags: [side-01, side-02, side-03]
+requirements_closed: [SIDE-01, SIDE-02, SIDE-03]
+affects:
+  - src/types/cad.ts
+  - src/stores/cadStore.ts
+  - src/stores/uiStore.ts
+  - src/lib/snapshotMigration.ts
+  - src/components/WallSurfacePanel.tsx
+  - src/three/WallMesh.tsx
+metrics:
+  completed: 2026-04-05
+  duration: ~25m
+---
+
+# Phase 17 Summary
+
+Closes SIDE-01/02/03 — every wall treatment is now per-side.
+
+## What shipped
+
+**Data model:** Each of wallpaper, wainscoting, crownMolding wraps
+its config in `{ A?, B? }`. WallArt items get a `side?: WallSide`
+field (defaults to "A" when missing). Snapshot migration auto-wraps
+legacy singleton shapes on load so existing projects survive.
+
+**uiStore:** `activeWallSide: "A" | "B"` with `setActiveWallSide`.
+Persists across wall selections (so if you toggle to SIDE_B you
+stay on B when selecting another wall).
+
+**WallSurfacePanel UI:** SIDE_A / SIDE_B toggle at the top. Every
+control below — wallpaper, wainscoting, crown, art add, art list —
+reads and writes the active side. Art list only shows items tagged
+with active side. + LIB and + ADD tag new art with active side.
+
+**3D rendering (WallMesh.tsx):** Neutral drywall base wall (no
+wallpaper bleeding across all 6 faces anymore). Wallpaper becomes
+a per-face overlay plane. Wainscoting + crown + art decor extracted
+into a `renderSideDecor()` helper called twice — once for side A,
+once inside a `<group rotation={[0, Math.PI, 0]}>` that flips the
+entire decor onto the -Z face for side B. Same code, two faces.
+
+## Migration
+
+```ts
+// Legacy: wall.wallpaper = { kind: "pattern", imageUrl, scaleFt }
+// After:  wall.wallpaper = { A: { kind: "pattern", imageUrl, scaleFt } }
+```
+
+Detection uses a presence check on the legacy shape's key fields
+(`.kind` for Wallpaper, `.enabled` for trim) — if present, wrap in
+`{ A: <legacy> }`. Runs in `migrateSnapshot` every load.
+
+## Gotchas resolved
+
+- **Wallpaper bleed:** ExtrudeGeometry wrapped the wallpaper texture
+  onto all 6 faces of the wall (top/bottom/edges included). Moving
+  wallpaper to overlay planes fixes this.
+- **Mirror X on side B:** the `rotation={[0, π, 0]}` group naturally
+  flips local X and Z, so an art item at offset=2 from wall.start
+  appears at the same "2ft from wall.start" position on both faces
+  (just viewed from opposite sides). Consistent mental model.
+
+## Deferred
+
+- **Per-side 2D icons:** FabricCanvas renders wall art on a single
+  face in 2D. A small "A/B" badge next to art items would help but
+  isn't blocking.
+- **Copy to other side:** no one-click "mirror SIDE_A to SIDE_B"
+  action yet — user re-enters trim height/color manually.

--- a/src/components/WallSurfacePanel.tsx
+++ b/src/components/WallSurfacePanel.tsx
@@ -9,6 +9,8 @@ import { FRAME_PRESETS } from "@/types/framedArt";
 export default function WallSurfacePanel() {
   const selectedIds = useUIStore((s) => s.selectedIds);
   const walls = useActiveWalls();
+  const activeSide = useUIStore((s) => s.activeWallSide);
+  const setActiveSide = useUIStore((s) => s.setActiveWallSide);
   const setWallpaper = useCADStore((s) => s.setWallpaper);
   const toggleWainscoting = useCADStore((s) => s.toggleWainscoting);
   const toggleCrownMolding = useCADStore((s) => s.toggleCrownMolding);
@@ -23,13 +25,13 @@ export default function WallSurfacePanel() {
   const wall = walls[selectedIds[0]];
   if (!wall) return null;
 
-  const wp = wall.wallpaper;
-  const wains = wall.wainscoting;
-  const crown = wall.crownMolding;
-  const artItems = wall.wallArt ?? [];
+  const wp = wall.wallpaper?.[activeSide];
+  const wains = wall.wainscoting?.[activeSide];
+  const crown = wall.crownMolding?.[activeSide];
+  const artItems = (wall.wallArt ?? []).filter((a) => (a.side ?? "A") === activeSide);
 
   const handleWallpaperColor = (color: string) => {
-    setWallpaper(wall.id, { kind: "color", color });
+    setWallpaper(wall.id, activeSide, { kind: "color", color });
   };
 
   const handleWallpaperImage = (file: File) => {
@@ -42,7 +44,7 @@ export default function WallSurfacePanel() {
         imageUrl: reader.result as string,
         scaleFt: 0,
       };
-      setWallpaper(wall.id, material);
+      setWallpaper(wall.id, activeSide, material);
     };
     reader.readAsDataURL(file);
   };
@@ -50,7 +52,7 @@ export default function WallSurfacePanel() {
   const toggleTile = () => {
     if (!wp || wp.kind !== "pattern") return;
     const newScale = (wp.scaleFt ?? 0) > 0 ? 0 : 2;
-    setWallpaper(wall.id, { ...wp, scaleFt: newScale });
+    setWallpaper(wall.id, activeSide, { ...wp, scaleFt: newScale });
   };
 
   const handleAddArt = (file: File) => {
@@ -63,6 +65,7 @@ export default function WallSurfacePanel() {
         width: 2,
         height: 2.5,
         imageUrl: reader.result as string,
+        side: activeSide,
       });
     };
     reader.readAsDataURL(file);
@@ -78,6 +81,7 @@ export default function WallSurfacePanel() {
       height: 2.5,
       imageUrl: item.imageUrl,
       frameStyle: item.frameStyle,
+      side: activeSide,
     });
     setShowLibrary(false);
   };
@@ -87,6 +91,23 @@ export default function WallSurfacePanel() {
       <h3 className="font-mono text-[10px] text-accent-light tracking-widest uppercase">
         WALL_SURFACE
       </h3>
+
+      {/* Side toggle (Phase 17) */}
+      <div className="flex gap-1">
+        {(["A", "B"] as const).map((s) => (
+          <button
+            key={s}
+            onClick={() => setActiveSide(s)}
+            className={`flex-1 font-mono text-[9px] tracking-widest py-1 rounded-sm border ${
+              activeSide === s
+                ? "border-accent text-accent-light bg-accent/10"
+                : "border-outline-variant/30 text-text-dim"
+            }`}
+          >
+            SIDE_{s}
+          </button>
+        ))}
+      </div>
 
       {/* Wallpaper */}
       <div>
@@ -106,7 +127,7 @@ export default function WallSurfacePanel() {
           </button>
           {wp && (
             <button
-              onClick={() => setWallpaper(wall.id, undefined)}
+              onClick={() => setWallpaper(wall.id, activeSide, undefined)}
               className="font-mono text-[9px] text-text-ghost hover:text-text-primary px-2 py-1"
               title="Remove wallpaper"
             >
@@ -146,7 +167,9 @@ export default function WallSurfacePanel() {
           <input
             type="checkbox"
             checked={wains?.enabled ?? false}
-            onChange={(e) => toggleWainscoting(wall.id, e.target.checked, wains?.heightFt, wains?.color)}
+            onChange={(e) =>
+              toggleWainscoting(wall.id, activeSide, e.target.checked, wains?.heightFt, wains?.color)
+            }
             className="w-3 h-3 accent-accent rounded-none"
           />
           <span className="font-mono text-[9px] text-text-dim tracking-wider">WAINSCOTING</span>
@@ -160,7 +183,7 @@ export default function WallSurfacePanel() {
               max="6"
               value={wains.heightFt}
               onChange={(e) =>
-                toggleWainscoting(wall.id, true, parseFloat(e.target.value) || 3, wains.color)
+                toggleWainscoting(wall.id, activeSide, true, parseFloat(e.target.value) || 3, wains.color)
               }
               className="w-16 font-mono text-[9px] bg-obsidian-high text-accent-light border border-outline-variant/30 px-1 py-0.5 rounded-sm"
             />
@@ -168,7 +191,9 @@ export default function WallSurfacePanel() {
             <input
               type="color"
               value={wains.color}
-              onChange={(e) => toggleWainscoting(wall.id, true, wains.heightFt, e.target.value)}
+              onChange={(e) =>
+                toggleWainscoting(wall.id, activeSide, true, wains.heightFt, e.target.value)
+              }
               className="w-6 h-5 bg-transparent border border-outline-variant/30 rounded-sm cursor-pointer"
             />
           </div>
@@ -182,7 +207,7 @@ export default function WallSurfacePanel() {
             type="checkbox"
             checked={crown?.enabled ?? false}
             onChange={(e) =>
-              toggleCrownMolding(wall.id, e.target.checked, crown?.heightFt, crown?.color)
+              toggleCrownMolding(wall.id, activeSide, e.target.checked, crown?.heightFt, crown?.color)
             }
             className="w-3 h-3 accent-accent rounded-none"
           />
@@ -197,7 +222,7 @@ export default function WallSurfacePanel() {
               max="1"
               value={crown.heightFt}
               onChange={(e) =>
-                toggleCrownMolding(wall.id, true, parseFloat(e.target.value) || 0.33, crown.color)
+                toggleCrownMolding(wall.id, activeSide, true, parseFloat(e.target.value) || 0.33, crown.color)
               }
               className="w-16 font-mono text-[9px] bg-obsidian-high text-accent-light border border-outline-variant/30 px-1 py-0.5 rounded-sm"
             />
@@ -205,7 +230,9 @@ export default function WallSurfacePanel() {
             <input
               type="color"
               value={crown.color}
-              onChange={(e) => toggleCrownMolding(wall.id, true, crown.heightFt, e.target.value)}
+              onChange={(e) =>
+                toggleCrownMolding(wall.id, activeSide, true, crown.heightFt, e.target.value)
+              }
               className="w-6 h-5 bg-transparent border border-outline-variant/30 rounded-sm cursor-pointer"
             />
           </div>
@@ -215,7 +242,9 @@ export default function WallSurfacePanel() {
       {/* Wall art */}
       <div>
         <div className="flex items-center justify-between mb-1">
-          <span className="font-mono text-[9px] text-text-dim tracking-wider">WALL_ART ({artItems.length})</span>
+          <span className="font-mono text-[9px] text-text-dim tracking-wider">
+            WALL_ART ({artItems.length})
+          </span>
           <div className="flex items-center gap-2">
             <button
               onClick={() => setShowLibrary((v) => !v)}

--- a/src/lib/snapshotMigration.ts
+++ b/src/lib/snapshotMigration.ts
@@ -15,6 +15,35 @@ export function defaultSnapshot(): CADSnapshot {
   };
 }
 
+/** Phase 17: wrap legacy singleton treatments in { A, B } shape. Mutates in place. */
+function migrateWallsPerSide(rooms: Record<string, RoomDoc> | undefined): void {
+  if (!rooms) return;
+  for (const doc of Object.values(rooms)) {
+    if (!doc?.walls) continue;
+    for (const wall of Object.values(doc.walls)) {
+      const w = wall as any;
+      // Wallpaper: detect legacy singleton (has .kind)
+      if (w.wallpaper && typeof w.wallpaper === "object" && "kind" in w.wallpaper) {
+        w.wallpaper = { A: w.wallpaper };
+      }
+      // Wainscoting: detect legacy (has .enabled)
+      if (w.wainscoting && typeof w.wainscoting === "object" && "enabled" in w.wainscoting) {
+        w.wainscoting = { A: w.wainscoting };
+      }
+      // Crown: same pattern
+      if (w.crownMolding && typeof w.crownMolding === "object" && "enabled" in w.crownMolding) {
+        w.crownMolding = { A: w.crownMolding };
+      }
+      // WallArt items: default missing side to "A"
+      if (Array.isArray(w.wallArt)) {
+        for (const art of w.wallArt) {
+          if (!art.side) art.side = "A";
+        }
+      }
+    }
+  }
+}
+
 export function migrateSnapshot(raw: unknown): CADSnapshot {
   // v2 passthrough
   if (
@@ -23,7 +52,9 @@ export function migrateSnapshot(raw: unknown): CADSnapshot {
     (raw as CADSnapshot).version === 2 &&
     (raw as CADSnapshot).rooms
   ) {
-    return raw as CADSnapshot;
+    const snap = raw as CADSnapshot;
+    migrateWallsPerSide(snap.rooms);
+    return snap;
   }
   // v1 legacy shape
   if (
@@ -40,9 +71,11 @@ export function migrateSnapshot(raw: unknown): CADSnapshot {
       walls: legacy.walls ?? {},
       placedProducts: legacy.placedProducts ?? {},
     };
+    const rooms = { room_main: mainRoom };
+    migrateWallsPerSide(rooms);
     return {
       version: 2,
-      rooms: { room_main: mainRoom },
+      rooms,
       activeRoomId: "room_main",
     };
   }

--- a/src/stores/cadStore.ts
+++ b/src/stores/cadStore.ts
@@ -12,6 +12,7 @@ import type {
   FloorMaterial,
   Wallpaper,
   WallArt,
+  WallSide,
   CustomElement,
   PlacedCustomElement,
 } from "@/types/cad";
@@ -51,9 +52,9 @@ interface CADState {
   updateCeiling: (id: string, changes: Partial<Ceiling>) => void;
   removeCeiling: (id: string) => void;
   setFloorMaterial: (material: FloorMaterial | undefined) => void;
-  setWallpaper: (wallId: string, wallpaper: Wallpaper | undefined) => void;
-  toggleWainscoting: (wallId: string, enabled: boolean, heightFt?: number, color?: string) => void;
-  toggleCrownMolding: (wallId: string, enabled: boolean, heightFt?: number, color?: string) => void;
+  setWallpaper: (wallId: string, side: WallSide, wallpaper: Wallpaper | undefined) => void;
+  toggleWainscoting: (wallId: string, side: WallSide, enabled: boolean, heightFt?: number, color?: string) => void;
+  toggleCrownMolding: (wallId: string, side: WallSide, enabled: boolean, heightFt?: number, color?: string) => void;
   addWallArt: (wallId: string, art: Omit<WallArt, "id">) => string;
   updateWallArt: (wallId: string, artId: string, changes: Partial<WallArt>) => void;
   removeWallArt: (wallId: string, artId: string) => void;
@@ -406,42 +407,52 @@ export const useCADStore = create<CADState>()((set) => ({
       })
     ),
 
-  setWallpaper: (wallId, wallpaper) =>
+  setWallpaper: (wallId, side, wallpaper) =>
     set(
       produce((s: CADState) => {
         const doc = activeDoc(s);
         if (!doc || !doc.walls[wallId]) return;
         pushHistory(s);
-        if (wallpaper) doc.walls[wallId].wallpaper = wallpaper;
-        else delete doc.walls[wallId].wallpaper;
+        const wall = doc.walls[wallId];
+        if (!wall.wallpaper) wall.wallpaper = {};
+        if (wallpaper) wall.wallpaper[side] = wallpaper;
+        else delete wall.wallpaper[side];
+        // Clean up if both sides empty
+        if (!wall.wallpaper.A && !wall.wallpaper.B) delete wall.wallpaper;
       })
     ),
 
-  toggleWainscoting: (wallId, enabled, heightFt = 3, color = "#ffffff") =>
+  toggleWainscoting: (wallId, side, enabled, heightFt = 3, color = "#ffffff") =>
     set(
       produce((s: CADState) => {
         const doc = activeDoc(s);
         if (!doc || !doc.walls[wallId]) return;
         pushHistory(s);
+        const wall = doc.walls[wallId];
+        if (!wall.wainscoting) wall.wainscoting = {};
         if (enabled) {
-          doc.walls[wallId].wainscoting = { enabled: true, heightFt, color };
+          wall.wainscoting[side] = { enabled: true, heightFt, color };
         } else {
-          delete doc.walls[wallId].wainscoting;
+          delete wall.wainscoting[side];
         }
+        if (!wall.wainscoting.A && !wall.wainscoting.B) delete wall.wainscoting;
       })
     ),
 
-  toggleCrownMolding: (wallId, enabled, heightFt = 0.33, color = "#ffffff") =>
+  toggleCrownMolding: (wallId, side, enabled, heightFt = 0.33, color = "#ffffff") =>
     set(
       produce((s: CADState) => {
         const doc = activeDoc(s);
         if (!doc || !doc.walls[wallId]) return;
         pushHistory(s);
+        const wall = doc.walls[wallId];
+        if (!wall.crownMolding) wall.crownMolding = {};
         if (enabled) {
-          doc.walls[wallId].crownMolding = { enabled: true, heightFt, color };
+          wall.crownMolding[side] = { enabled: true, heightFt, color };
         } else {
-          delete doc.walls[wallId].crownMolding;
+          delete wall.crownMolding[side];
         }
+        if (!wall.crownMolding.A && !wall.crownMolding.B) delete wall.crownMolding;
       })
     ),
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { ToolType } from "@/types/cad";
+import type { ToolType, WallSide } from "@/types/cad";
 
 export type HelpSectionId =
   | "getting-started"
@@ -19,6 +19,7 @@ interface UIState {
   activeHelpSection: HelpSectionId;
   userZoom: number; // 1.0 = auto-fit, 2.0 = 2x, etc.
   panOffset: { x: number; y: number }; // pixel offset applied on top of auto-fit origin
+  activeWallSide: WallSide; // which face of the selected wall is being edited (Phase 17)
 
   setTool: (tool: ToolType) => void;
   select: (ids: string[]) => void;
@@ -38,6 +39,7 @@ interface UIState {
   setPanOffset: (offset: { x: number; y: number }) => void;
   zoomAt: (cursor: { x: number; y: number }, factor: number, baseFit: { scale: number; origin: { x: number; y: number } }) => void;
   resetView: () => void;
+  setActiveWallSide: (side: WallSide) => void;
 }
 
 const MIN_ZOOM = 0.25;
@@ -55,6 +57,7 @@ export const useUIStore = create<UIState>()((set) => ({
   activeHelpSection: "getting-started",
   userZoom: 1,
   panOffset: { x: 0, y: 0 },
+  activeWallSide: "A",
 
   setTool: (tool) => set({ activeTool: tool, selectedIds: [] }),
   select: (ids) => set({ selectedIds: ids }),
@@ -117,4 +120,5 @@ export const useUIStore = create<UIState>()((set) => ({
       };
     }),
   resetView: () => set({ userZoom: 1, panOffset: { x: 0, y: 0 } }),
+  setActiveWallSide: (side) => set({ activeWallSide: side }),
 }));

--- a/src/three/WallMesh.tsx
+++ b/src/three/WallMesh.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import * as THREE from "three";
-import type { WallSegment } from "@/types/cad";
+import type { WallSegment, Wallpaper, WainscotConfig, CrownConfig, WallArt } from "@/types/cad";
 import { wallLength, angle } from "@/lib/geometry";
 import { FRAME_PRESETS } from "@/types/framedArt";
 
@@ -10,7 +10,6 @@ interface Props {
 }
 
 // Separate caches for wall art (clamped, stretched) vs wallpaper (tiling).
-// Sharing one cache caused repeat-settings leak between the two uses.
 const wallArtTextureCache = new Map<string, THREE.Texture>();
 function getWallArtTexture(dataUrl: string): THREE.Texture {
   let tex = wallArtTextureCache.get(dataUrl);
@@ -33,47 +32,6 @@ function getWallpaperTexture(dataUrl: string): THREE.Texture {
     tex = loader.load(dataUrl);
     wallpaperTextureCache.set(dataUrl, tex);
   }
-  return tex;
-}
-
-// Procedural wainscoting texture — board-and-batten pattern.
-const wainscotTextureCache = new Map<string, THREE.CanvasTexture>();
-function getWainscotingTexture(color: string): THREE.CanvasTexture {
-  const key = color;
-  const cached = wainscotTextureCache.get(key);
-  if (cached) return cached;
-  const PX = 256;
-  const canvas = document.createElement("canvas");
-  canvas.width = PX;
-  canvas.height = PX;
-  const ctx = canvas.getContext("2d")!;
-  // Base fill
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, PX, PX);
-  // Shadow lines: top + bottom rails + left/right stiles
-  const rail = 6;
-  ctx.fillStyle = "rgba(0,0,0,0.25)";
-  ctx.fillRect(0, 0, PX, rail); // top rail
-  ctx.fillRect(0, PX - rail, PX, rail); // bottom rail
-  ctx.fillRect(0, 0, rail, PX); // left stile
-  ctx.fillRect(PX - rail, 0, rail, PX); // right stile
-  // Inset panel shadow
-  const inset = 24;
-  ctx.strokeStyle = "rgba(0,0,0,0.15)";
-  ctx.lineWidth = 2;
-  ctx.strokeRect(inset, inset, PX - inset * 2, PX - inset * 2);
-  // Highlight inset panel top/left (raised-panel illusion)
-  ctx.strokeStyle = "rgba(255,255,255,0.4)";
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.moveTo(inset + 2, PX - inset - 2);
-  ctx.lineTo(inset + 2, inset + 2);
-  ctx.lineTo(PX - inset - 2, inset + 2);
-  ctx.stroke();
-  const tex = new THREE.CanvasTexture(canvas);
-  tex.wrapS = THREE.RepeatWrapping;
-  tex.wrapT = THREE.ClampToEdgeWrapping;
-  wainscotTextureCache.set(key, tex);
   return tex;
 }
 
@@ -123,229 +81,257 @@ export default function WallMesh({ wall, isSelected }: Props) {
     return geo;
   }, [length, height, thickness, halfLen, halfH, wall.openings]);
 
-  // Wallpaper → base material color or pattern texture
-  const baseColor = isSelected ? "#93c5fd" : wall.wallpaper?.color ?? "#f8f5ef";
-  const wallpaperTexture =
-    wall.wallpaper?.kind === "pattern" && wall.wallpaper.imageUrl
-      ? getWallpaperTexture(wall.wallpaper.imageUrl)
-      : null;
-  if (wallpaperTexture) {
-    // scaleFt > 0 = tile; undefined/0 = stretch across whole wall
-    const s = wall.wallpaper?.scaleFt ?? 0;
-    if (s > 0) {
-      wallpaperTexture.wrapS = THREE.RepeatWrapping;
-      wallpaperTexture.wrapT = THREE.RepeatWrapping;
-      wallpaperTexture.repeat.set(length / s, height / s);
-    } else {
-      wallpaperTexture.wrapS = THREE.ClampToEdgeWrapping;
-      wallpaperTexture.wrapT = THREE.ClampToEdgeWrapping;
-      wallpaperTexture.repeat.set(1, 1);
-    }
-    wallpaperTexture.needsUpdate = true;
-  }
+  const baseColor = isSelected ? "#93c5fd" : "#f8f5ef"; // neutral drywall
+  const bandOffset = 0.01;
 
-  // Wainscoting band (bottom of wall)
-  const wainscotHeight = wall.wainscoting?.enabled ? wall.wainscoting.heightFt : 0;
-  // Crown molding band (top of wall)
-  const crownHeight = wall.crownMolding?.enabled ? wall.crownMolding.heightFt : 0;
-  const bandOffset = 0.01; // small offset to avoid z-fighting
+  // Build a wallpaper overlay plane for one face (null if no wallpaper on that side)
+  const renderWallpaperOverlay = (wp: Wallpaper | undefined, key: string) => {
+    if (!wp) return null;
+    let tex: THREE.Texture | null = null;
+    if (wp.kind === "pattern" && wp.imageUrl) {
+      tex = getWallpaperTexture(wp.imageUrl);
+      const s = wp.scaleFt ?? 0;
+      if (s > 0) {
+        tex.wrapS = THREE.RepeatWrapping;
+        tex.wrapT = THREE.RepeatWrapping;
+        tex.repeat.set(length / s, height / s);
+      } else {
+        tex.wrapS = THREE.ClampToEdgeWrapping;
+        tex.wrapT = THREE.ClampToEdgeWrapping;
+        tex.repeat.set(1, 1);
+      }
+      tex.needsUpdate = true;
+    }
+    return (
+      <mesh key={key} position={[0, 0, thickness / 2 + bandOffset / 2]}>
+        <planeGeometry args={[length, height]} />
+        <meshStandardMaterial
+          color={wp.kind === "color" ? wp.color ?? "#f8f5ef" : "#ffffff"}
+          map={tex ?? undefined}
+          roughness={0.85}
+          metalness={0}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+    );
+  };
+
+  // Build decor (wainscoting + crown + art) for one face. All positions are in
+  // wall-local space with +Z = "this face". Side B wraps this in a group that
+  // rotates 180° around Y, naturally flipping X and Z to the back face.
+  const renderSideDecor = (
+    wains: WainscotConfig | undefined,
+    crown: CrownConfig | undefined,
+    artItems: WallArt[]
+  ) => {
+    const wainscotHeight = wains?.enabled ? wains.heightFt : 0;
+    const crownHeight = crown?.enabled ? crown.heightFt : 0;
+
+    return (
+      <>
+        {/* Wainscoting — 3D recessed panels */}
+        {wainscotHeight > 0 && (() => {
+          const color = wains!.color;
+          const frameColor = color;
+          const frameDepth = 0.18;
+          const backDepth = 0.05;
+          const stileWidth = 0.33;
+          const railHeight = 0.33;
+          const chairCapHeight = 0.17;
+          const chairCapDepth = 0.25;
+
+          const targetPanelWidth = Math.max(1.5, wainscotHeight * 0.9);
+          const interiorWidth = length - 2 * stileWidth;
+          const panelCount = Math.max(1, Math.round(interiorWidth / targetPanelWidth));
+          const actualPanelWidth =
+            (interiorWidth - (panelCount - 1) * stileWidth) / panelCount;
+
+          const mat = (
+            <meshStandardMaterial color={frameColor} roughness={0.65} metalness={0} />
+          );
+
+          const meshes: React.ReactNode[] = [];
+
+          meshes.push(
+            <mesh
+              key="back"
+              position={[0, -halfH + wainscotHeight / 2, thickness / 2 + backDepth / 2]}
+              castShadow
+              receiveShadow
+            >
+              <boxGeometry args={[length, wainscotHeight, backDepth]} />
+              <meshStandardMaterial color={color} roughness={0.7} metalness={0} />
+            </mesh>
+          );
+
+          const topRailY = -halfH + wainscotHeight - chairCapHeight - railHeight / 2;
+          meshes.push(
+            <mesh
+              key="top-rail"
+              position={[0, topRailY, thickness / 2 + frameDepth / 2]}
+              castShadow
+              receiveShadow
+            >
+              <boxGeometry args={[length, railHeight, frameDepth]} />
+              {mat}
+            </mesh>
+          );
+
+          const bottomRailY = -halfH + railHeight / 2;
+          meshes.push(
+            <mesh
+              key="bottom-rail"
+              position={[0, bottomRailY, thickness / 2 + frameDepth / 2]}
+              castShadow
+              receiveShadow
+            >
+              <boxGeometry args={[length, railHeight, frameDepth]} />
+              {mat}
+            </mesh>
+          );
+
+          const panelAreaHeight = wainscotHeight - chairCapHeight - 2 * railHeight;
+          const panelCenterY = -halfH + railHeight + panelAreaHeight / 2;
+          for (let i = 0; i <= panelCount; i++) {
+            const stileX =
+              -length / 2 + stileWidth / 2 + i * (actualPanelWidth + stileWidth);
+            meshes.push(
+              <mesh
+                key={`stile-${i}`}
+                position={[stileX, panelCenterY, thickness / 2 + frameDepth / 2]}
+                castShadow
+                receiveShadow
+              >
+                <boxGeometry args={[stileWidth, panelAreaHeight, frameDepth]} />
+                {mat}
+              </mesh>
+            );
+          }
+
+          meshes.push(
+            <mesh
+              key="chair-cap"
+              position={[
+                0,
+                -halfH + wainscotHeight - chairCapHeight / 2,
+                thickness / 2 + chairCapDepth / 2,
+              ]}
+              castShadow
+              receiveShadow
+            >
+              <boxGeometry args={[length, chairCapHeight, chairCapDepth]} />
+              {mat}
+            </mesh>
+          );
+
+          return <group>{meshes}</group>;
+        })()}
+
+        {/* Crown molding */}
+        {crownHeight > 0 && (
+          <mesh
+            position={[0, halfH - crownHeight / 2, thickness / 2 + 0.08]}
+            castShadow
+            receiveShadow
+          >
+            <boxGeometry args={[length, crownHeight, 0.15]} />
+            <meshStandardMaterial
+              color={crown!.color}
+              roughness={0.6}
+              metalness={0}
+            />
+          </mesh>
+        )}
+
+        {/* Wall art — framed or flat */}
+        {artItems.map((art) => {
+          const tex = getWallArtTexture(art.imageUrl);
+          const artX = art.offset - halfLen + art.width / 2;
+          const artY = art.centerY - halfH;
+          const preset = art.frameStyle ? FRAME_PRESETS[art.frameStyle] : null;
+          const frameW = preset?.width ?? 0;
+          const frameD = preset?.depth ?? 0;
+          const baseZ = thickness / 2 + bandOffset * 2;
+
+          if (!preset || art.frameStyle === "none" || frameW === 0) {
+            return (
+              <mesh key={art.id} position={[artX, artY, baseZ]}>
+                <planeGeometry args={[art.width, art.height]} />
+                <meshStandardMaterial
+                  map={tex}
+                  roughness={0.5}
+                  metalness={0}
+                  side={THREE.DoubleSide}
+                />
+              </mesh>
+            );
+          }
+
+          const innerW = Math.max(0.01, art.width - 2 * frameW);
+          const innerH = Math.max(0.01, art.height - 2 * frameW);
+          const artZ = baseZ + 0.002;
+          const frameCenterZ = baseZ + frameD / 2;
+
+          return (
+            <group key={art.id} position={[artX, artY, 0]}>
+              <mesh position={[0, 0, artZ]}>
+                <planeGeometry args={[innerW, innerH]} />
+                <meshStandardMaterial
+                  map={tex}
+                  roughness={0.5}
+                  metalness={0}
+                  side={THREE.DoubleSide}
+                />
+              </mesh>
+              <mesh position={[0, art.height / 2 - frameW / 2, frameCenterZ]} castShadow>
+                <boxGeometry args={[art.width, frameW, frameD]} />
+                <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
+              </mesh>
+              <mesh position={[0, -(art.height / 2 - frameW / 2), frameCenterZ]} castShadow>
+                <boxGeometry args={[art.width, frameW, frameD]} />
+                <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
+              </mesh>
+              <mesh position={[-(art.width / 2 - frameW / 2), 0, frameCenterZ]} castShadow>
+                <boxGeometry args={[frameW, innerH, frameD]} />
+                <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
+              </mesh>
+              <mesh position={[art.width / 2 - frameW / 2, 0, frameCenterZ]} castShadow>
+                <boxGeometry args={[frameW, innerH, frameD]} />
+                <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
+              </mesh>
+            </group>
+          );
+        })}
+      </>
+    );
+  };
+
+  const artA = (wall.wallArt ?? []).filter((a) => (a.side ?? "A") === "A");
+  const artB = (wall.wallArt ?? []).filter((a) => (a.side ?? "A") === "B");
 
   return (
     <group position={position} rotation={rotation}>
+      {/* Base wall — neutral drywall color */}
       <mesh geometry={geometry} castShadow receiveShadow>
         <meshStandardMaterial
           color={baseColor}
-          map={wallpaperTexture ?? undefined}
           roughness={0.85}
           metalness={0}
           side={THREE.DoubleSide}
         />
       </mesh>
 
-      {/* Wainscoting — 3D recessed panels with real frame geometry */}
-      {wainscotHeight > 0 && (() => {
-        const color = wall.wainscoting!.color;
-        const frameColor = color;
-        // Frame/stile/rail protrusion (stick out further — raised)
-        const frameDepth = 0.18; // ~2"
-        // Recessed backing panel (sits further back)
-        const backDepth = 0.05; // ~0.6" — the "recessed" floor of each panel
-        // Frame strip thickness
-        const stileWidth = 0.33; // ~4" wide stiles
-        const railHeight = 0.33; // ~4" tall top/bottom rails
-        const chairCapHeight = 0.17; // ~2" chair rail cap
-        const chairCapDepth = 0.25; // ~3" — sticks out the most
+      {/* Side A — positive Z face */}
+      <group>
+        {renderWallpaperOverlay(wall.wallpaper?.A, "wp-A")}
+        {renderSideDecor(wall.wainscoting?.A, wall.crownMolding?.A, artA)}
+      </group>
 
-        // Target panel width ~ wainscotHeight (squarish panels)
-        const targetPanelWidth = Math.max(1.5, wainscotHeight * 0.9);
-        const interiorWidth = length - 2 * stileWidth;
-        const panelCount = Math.max(1, Math.round(interiorWidth / targetPanelWidth));
-        const actualPanelWidth = (interiorWidth - (panelCount - 1) * stileWidth) / panelCount;
-
-        const mat = (
-          <meshStandardMaterial
-            color={frameColor}
-            roughness={0.65}
-            metalness={0}
-          />
-        );
-
-        const meshes: React.ReactNode[] = [];
-
-        // Recessed backing (full wainscoting area)
-        meshes.push(
-          <mesh
-            key="back"
-            position={[0, -halfH + wainscotHeight / 2, thickness / 2 + backDepth / 2]}
-            castShadow
-            receiveShadow
-          >
-            <boxGeometry args={[length, wainscotHeight, backDepth]} />
-            <meshStandardMaterial color={color} roughness={0.7} metalness={0} />
-          </mesh>
-        );
-
-        // Top rail (horizontal strip above panels)
-        const topRailY = -halfH + wainscotHeight - chairCapHeight - railHeight / 2;
-        meshes.push(
-          <mesh
-            key="top-rail"
-            position={[0, topRailY, thickness / 2 + frameDepth / 2]}
-            castShadow
-            receiveShadow
-          >
-            <boxGeometry args={[length, railHeight, frameDepth]} />
-            {mat}
-          </mesh>
-        );
-
-        // Bottom rail
-        const bottomRailY = -halfH + railHeight / 2;
-        meshes.push(
-          <mesh
-            key="bottom-rail"
-            position={[0, bottomRailY, thickness / 2 + frameDepth / 2]}
-            castShadow
-            receiveShadow
-          >
-            <boxGeometry args={[length, railHeight, frameDepth]} />
-            {mat}
-          </mesh>
-        );
-
-        // Vertical stiles (including edges)
-        const panelAreaHeight = wainscotHeight - chairCapHeight - 2 * railHeight;
-        const panelCenterY = -halfH + railHeight + panelAreaHeight / 2;
-        for (let i = 0; i <= panelCount; i++) {
-          const stileX = -length / 2 + stileWidth / 2 + i * (actualPanelWidth + stileWidth);
-          meshes.push(
-            <mesh
-              key={`stile-${i}`}
-              position={[stileX, panelCenterY, thickness / 2 + frameDepth / 2]}
-              castShadow
-              receiveShadow
-            >
-              <boxGeometry args={[stileWidth, panelAreaHeight, frameDepth]} />
-              {mat}
-            </mesh>
-          );
-        }
-
-        // Chair rail cap at very top — sticks out most
-        meshes.push(
-          <mesh
-            key="chair-cap"
-            position={[0, -halfH + wainscotHeight - chairCapHeight / 2, thickness / 2 + chairCapDepth / 2]}
-            castShadow
-            receiveShadow
-          >
-            <boxGeometry args={[length, chairCapHeight, chairCapDepth]} />
-            {mat}
-          </mesh>
-        );
-
-        return <group>{meshes}</group>;
-      })()}
-
-      {/* Crown molding — 3D extruded band at ceiling line */}
-      {crownHeight > 0 && (
-        <mesh
-          position={[0, halfH - crownHeight / 2, thickness / 2 + 0.08]}
-          castShadow
-          receiveShadow
-        >
-          <boxGeometry args={[length, crownHeight, 0.15]} />
-          <meshStandardMaterial
-            color={wall.crownMolding!.color}
-            roughness={0.6}
-            metalness={0}
-          />
-        </mesh>
-      )}
-
-      {/* Wall art items — framed or flat, on interior face */}
-      {(wall.wallArt ?? []).map((art) => {
-        const tex = getWallArtTexture(art.imageUrl);
-        const artX = art.offset - halfLen + art.width / 2;
-        const artY = art.centerY - halfH;
-        const preset = art.frameStyle ? FRAME_PRESETS[art.frameStyle] : null;
-        const frameW = preset?.width ?? 0;
-        const frameD = preset?.depth ?? 0;
-        const baseZ = thickness / 2 + bandOffset * 2;
-
-        // No frame (or frameStyle="none") → flat plane (legacy behavior)
-        if (!preset || art.frameStyle === "none" || frameW === 0) {
-          return (
-            <mesh key={art.id} position={[artX, artY, baseZ]}>
-              <planeGeometry args={[art.width, art.height]} />
-              <meshStandardMaterial map={tex} roughness={0.5} metalness={0} side={THREE.DoubleSide} />
-            </mesh>
-          );
-        }
-
-        // Framed: inset art plane + 4 frame strips protruding from wall
-        const innerW = Math.max(0.01, art.width - 2 * frameW);
-        const innerH = Math.max(0.01, art.height - 2 * frameW);
-        // Art plane sits at the BACK of the frame (so frame depth appears to recess it)
-        const artZ = baseZ + 0.002;
-        const frameCenterZ = baseZ + frameD / 2;
-
-        return (
-          <group key={art.id} position={[artX, artY, 0]}>
-            {/* Art plane (recessed inside frame) */}
-            <mesh position={[0, 0, artZ]}>
-              <planeGeometry args={[innerW, innerH]} />
-              <meshStandardMaterial
-                map={tex}
-                roughness={0.5}
-                metalness={0}
-                side={THREE.DoubleSide}
-              />
-            </mesh>
-
-            {/* Top frame strip */}
-            <mesh position={[0, art.height / 2 - frameW / 2, frameCenterZ]} castShadow>
-              <boxGeometry args={[art.width, frameW, frameD]} />
-              <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
-            </mesh>
-            {/* Bottom frame strip */}
-            <mesh position={[0, -(art.height / 2 - frameW / 2), frameCenterZ]} castShadow>
-              <boxGeometry args={[art.width, frameW, frameD]} />
-              <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
-            </mesh>
-            {/* Left frame strip */}
-            <mesh position={[-(art.width / 2 - frameW / 2), 0, frameCenterZ]} castShadow>
-              <boxGeometry args={[frameW, innerH, frameD]} />
-              <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
-            </mesh>
-            {/* Right frame strip */}
-            <mesh position={[art.width / 2 - frameW / 2, 0, frameCenterZ]} castShadow>
-              <boxGeometry args={[frameW, innerH, frameD]} />
-              <meshStandardMaterial color={preset.color} roughness={0.4} metalness={0.2} />
-            </mesh>
-          </group>
-        );
-      })}
+      {/* Side B — flip 180° around Y so decor lands on -Z face */}
+      <group rotation={[0, Math.PI, 0]}>
+        {renderWallpaperOverlay(wall.wallpaper?.B, "wp-B")}
+        {renderSideDecor(wall.wainscoting?.B, wall.crownMolding?.B, artB)}
+      </group>
     </group>
   );
 }

--- a/src/types/cad.ts
+++ b/src/types/cad.ts
@@ -3,6 +3,20 @@ export interface Point {
   y: number;
 }
 
+export type WallSide = "A" | "B";
+
+export interface WainscotConfig {
+  enabled: boolean;
+  heightFt: number; // default 3 (36")
+  color: string; // hex
+}
+
+export interface CrownConfig {
+  enabled: boolean;
+  heightFt: number; // band height, default 0.33 (4")
+  color: string;
+}
+
 export interface WallSegment {
   id: string;
   start: Point;
@@ -10,21 +24,13 @@ export interface WallSegment {
   thickness: number; // feet, default 0.5
   height: number; // feet, default 8
   openings: Opening[];
-  /** Wallpaper applied to this wall (solid color or pattern image). */
-  wallpaper?: Wallpaper;
-  /** Wainscoting panel toggle. Defaults to off. */
-  wainscoting?: {
-    enabled: boolean;
-    heightFt: number; // default 3 (36")
-    color: string; // hex
-  };
-  /** Crown molding toggle. Defaults to off. */
-  crownMolding?: {
-    enabled: boolean;
-    heightFt: number; // band height, default 0.33 (4")
-    color: string;
-  };
-  /** Wall art items placed on this wall's interior face. */
+  /** Wallpaper per side (Phase 17). */
+  wallpaper?: { A?: Wallpaper; B?: Wallpaper };
+  /** Wainscoting per side (Phase 17). */
+  wainscoting?: { A?: WainscotConfig; B?: WainscotConfig };
+  /** Crown molding per side (Phase 17). */
+  crownMolding?: { A?: CrownConfig; B?: CrownConfig };
+  /** Wall art items. Each item has a side (defaults to "A"). */
   wallArt?: WallArt[];
 }
 
@@ -49,6 +55,8 @@ export interface WallArt {
   imageUrl: string;
   /** Frame style (Phase 15). Missing = no frame (flat plane, legacy). */
   frameStyle?: import("./framedArt").FrameStyle;
+  /** Which face of the wall the art hangs on (Phase 17). Defaults to "A". */
+  side?: WallSide;
 }
 
 export interface Opening {


### PR DESCRIPTION
## Summary
- Every wall treatment (wallpaper, wainscoting, crown, wall art) becomes per-side (SIDE_A / SIDE_B)
- SIDE toggle at top of WallSurfacePanel — all controls route through active side
- WallMesh renders both faces independently with correct geometry (180° Y rotation for side B)
- Fixes wallpaper-bleeds-everywhere bug by moving wallpaper to per-face overlay planes
- Migration: legacy singleton treatments auto-wrap in \`{ A: <old> }\` on load

## Data model change
\`\`\`ts
// Before
wall.wallpaper: Wallpaper | undefined
wall.wainscoting: { enabled, heightFt, color } | undefined
wall.crownMolding: { enabled, heightFt, color } | undefined

// After
wall.wallpaper: { A?: Wallpaper; B?: Wallpaper } | undefined
wall.wainscoting: { A?: WainscotConfig; B?: WainscotConfig } | undefined
wall.crownMolding: { A?: CrownConfig; B?: CrownConfig } | undefined

// WallArt adds side?: "A" | "B"
\`\`\`

## What to test
- [ ] SIDE_A / SIDE_B toggle appears at top of wall surface panel
- [ ] Set wallpaper on SIDE_A only → 3D shows opposite face as plain drywall
- [ ] Set different wallpaper on each side → both render correctly on correct faces
- [ ] Wainscoting enabled on SIDE_A only → protrudes on +Z face only
- [ ] Set different wainscoting heights on each side → renders independently
- [ ] Wall art added on SIDE_B shows on -Z face, facing outward
- [ ] Art list filters to only the active side's items
- [ ] Load a pre-Phase-17 project → legacy wallpaper/trim migrate to side A, other side blank
- [ ] Undo/redo per-side changes works cleanly
- [ ] Wallpaper no longer bleeds onto top/bottom edges of wall (regression check)

## Deferred
- 2D-canvas side badges on art items
- "Copy SIDE_A → SIDE_B" one-click action

🤖 Generated with [Claude Code](https://claude.com/claude-code)