### PR TITLE
Plan v1.5 Performance & Tech Debt milestone

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -24,11 +24,23 @@ This is a single-user personal tool. Not a SaaS, not a professional CAD app, not
 
 See `.planning/ROADMAP.md` for links to each milestone archive.
 
-## Current Milestone
+## Current Milestone: v1.5 Performance & Tech Debt
 
-None active. Next milestone TBD — candidates in backlog (async product images in 2D canvas, auto-save with debounce, GLTF/OBJ model support, camera presets, editable dimension labels, PBR texture uploads, backend with authentication, design system redesign).
+**Goal:** Make the app feel smoother as scenes grow and close the highest-friction tech debt and bug debt before adding more features.
 
-Run `/gsd:new-milestone` to plan v1.5.
+**Target items:**
+- Canvas full-redraw → incremental updates (perf)
+- `JSON.parse(JSON.stringify())` → `structuredClone()` in cadStore snapshots (perf)
+- Tool cleanup off `(fc as any).__xToolCleanup` pattern (type-safety)
+- Tool state from module-level singletons → closures (multi-canvas safety)
+- Extract `pxToFeet` + `findClosestWall` to shared `toolUtils.ts` (DRY)
+- R3F v9 / React 19 upgrade tracking
+- Bug: 2D async product image rendering (#42)
+- Bug: Ceiling preset-id path (#43)
+
+**Source issues:** [#42](https://github.com/micahbank2/room-cad-renderer/issues/42), [#43](https://github.com/micahbank2/room-cad-renderer/issues/43), [#51](https://github.com/micahbank2/room-cad-renderer/issues/51), [#52](https://github.com/micahbank2/room-cad-renderer/issues/52), [#53](https://github.com/micahbank2/room-cad-renderer/issues/53), [#54](https://github.com/micahbank2/room-cad-renderer/issues/54), [#55](https://github.com/micahbank2/room-cad-renderer/issues/55), [#56](https://github.com/micahbank2/room-cad-renderer/issues/56)
+
+**Success criteria:** Identical UX, measurably better perf (60fps drag at 50 walls / 30 products), zero `as any` casts on Fabric instances, both bugs verified end-to-end.
 
 ## Target User
 
@@ -123,7 +135,16 @@ One person. Non-technical. Interior design enthusiast, not a professional. Comfo
 
 ### Active
 
-No active milestone. See `.planning/ROADMAP.md` for status.
+**v1.5 Milestone — Performance & Tech Debt** (in planning)
+
+- [ ] **PERF-01**: Canvas redraw uses incremental updates instead of full clear
+- [ ] **PERF-02**: cadStore snapshots use `structuredClone()` instead of JSON roundtrip
+- [ ] **TOOL-01**: Tool cleanup uses type-safe pattern (no `as any` on Fabric instance)
+- [ ] **TOOL-02**: Tool state held in closures, not module-level singletons
+- [ ] **TOOL-03**: `pxToFeet` + `findClosestWall` extracted to shared `toolUtils.ts`
+- [ ] **TRACK-01**: R3F v9 / React 19 upgrade path documented and tracked
+- [ ] **FIX-01**: Product images render in 2D canvas (async load)
+- [ ] **FIX-02**: Ceiling preset materials apply correctly in `CeilingMesh`
 
 ### Out of Scope
 
@@ -191,4 +212,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-04-18 after v1.4 milestone completion*
+*Last updated: 2026-04-17 — v1.5 Performance & Tech Debt milestone started*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,103 @@
+# v1.5 Requirements — Performance & Tech Debt
+
+**Milestone goal:** Make the app feel smoother as scenes grow and close the highest-friction tech debt and bug debt before adding more features.
+
+**Source issues:** [#42](https://github.com/micahbank2/room-cad-renderer/issues/42), [#43](https://github.com/micahbank2/room-cad-renderer/issues/43), [#51](https://github.com/micahbank2/room-cad-renderer/issues/51), [#52](https://github.com/micahbank2/room-cad-renderer/issues/52), [#53](https://github.com/micahbank2/room-cad-renderer/issues/53), [#54](https://github.com/micahbank2/room-cad-renderer/issues/54), [#55](https://github.com/micahbank2/room-cad-renderer/issues/55), [#56](https://github.com/micahbank2/room-cad-renderer/issues/56)
+
+**Success measure:** Identical UX, measurably better drag perf (target: 60fps at 50 walls / 30 products), zero `as any` casts on Fabric instances, both bugs verified end-to-end.
+
+---
+
+## v1.5 Requirements
+
+### Performance (PERF)
+
+- [ ] **PERF-01**: Canvas redraw uses incremental updates instead of full clear-and-redraw
+  - **Source:** [#51](https://github.com/micahbank2/room-cad-renderer/issues/51)
+  - **Verifiable:** Dragging a product in a 50-wall / 30-product scene maintains 60fps on M-series Mac. Visual parity with current behavior. All 115 tests pass.
+  - **Files:** `src/canvas/FabricCanvas.tsx`, `src/canvas/fabricSync.ts`
+
+- [ ] **PERF-02**: cadStore snapshots use `structuredClone()` instead of `JSON.parse(JSON.stringify())`
+  - **Source:** [#52](https://github.com/micahbank2/room-cad-renderer/issues/52)
+  - **Verifiable:** Snapshot perf measured before/after — ≥2x improvement at 50 walls / 30 products. Undo/redo still produces single entries for drag-completed mutations.
+  - **Files:** `src/stores/cadStore.ts` (lines 38–44)
+
+### Tool Architecture (TOOL)
+
+- [ ] **TOOL-01**: Tool cleanup uses type-safe pattern (no `as any` on Fabric canvas instance)
+  - **Source:** [#53](https://github.com/micahbank2/room-cad-renderer/issues/53)
+  - **Verifiable:** Zero `as any` casts on Fabric canvas. No event listener leaks during rapid tool switching. Existing tool behavior unchanged.
+  - **Files:** `src/canvas/tools/wallTool.ts:117`, `selectTool.ts:190`, `doorTool.ts:78`, `windowTool.ts:77`, `productTool.ts:60`
+
+- [ ] **TOOL-02**: Tool state held in closures, not module-level singletons
+  - **Source:** [#54](https://github.com/micahbank2/room-cad-renderer/issues/54)
+  - **Verifiable:** No `const state = {...}` at module scope in any tool file. Two parallel tool activations don't bleed state. Existing tool behavior unchanged.
+  - **Files:** `src/canvas/tools/wallTool.ts:7-13`, `selectTool.ts:8-20`, `productTool.ts:8`
+
+- [ ] **TOOL-03**: `pxToFeet` and `findClosestWall` extracted to shared `toolUtils.ts`
+  - **Source:** [#55](https://github.com/micahbank2/room-cad-renderer/issues/55)
+  - **Verifiable:** Zero duplicated implementations across 5 tool files. All tools take consistent `gridSnap` behavior on hover/click. All 115 tests pass.
+  - **Files:** All 5 files under `src/canvas/tools/`, new `src/canvas/tools/toolUtils.ts`
+
+### Tracking (TRACK)
+
+- [ ] **TRACK-01**: R3F v9 / React 19 upgrade path documented and tracked
+  - **Source:** [#56](https://github.com/micahbank2/room-cad-renderer/issues/56)
+  - **Verifiable:** Upgrade plan written into a README/notes block (not yet executed — blocked on R3F v9 stable). Issue #56 stays open as the tracking artifact.
+  - **Files:** `package.json` notes, `.planning/codebase/CONCERNS.md` update
+
+### Bug Fixes (FIX)
+
+- [ ] **FIX-01**: Product images render in 2D canvas (async load)
+  - **Source:** [#42](https://github.com/micahbank2/room-cad-renderer/issues/42)
+  - **Verifiable:** Product thumbnails appear in 2D canvas after placement. No flicker on existing renders. Project reload shows images without re-trigger.
+  - **Files:** `src/canvas/fabricSync.ts:155-168`
+
+- [ ] **FIX-02**: Ceiling preset materials apply correctly in `CeilingMesh`
+  - **Source:** [#43](https://github.com/micahbank2/room-cad-renderer/issues/43)
+  - **Verifiable:** Selecting a ceiling preset visibly changes the 3D ceiling material. Preset persists across reload. Hex color path still works.
+  - **Files:** `src/three/CeilingMesh.tsx`, `src/lib/surfaceMaterials.ts`
+
+---
+
+## Future Requirements (Deferred to Later Milestones)
+
+Issues filed but not in v1.5 scope:
+
+- [#44](https://github.com/micahbank2/room-cad-renderer/issues/44) Auto-save CAD scene with debounce
+- [#45](https://github.com/micahbank2/room-cad-renderer/issues/45) Camera presets (eye-level, top-down)
+- [#46](https://github.com/micahbank2/room-cad-renderer/issues/46) Editable dimension labels
+- [#47](https://github.com/micahbank2/room-cad-renderer/issues/47) User-uploaded PBR textures
+- [#48](https://github.com/micahbank2/room-cad-renderer/issues/48) Design system redesign (blocked on mockups)
+- [#49](https://github.com/micahbank2/room-cad-renderer/issues/49) Wainscot library item edit UI
+- [#50](https://github.com/micahbank2/room-cad-renderer/issues/50) Per-placement label override for custom elements
+- Pre-existing GH issues: [#17](https://github.com/micahbank2/room-cad-renderer/issues/17), [#19-33](https://github.com/micahbank2/room-cad-renderer/issues/19) (smart snapping, toolbar expansion, library rebuild, material engine, GLTF, cloud sync, user guides)
+
+## Out of Scope (Locked)
+
+From PROJECT.md:
+
+- Multi-user / collaboration
+- Export to contractors / CAD file formats
+- Pricing integration / shopping lists
+- Mobile / iPad support
+- Professional drafting features
+- Backend / server / auth (separately tracked as future work in [#30](https://github.com/micahbank2/room-cad-renderer/issues/30))
+- GLTF/OBJ 3D model upload (separately tracked as [#29](https://github.com/micahbank2/room-cad-renderer/issues/29) but explicitly deferred)
+
+---
+
+## Traceability
+
+| Requirement | Issue | Phase | Status |
+|-------------|-------|-------|--------|
+| PERF-01 | #51 | TBD | Pending |
+| PERF-02 | #52 | TBD | Pending |
+| TOOL-01 | #53 | TBD | Pending |
+| TOOL-02 | #54 | TBD | Pending |
+| TOOL-03 | #55 | TBD | Pending |
+| TRACK-01 | #56 | TBD | Pending |
+| FIX-01 | #42 | TBD | Pending |
+| FIX-02 | #43 | TBD | Pending |
+
+*Phase column filled by roadmapper.*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -91,13 +91,11 @@ From PROJECT.md:
 
 | Requirement | Issue | Phase | Status |
 |-------------|-------|-------|--------|
-| PERF-01 | #51 | TBD | Pending |
-| PERF-02 | #52 | TBD | Pending |
-| TOOL-01 | #53 | TBD | Pending |
-| TOOL-02 | #54 | TBD | Pending |
-| TOOL-03 | #55 | TBD | Pending |
-| TRACK-01 | #56 | TBD | Pending |
-| FIX-01 | #42 | TBD | Pending |
-| FIX-02 | #43 | TBD | Pending |
-
-*Phase column filled by roadmapper.*
+| PERF-01 | #51 | Phase 25 | Pending |
+| PERF-02 | #52 | Phase 25 | Pending |
+| TOOL-01 | #53 | Phase 24 | Pending |
+| TOOL-02 | #54 | Phase 24 | Pending |
+| TOOL-03 | #55 | Phase 24 | Pending |
+| TRACK-01 | #56 | Phase 27 | Pending |
+| FIX-01 | #42 | Phase 26 | Pending |
+| FIX-02 | #43 | Phase 26 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -7,6 +7,7 @@
 - ✅ **v1.2 New Element Types** — Phases 11–17 (shipped 2026-04-05) — see [milestones/v1.2-ROADMAP.md](milestones/v1.2-ROADMAP.md)
 - ✅ **v1.3 Color, Polish & Materials** — Phases 18–20 (shipped 2026-04-06) — see [milestones/v1.3-ROADMAP.md](milestones/v1.3-ROADMAP.md)
 - ✅ **v1.4 Polish & Tech Debt** — Phases 21–23 (shipped 2026-04-08) — see [milestones/v1.4-ROADMAP.md](milestones/v1.4-ROADMAP.md)
+- 🔄 **v1.5 Performance & Tech Debt** — Phases 24–27 (in progress)
 
 ---
 
@@ -49,6 +50,69 @@
 
 ---
 
-## Next Milestone
+## v1.5 Performance & Tech Debt
 
-No active milestone. Run `/gsd:new-milestone` to plan v1.5 — candidates in backlog (async product images, auto-save, GLTF model support, etc.).
+**Milestone goal:** Make the app feel smoother as scenes grow and close the highest-friction tech debt and bug debt before adding more features.
+
+### Phases
+
+- [ ] **Phase 24: Tool Architecture Refactor** — Eliminate `as any` casts, move state to closures, extract shared utilities
+- [ ] **Phase 25: Canvas & Store Performance** — Incremental canvas updates, faster cadStore snapshots
+- [ ] **Phase 26: Bug Sweep** — Fix async product images in 2D canvas and ceiling preset material path
+- [ ] **Phase 27: Upgrade Tracking** — Document R3F v9 / React 19 upgrade path
+
+### Phase Details
+
+### Phase 24: Tool Architecture Refactor
+**Goal**: Tool code is type-safe, state-isolated, and DRY — no `as any` casts on Fabric instances, no module-level singletons, no duplicated coordinate utilities
+**Depends on**: Nothing (internal refactor, no new features)
+**Requirements**: TOOL-01, TOOL-02, TOOL-03
+**Success Criteria** (what must be TRUE):
+  1. `ripgrep "(fc as any)" src/canvas/tools/` returns zero matches
+  2. No `const state = {...}` declarations at module scope in any tool file — all mutable tool state lives inside the activate closure
+  3. A single `src/canvas/tools/toolUtils.ts` exists and all 5 tool files import `pxToFeet` and `findClosestWall` from it — zero local duplicates
+  4. Rapid tool switching (select → wall → door → window → product, 10x fast) produces no event listener leaks (Chrome DevTools memory snapshot confirms stable listener count)
+  5. All 115 tests pass with no behavioral regressions
+**Plans**: TBD
+
+### Phase 25: Canvas & Store Performance
+**Goal**: Dragging in a complex scene sustains 60fps and cadStore undo snapshots are measurably faster
+**Depends on**: Phase 24 (tool files stabilized before canvas hot path is touched)
+**Requirements**: PERF-01, PERF-02
+**Success Criteria** (what must be TRUE):
+  1. Chrome DevTools Performance trace: dragging a product through a 50-wall / 30-product scene shows sustained 60fps (no frame drops below 16.7ms/frame)
+  2. `structuredClone()` replaces every `JSON.parse(JSON.stringify(...))` call in `cadStore.ts` — zero JSON roundtrips in snapshot code
+  3. Snapshot timing measured before/after: ≥2x improvement at 50 walls / 30 products (logged to console in dev mode)
+  4. Undo/redo still produces single history entries for completed drag mutations — no regression in history boundary behavior
+  5. All 115 tests pass with identical visual output
+**Plans**: TBD
+
+### Phase 26: Bug Sweep
+**Goal**: Product thumbnails appear in 2D canvas after placement and ceiling preset materials render correctly in 3D
+**Depends on**: Nothing (both bugs are isolated to specific files; can run in parallel with Phase 24/25 but grouped here for clean PR)
+**Requirements**: FIX-01, FIX-02
+**Success Criteria** (what must be TRUE):
+  1. Place a product with an uploaded image — thumbnail appears in 2D canvas within one render cycle (no placeholder-only render)
+  2. Project reload shows product images in 2D canvas without any re-trigger or user action
+  3. Select a ceiling preset material in the ceiling panel — the 3D ceiling mesh visibly changes to that material
+  4. Preset material selection persists across project save/reload (not reset to default hex on load)
+**Plans**: TBD
+
+### Phase 27: Upgrade Tracking
+**Goal**: R3F v9 / React 19 upgrade path is documented and the blocking issue is tracked so it can be executed when R3F v9 stabilizes
+**Depends on**: Phase 25 (want final v1.5 perf baseline recorded before noting upgrade target)
+**Requirements**: TRACK-01
+**Success Criteria** (what must be TRUE):
+  1. `.planning/codebase/CONCERNS.md` contains an R3F v9 / React 19 section with: current pinned versions, known blockers (hook errors with React 19), and the upgrade sequence (R3F v9 → drei v10 → React 19)
+  2. GitHub issue #56 is updated with the documented upgrade plan and stays open as the tracking artifact
+  3. No version bumps are made in `package.json` — this phase is documentation only
+**Plans**: TBD
+
+### Progress Table
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 24. Tool Architecture Refactor | 0/? | Not started | - |
+| 25. Canvas & Store Performance | 0/? | Not started | - |
+| 26. Bug Sweep | 0/? | Not started | - |
+| 27. Upgrade Tracking | 0/? | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,11 +3,11 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Performance & Tech Debt
 status: planning
-stopped_at: defining requirements for v1.5
+stopped_at: roadmap created — ready for phase planning
 last_updated: "2026-04-17T00:00:00.000Z"
 last_activity: 2026-04-17
 progress:
-  total_phases: 0
+  total_phases: 4
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -25,10 +25,12 @@ See: .planning/PROJECT.md (updated 2026-04-17)
 
 ## Current Position
 
-Phase: Not started (defining requirements)
+Phase: 24 (Tool Architecture Refactor) — Not started
 Plan: —
-Status: Defining requirements for v1.5 Performance & Tech Debt
-Last activity: 2026-04-17 — Milestone v1.5 started, 8 issues filed (#42, #43, #51-56)
+Status: Roadmap created; ready to begin Phase 24
+Last activity: 2026-04-17 — v1.5 roadmap written (4 phases, 8 requirements mapped)
+
+[==========] 0% (0/4 phases complete)
 
 ## Accumulated Context
 
@@ -56,6 +58,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-04-17 — v1.5 milestone planning started
-Stopped at: Defining requirements; awaiting REQUIREMENTS.md + ROADMAP.md generation
+Last session: 2026-04-17 — v1.5 roadmap created (Phases 24–27)
+Stopped at: Ready to plan Phase 24
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,11 +1,11 @@
 ---
 gsd_state_version: 1.0
-milestone: null
-milestone_name: null
-status: between_milestones
-stopped_at: v1.4 milestone archived 2026-04-18
-last_updated: "2026-04-18T00:00:00.000Z"
-last_activity: 2026-04-18
+milestone: v1.5
+milestone_name: Performance & Tech Debt
+status: planning
+stopped_at: defining requirements for v1.5
+last_updated: "2026-04-17T00:00:00.000Z"
+last_activity: 2026-04-17
 progress:
   total_phases: 0
   completed_phases: 0
@@ -18,19 +18,17 @@ progress:
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-04-18)
+See: .planning/PROJECT.md (updated 2026-04-17)
 
 **Core value:** Jessica can see her future room with her actual furniture before spending money.
-**Current focus:** Planning next milestone — v1.5 TBD
+**Current focus:** v1.5 — Performance & Tech Debt (no user-visible new features)
 
 ## Current Position
 
-No active milestone. v1.4 Polish & Tech Debt shipped 2026-04-08 and archived 2026-04-18.
-
-Run `/gsd:new-milestone` to start v1.5 planning. Backlog candidates:
-- High: async product images in 2D canvas, auto-save with debounce
-- Medium: GLTF/OBJ model support, camera presets, editable dimension labels
-- Low: user-uploaded PBR textures, design system redesign, backend + auth, advanced 3D
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements for v1.5 Performance & Tech Debt
+Last activity: 2026-04-17 — Milestone v1.5 started, 8 issues filed (#42, #43, #51-56)
 
 ## Accumulated Context
 
@@ -58,6 +56,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-04-18 — v1.4 milestone retrofit + archival
-Stopped at: v1.4 archived; ready for v1.5 planning
+Last session: 2026-04-17 — v1.5 milestone planning started
+Stopped at: Defining requirements; awaiting REQUIREMENTS.md + ROADMAP.md generation
 Resume file: None


### PR DESCRIPTION
## Summary

Kicks off **v1.5 — Performance & Tech Debt**, a no-feature milestone focused on smoothing the highest-friction perf issues and refactoring tool-architecture tech debt before we add more user-facing capability.

**Scope:** 4 phases / 8 requirements / 8 GitHub issues filed as part of planning.

| Phase | Goal | Requirements | Issues |
|-------|------|--------------|--------|
| 24 — Tool Architecture Refactor | Type-safe, state-isolated, DRY tool code | TOOL-01/02/03 | #53, #54, #55 |
| 25 — Canvas & Store Performance | 60fps drag at 50 walls / 30 products | PERF-01/02 | #51, #52 |
| 26 — Bug Sweep | 2D async product images + ceiling preset materials | FIX-01/02 | #42, #43 |
| 27 — Upgrade Tracking | R3F v9 / React 19 path documented | TRACK-01 | #56 |

## What's in this PR

- `.planning/PROJECT.md` — Current Milestone section + Active requirements list
- `.planning/REQUIREMENTS.md` — 8 requirements with verification criteria + traceability table
- `.planning/ROADMAP.md` — v1.5 section appended (v1.0–v1.4 archive summaries preserved)
- `.planning/STATE.md` — milestone field set to v1.5, status `planning`
- 15 GitHub issues filed (#42–#56): 8 in v1.5 scope, 7 deferred

**Source for v1.5 scope:** `.planning/codebase/CONCERNS.md` analysis (already done) — every tech debt item maps directly to a documented concern.

## Success measure

- Identical UX (no user-visible feature changes)
- Sustained 60fps drag in 50w/30p scene (Chrome DevTools perf trace)
- ≥2x snapshot timing improvement after `structuredClone()` swap
- Zero `(fc as any)` casts under `src/canvas/tools/`
- All 115 tests pass throughout
- Both bugs (#42, #43) verified end-to-end

## Test plan

- [x] PROJECT.md / REQUIREMENTS.md / ROADMAP.md / STATE.md cross-reference correctly (req IDs, phase numbers, issue links)
- [x] All 8 requirements mapped to exactly one phase (no orphans)
- [x] Phase numbering continues from v1.4 (last phase 23 → v1.5 starts at 24)
- [x] Future requirements section lists every filed issue not in scope
- [x] Out of Scope section preserved from prior milestone

No code changes in this PR — planning only.

## Next

After merge: `/gsd:discuss-phase 24` (with fresh context) to gather Phase 24 scope and start execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)