### PR TITLE
fix(14): persist customElements catalog (closes CUSTOM-05)

### DIFF
--- a/src/components/ProjectManager.tsx
+++ b/src/components/ProjectManager.tsx
@@ -29,8 +29,13 @@ export default function ProjectManager() {
   async function handleSave() {
     setSaving(true);
     const id = currentId ?? `proj_${uid()}`;
-    const { rooms, activeRoomId } = useCADStore.getState();
-    await saveProject(id, projectName, { version: 2, rooms, activeRoomId });
+    const st = useCADStore.getState() as any;
+    await saveProject(id, projectName, {
+      version: 2,
+      rooms: st.rooms,
+      activeRoomId: st.activeRoomId,
+      ...(st.customElements ? { customElements: st.customElements } : {}),
+    });
     setActive(id, projectName);
     const updated = await listProjects();
     setProjects(updated);

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -14,9 +14,12 @@ export function useAutoSave(): void {
 
     const unsub = useCADStore.subscribe((state, prevState) => {
       // Only trigger on data changes, not past/future mutations
+      const prevCustom = (prevState as any).customElements;
+      const nextCustom = (state as any).customElements;
       if (
         state.rooms === prevState.rooms &&
-        state.activeRoomId === prevState.activeRoomId
+        state.activeRoomId === prevState.activeRoomId &&
+        prevCustom === nextCustom
       ) {
         return;
       }
@@ -32,8 +35,13 @@ export function useAutoSave(): void {
           useProjectStore.getState().setActive(id, name);
         }
         useProjectStore.getState().setSaveStatus("saving");
-        const { rooms, activeRoomId } = useCADStore.getState();
-        await saveProject(id, name, { version: 2, rooms, activeRoomId });
+        const st = useCADStore.getState() as any;
+        await saveProject(id, name, {
+          version: 2,
+          rooms: st.rooms,
+          activeRoomId: st.activeRoomId,
+          ...(st.customElements ? { customElements: st.customElements } : {}),
+        });
         useProjectStore.getState().setSaveStatus("saved");
         if (fadeTimer) clearTimeout(fadeTimer);
         fadeTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary
Audit finding from \`.planning/v1.2-MILESTONE-AUDIT.md\` — the custom element catalog was not being included in the saveProject payload, causing catalogs (and by extension, placed custom elements) to silently disappear on reload.

## Root cause
Both save call-sites constructed the snapshot manually, omitting \`customElements\`:
- \`src/hooks/useAutoSave.ts:36\`
- \`src/components/ProjectManager.tsx:33\`

The cadStore internal \`snapshot()\` helper handled it correctly, but external call-sites bypassed it.

## Fix
1. Both save sites now include \`customElements\` in payload
2. \`useAutoSave\` subscription extended to dirty on \`customElements\` changes (so catalog-only edits without room changes trigger autosave)

## What to test
- [ ] Create a custom element in the library
- [ ] Place it in a room
- [ ] Refresh the page
- [ ] Verify the custom element still appears in 3D + catalog still visible in sidebar

## Impact
Closes CUSTOM-05. v1.2 milestone moves from 28/29 to 29/29 requirements satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)