### PR TITLE
Phase 27: Upgrade Tracking — document R3F v9 / React 19 path

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -41,7 +41,7 @@
 
 ### Tracking (TRACK)
 
-- [ ] **TRACK-01**: R3F v9 / React 19 upgrade path documented and tracked
+- [x] **TRACK-01**: R3F v9 / React 19 upgrade path documented and tracked
   - **Source:** [#56](https://github.com/micahbank2/room-cad-renderer/issues/56)
   - **Verifiable:** Upgrade plan written into a README/notes block (not yet executed — blocked on R3F v9 stable). Issue #56 stays open as the tracking artifact.
   - **Files:** `package.json` notes, `.planning/codebase/CONCERNS.md` update

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -120,7 +120,7 @@
   3. No version bumps are made in `package.json` — this phase is documentation only
 **Plans**: 3 plans
   - [x] 27-01-PLAN.md — Append new `## R3F v9 / React 19 Upgrade` section to CONCERNS.md with target versions, sequence, blockers, per-package breaking changes, affected files, citations (TRACK-01)
-  - [ ] 27-02-PLAN.md — Rewrite existing "React 18 downgrade" Tech Debt bullet in CONCERNS.md as a short pointer to the new section (TRACK-01)
+  - [x] 27-02-PLAN.md — Rewrite existing "React 18 downgrade" Tech Debt bullet in CONCERNS.md as a short pointer to the new section (TRACK-01)
   - [ ] 27-03-PLAN.md — Post comment on GitHub issue #56 summarizing the documented upgrade plan; issue stays OPEN (TRACK-01)
 
 ### Progress Table
@@ -130,4 +130,4 @@
 | 24. Tool Architecture Refactor | 4/4 | Complete    | 2026-04-19 |
 | 25. Canvas & Store Performance | 4/4 | Complete    | 2026-04-20 |
 | 26. Bug Sweep | 4/4 | Complete    | 2026-04-20 |
-| 27. Upgrade Tracking | 1/3 | In Progress|  |
+| 27. Upgrade Tracking | 2/3 | In Progress|  |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -7,7 +7,7 @@
 - ✅ **v1.2 New Element Types** — Phases 11–17 (shipped 2026-04-05) — see [milestones/v1.2-ROADMAP.md](milestones/v1.2-ROADMAP.md)
 - ✅ **v1.3 Color, Polish & Materials** — Phases 18–20 (shipped 2026-04-06) — see [milestones/v1.3-ROADMAP.md](milestones/v1.3-ROADMAP.md)
 - ✅ **v1.4 Polish & Tech Debt** — Phases 21–23 (shipped 2026-04-08) — see [milestones/v1.4-ROADMAP.md](milestones/v1.4-ROADMAP.md)
-- 🔄 **v1.5 Performance & Tech Debt** — Phases 24–27 (in progress)
+- ✅ **v1.5 Performance & Tech Debt** — Phases 24–27 (completed 2026-04-20)
 
 ---
 
@@ -59,7 +59,7 @@
 - [x] **Phase 24: Tool Architecture Refactor** — Eliminate `as any` casts, move state to closures, extract shared utilities (shipped 2026-04-18)
 - [x] **Phase 25: Canvas & Store Performance** — Incremental canvas updates, faster cadStore snapshots (completed 2026-04-20)
 - [x] **Phase 26: Bug Sweep** — Fix async product images in 2D canvas and ceiling preset material path (completed 2026-04-20)
-- [ ] **Phase 27: Upgrade Tracking** — Document R3F v9 / React 19 upgrade path
+- [x] **Phase 27: Upgrade Tracking** — Document R3F v9 / React 19 upgrade path (completed 2026-04-20)
 
 ### Phase Details
 
@@ -121,7 +121,7 @@
 **Plans**: 3 plans
   - [x] 27-01-PLAN.md — Append new `## R3F v9 / React 19 Upgrade` section to CONCERNS.md with target versions, sequence, blockers, per-package breaking changes, affected files, citations (TRACK-01)
   - [x] 27-02-PLAN.md — Rewrite existing "React 18 downgrade" Tech Debt bullet in CONCERNS.md as a short pointer to the new section (TRACK-01)
-  - [ ] 27-03-PLAN.md — Post comment on GitHub issue #56 summarizing the documented upgrade plan; issue stays OPEN (TRACK-01)
+  - [x] 27-03-PLAN.md — Post comment on GitHub issue #56 summarizing the documented upgrade plan; issue stays OPEN (TRACK-01)
 
 ### Progress Table
 
@@ -130,4 +130,4 @@
 | 24. Tool Architecture Refactor | 4/4 | Complete    | 2026-04-19 |
 | 25. Canvas & Store Performance | 4/4 | Complete    | 2026-04-20 |
 | 26. Bug Sweep | 4/4 | Complete    | 2026-04-20 |
-| 27. Upgrade Tracking | 2/3 | In Progress|  |
+| 27. Upgrade Tracking | 3/3 | Complete    | 2026-04-20 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -119,7 +119,7 @@
   2. GitHub issue #56 is updated with the documented upgrade plan and stays open as the tracking artifact
   3. No version bumps are made in `package.json` — this phase is documentation only
 **Plans**: 3 plans
-  - [ ] 27-01-PLAN.md — Append new `## R3F v9 / React 19 Upgrade` section to CONCERNS.md with target versions, sequence, blockers, per-package breaking changes, affected files, citations (TRACK-01)
+  - [x] 27-01-PLAN.md — Append new `## R3F v9 / React 19 Upgrade` section to CONCERNS.md with target versions, sequence, blockers, per-package breaking changes, affected files, citations (TRACK-01)
   - [ ] 27-02-PLAN.md — Rewrite existing "React 18 downgrade" Tech Debt bullet in CONCERNS.md as a short pointer to the new section (TRACK-01)
   - [ ] 27-03-PLAN.md — Post comment on GitHub issue #56 summarizing the documented upgrade plan; issue stays OPEN (TRACK-01)
 
@@ -130,4 +130,4 @@
 | 24. Tool Architecture Refactor | 4/4 | Complete    | 2026-04-19 |
 | 25. Canvas & Store Performance | 4/4 | Complete    | 2026-04-20 |
 | 26. Bug Sweep | 4/4 | Complete    | 2026-04-20 |
-| 27. Upgrade Tracking | 0/3 | Not started | - |
+| 27. Upgrade Tracking | 1/3 | In Progress|  |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -118,7 +118,10 @@
   1. `.planning/codebase/CONCERNS.md` contains an R3F v9 / React 19 section with: current pinned versions, known blockers (hook errors with React 19), and the upgrade sequence (R3F v9 → drei v10 → React 19)
   2. GitHub issue #56 is updated with the documented upgrade plan and stays open as the tracking artifact
   3. No version bumps are made in `package.json` — this phase is documentation only
-**Plans**: TBD
+**Plans**: 3 plans
+  - [ ] 27-01-PLAN.md — Append new `## R3F v9 / React 19 Upgrade` section to CONCERNS.md with target versions, sequence, blockers, per-package breaking changes, affected files, citations (TRACK-01)
+  - [ ] 27-02-PLAN.md — Rewrite existing "React 18 downgrade" Tech Debt bullet in CONCERNS.md as a short pointer to the new section (TRACK-01)
+  - [ ] 27-03-PLAN.md — Post comment on GitHub issue #56 summarizing the documented upgrade plan; issue stays OPEN (TRACK-01)
 
 ### Progress Table
 
@@ -127,4 +130,4 @@
 | 24. Tool Architecture Refactor | 4/4 | Complete    | 2026-04-19 |
 | 25. Canvas & Store Performance | 4/4 | Complete    | 2026-04-20 |
 | 26. Bug Sweep | 4/4 | Complete    | 2026-04-20 |
-| 27. Upgrade Tracking | 0/? | Not started | - |
+| 27. Upgrade Tracking | 0/3 | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Performance & Tech Debt
-status: executing
-stopped_at: Completed 27-01-PLAN.md
-last_updated: "2026-04-20T18:09:04.043Z"
+status: milestone-complete
+stopped_at: Completed 27-03-PLAN.md (Phase 27 done; v1.5 milestone complete)
+last_updated: "2026-04-20T18:11:29.000Z"
 last_activity: 2026-04-20
 progress:
   total_phases: 4
-  completed_phases: 3
+  completed_phases: 4
   total_plans: 15
-  completed_plans: 14
+  completed_plans: 15
 ---
 
 # Project State
@@ -20,16 +20,16 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-17)
 
 **Core value:** Jessica can see her future room with her actual furniture before spending money.
-**Current focus:** Phase 27 — upgrade-tracking (Wave 1 complete)
+**Current focus:** v1.5 Performance & Tech Debt milestone complete — all 4 phases (24, 25, 26, 27) shipped.
 
 ## Current Position
 
-Phase: 27
-Plan: 02 (next — Wave 2, unblocked by 27-01)
-Status: Phase 27 in progress (plan 01 of 3 complete; Wave 2 unblocked)
+Phase: 27 (complete)
+Plan: — (v1.5 milestone complete; next milestone not yet scoped)
+Status: v1.5 milestone complete — all 15 plans across 4 phases done
 Last activity: 2026-04-20
 
-[█████████░] 87% (13/15 v1.5 plans complete; Phase 27 plans 1/3 done)
+[██████████] 100% (15/15 v1.5 plans complete; 4/4 phases complete)
 
 ## Accumulated Context
 
@@ -56,6 +56,7 @@ Full log in PROJECT.md Key Decisions table. Recent v1.4 decisions:
 - [Phase 26-bug-sweep]: Phase 26 closed — FIX-01 fixed (Group rebuild via onImageReady/React tick); FIX-02 closed as Outcome A (perception-only, regression guards added). GitHub #42 and #43 closed per D-14. Full suite 191 passing (6 pre-existing unrelated failures unchanged). D-10 + D-12 user-approved 2026-04-20. Backlog: #60 (drag-to-resize UX), #61 (WOOD_PLANK PBR realism) filed during smoke session.
 - [Phase 27-upgrade-tracking]: Plan 27-01: Appended `## R3F v9 / React 19 Upgrade` section to CONCERNS.md — documents current pins, locked target majors (^9.0.0 R3F / ^10.0.0 drei / ^19.0.0 React), sequence phrase `R3F v9 → drei v10 → React 19`, affected files, canonical citations, and links issue #56 as persistent tracker. Wave 2 (plans 27-02 + 27-03) now unblocked.
 - [Phase 27-upgrade-tracking]: Tech Debt React 18 bullet rewritten as pointer to the new § R3F v9 / React 19 Upgrade section; duplicated fix content removed; issue #56 linked inline
+- [Phase 27-upgrade-tracking]: Plan 27-03: Dated upgrade-plan comment posted on GH issue #56 (issuecomment-4283199813) linking to CONCERNS.md § R3F v9 / React 19 Upgrade; issue state OPEN, milestone/labels/assignees unchanged, zero repo files modified (D-05..D-08 all honored). TRACK-01 acceptance #2 satisfied. Phase 27 complete → v1.5 milestone closed (4/4 phases, 15/15 plans).
 
 ### Pending Todos
 
@@ -73,6 +74,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-04-20T18:06:19.170Z
-Stopped at: Completed 27-01-PLAN.md
+Last session: 2026-04-20T18:11:29.000Z
+Stopped at: Completed 27-03-PLAN.md (Phase 27 done; v1.5 milestone complete)
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Performance & Tech Debt
-status: Phase closed; ready for Phase 27 (Upgrade Tracking)
-stopped_at: Phase 27 context gathered
-last_updated: "2026-04-20T17:47:51.410Z"
+status: Phase 27 in progress (plan 01 of 3 complete; Wave 2 unblocked)
+stopped_at: Completed 27-01-PLAN.md
+last_updated: "2026-04-20T18:07:08.513Z"
 last_activity: 2026-04-20
 progress:
   total_phases: 4
   completed_phases: 3
-  total_plans: 12
-  completed_plans: 12
+  total_plans: 15
+  completed_plans: 13
 ---
 
 # Project State
@@ -20,16 +20,16 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-17)
 
 **Core value:** Jessica can see her future room with her actual furniture before spending money.
-**Current focus:** Phase 26 — bug-sweep
+**Current focus:** Phase 27 — upgrade-tracking (Wave 1 complete)
 
 ## Current Position
 
 Phase: 27
-Plan: Not started
-Status: Phase closed; ready for Phase 27 (Upgrade Tracking)
+Plan: 02 (next — Wave 2, unblocked by 27-01)
+Status: Phase 27 in progress (plan 01 of 3 complete; Wave 2 unblocked)
 Last activity: 2026-04-20
 
-[===============] 75% (3/4 v1.5 phases complete; Phase 26 plans 4/4 done)
+[█████████░] 87% (13/15 v1.5 plans complete; Phase 27 plans 1/3 done)
 
 ## Accumulated Context
 
@@ -54,6 +54,7 @@ Full log in PROJECT.md Key Decisions table. Recent v1.4 decisions:
 - [Phase 26-bug-sweep]: FIX-01: React tick state (productImageTick) in FabricCanvas bumped by renderProducts onImageReady callback — forces Group rebuild on async image load without touching productImageCache.ts (D-02) or fabric internals (D-03 first-paint correctness)
 - [Phase 26]: FIX-02 closed as Outcome A (Pitfall 3 perception-only). PLASTER #f0ebe0 vs PAINTED_DRYWALL #f5f5f5 differ by ~3 L* points — below JND. Production code path verified correct end-to-end; 4 store-integration regression guards added.
 - [Phase 26-bug-sweep]: Phase 26 closed — FIX-01 fixed (Group rebuild via onImageReady/React tick); FIX-02 closed as Outcome A (perception-only, regression guards added). GitHub #42 and #43 closed per D-14. Full suite 191 passing (6 pre-existing unrelated failures unchanged). D-10 + D-12 user-approved 2026-04-20. Backlog: #60 (drag-to-resize UX), #61 (WOOD_PLANK PBR realism) filed during smoke session.
+- [Phase 27-upgrade-tracking]: Plan 27-01: Appended `## R3F v9 / React 19 Upgrade` section to CONCERNS.md — documents current pins, locked target majors (^9.0.0 R3F / ^10.0.0 drei / ^19.0.0 React), sequence phrase `R3F v9 → drei v10 → React 19`, affected files, canonical citations, and links issue #56 as persistent tracker. Wave 2 (plans 27-02 + 27-03) now unblocked.
 
 ### Pending Todos
 
@@ -71,6 +72,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-04-20T17:47:51.407Z
-Stopped at: Phase 27 context gathered
-Resume file: .planning/phases/27-upgrade-tracking/27-CONTEXT.md
+Last session: 2026-04-20T18:06:19.170Z
+Stopped at: Completed 27-01-PLAN.md
+Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Performance & Tech Debt
 status: Phase closed; ready for Phase 27 (Upgrade Tracking)
-stopped_at: Completed 26-03-wave3-verification-and-closeout-PLAN.md (Phase 26 closed)
-last_updated: "2026-04-20T17:32:33.483Z"
+stopped_at: Phase 27 context gathered
+last_updated: "2026-04-20T17:47:51.410Z"
 last_activity: 2026-04-20
 progress:
   total_phases: 4
@@ -71,6 +71,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-04-20T18:00:00.000Z
-Stopped at: Completed 26-03-wave3-verification-and-closeout-PLAN.md (Phase 26 closed)
-Resume file: None
+Last session: 2026-04-20T17:47:51.407Z
+Stopped at: Phase 27 context gathered
+Resume file: .planning/phases/27-upgrade-tracking/27-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Performance & Tech Debt
-status: Phase 27 in progress (plan 01 of 3 complete; Wave 2 unblocked)
+status: executing
 stopped_at: Completed 27-01-PLAN.md
-last_updated: "2026-04-20T18:07:08.513Z"
+last_updated: "2026-04-20T18:09:04.043Z"
 last_activity: 2026-04-20
 progress:
   total_phases: 4
   completed_phases: 3
   total_plans: 15
-  completed_plans: 13
+  completed_plans: 14
 ---
 
 # Project State
@@ -55,6 +55,7 @@ Full log in PROJECT.md Key Decisions table. Recent v1.4 decisions:
 - [Phase 26]: FIX-02 closed as Outcome A (Pitfall 3 perception-only). PLASTER #f0ebe0 vs PAINTED_DRYWALL #f5f5f5 differ by ~3 L* points — below JND. Production code path verified correct end-to-end; 4 store-integration regression guards added.
 - [Phase 26-bug-sweep]: Phase 26 closed — FIX-01 fixed (Group rebuild via onImageReady/React tick); FIX-02 closed as Outcome A (perception-only, regression guards added). GitHub #42 and #43 closed per D-14. Full suite 191 passing (6 pre-existing unrelated failures unchanged). D-10 + D-12 user-approved 2026-04-20. Backlog: #60 (drag-to-resize UX), #61 (WOOD_PLANK PBR realism) filed during smoke session.
 - [Phase 27-upgrade-tracking]: Plan 27-01: Appended `## R3F v9 / React 19 Upgrade` section to CONCERNS.md — documents current pins, locked target majors (^9.0.0 R3F / ^10.0.0 drei / ^19.0.0 React), sequence phrase `R3F v9 → drei v10 → React 19`, affected files, canonical citations, and links issue #56 as persistent tracker. Wave 2 (plans 27-02 + 27-03) now unblocked.
+- [Phase 27-upgrade-tracking]: Tech Debt React 18 bullet rewritten as pointer to the new § R3F v9 / React 19 Upgrade section; duplicated fix content removed; issue #56 linked inline
 
 ### Pending Todos
 

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -5,10 +5,10 @@
 ## Tech Debt
 
 **React 18 downgrade (was React 19):**
-- Issue: React was pinned to `^18.3.1` to maintain compatibility with `@react-three/fiber` v8 and `@react-three/drei` v9, which do not fully support React 19. This is an explicit constraint, not an oversight.
+- Issue: React is pinned to `^18.3.1` because `@react-three/fiber` v8 and `@react-three/drei` v9 had hook errors with React 19 at the time the pin was set.
 - Files: `package.json`
-- Impact: Cannot use React 19 features (server components, improved `use()` hook, improved transitions). Will need to track R3F's React 19 support timeline.
-- Fix approach: Upgrade to `@react-three/fiber` v9 (when stable) before bumping React to 19.
+- Impact: Cannot use React 19 features (improved `use()` hook, improved transitions, ref cleanup functions).
+- Fix approach: see § R3F v9 / React 19 Upgrade below for the full upgrade plan (target versions, sequence, affected files, citations). Tracked in [issue #56](https://github.com/micahbank2/room-cad-renderer/issues/56).
 
 **Tool cleanup stored as arbitrary property on Fabric canvas instance:**
 - Issue: Each tool stores its cleanup function on the Fabric canvas instance via `(fc as any).__xToolCleanup`. This bypasses TypeScript's type system entirely and pollutes a third-party object.

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -88,6 +88,111 @@
 - Impact: The library view sidebar is entirely cosmetic — filtering only works via the search input in the main `ProductLibrary` component.
 - Fix approach: Wire checkboxes to state and pass selected filters as props to `ProductLibrary`, or remove the sidebar entirely until the feature is implemented.
 
+## R3F v9 / React 19 Upgrade
+
+This section documents the deferred upgrade from the current React 18 + R3F v8 + drei v9 stack to React 19 + R3F v9 + drei v10. Per phase 27 decisions (D-01 through D-04), this is a tracking/documentation artifact only — execution is deferred to a future phase when timing aligns. No `package.json` or `src/` changes are made in phase 27.
+
+### Current State
+
+The codebase is pinned to React 18 with R3F v8 and drei v9 because R3F v8 / drei v9 do not support React 19. The original downgrade (captured in the Tech Debt "React 18 downgrade" bullet above) was driven by hook errors with React 19 under the v8/v9 matrix.
+
+Current pinned versions (verified from `package.json` on 2026-04-20):
+
+| Package | Current |
+|---------|---------|
+| `react` | `^18.3.1` |
+| `react-dom` | `^18.3.1` |
+| `@types/react` | `^18.3.18` |
+| `@types/react-dom` | `^18.3.5` |
+| `@react-three/fiber` | `^8.17.14` |
+| `@react-three/drei` | `^9.122.0` |
+| `three` | `^0.183.2` |
+| `@types/three` | `^0.183.1` |
+
+### Target Versions
+
+Target pinned versions (per D-02, locked):
+
+| Package | Target |
+|---------|--------|
+| `react` | `^19.0.0` |
+| `react-dom` | `^19.0.0` |
+| `@types/react` | `^19.0.0` |
+| `@types/react-dom` | `^19.0.0` |
+| `@react-three/fiber` | `^9.0.0` |
+| `@react-three/drei` | `^10.0.0` |
+| `three` | unchanged (`^0.183.2`) |
+| `@types/three` | unchanged (`^0.183.1`) |
+
+Latest stables verified during research (2026-04-20): R3F 9.6.0, drei 10.7.7, React 19.2.x. Pin to the major ranges above per D-02 — do not pin to specific minors in `package.json`.
+
+### Upgrade Sequence
+
+Locked conceptual sequence: `R3F v9 → drei v10 → React 19`.
+
+This is the conceptual dependency ordering: R3F v9 is the gatekeeper because drei v10 peer-requires R3F v9, and React 19 is peer-required by both R3F v9 and drei v10. In practice a single-PR `npm install` covers all four peer-deps at once (per RESEARCH.md §6 Option A). Example install command:
+
+```
+npm install react@^19 react-dom@^19 @react-three/fiber@^9 @react-three/drei@^10 @types/react@^19 @types/react-dom@^19
+```
+
+Do not stage the four bumps across separate PRs — intermediate peer-dep states are invalid (e.g., drei v10 + R3F v8 will not resolve).
+
+### Known Blockers
+
+- The original blocker was **hook errors with React 19** on the v8/v9 matrix — this is the same language used in the existing Tech Debt "React 18 downgrade" bullet above. That blocker is resolved at the upstream level by R3F v9 + drei v10 + React 19 all being GA stable as of 2026-04-20.
+- Upstream status as of 2026-04-20: R3F v9 stable, drei v10 stable, React 19 GA. The blocker is resolved at the ecosystem level; execution of this upgrade is deferred to a future phase based on scheduling, not on ecosystem readiness.
+- React 19.2 reconciler nuance: pin React 19.2.x at execution time to match the tested R3F v9 compatibility matrix (per RESEARCH.md §4). Avoid leading edge pre-releases.
+
+### Per-Package Breaking Changes (Summary)
+
+**R3F v9:**
+- JSX namespace augmentation deprecated — use the exported `ThreeElements` type for JSX-intrinsic element typing instead of relying on global JSX namespace merging.
+- Strict Mode double-render verification is needed for any `useFrame` imperative code to ensure effects are idempotent.
+- Affected in this codebase: `src/three/ThreeViewport.tsx` and `src/three/WalkCameraController.tsx` import sites, plus all `src/three/*Mesh.tsx` files that use JSX intrinsics (`<mesh>`, `<group>`, `<boxGeometry>`, etc.).
+
+**drei v10:**
+- Manual `ContextBridge` component removed — not used in this codebase.
+- Peer-requires `@react-three/fiber@^9` and React 19 — drives the single-PR upgrade pattern above.
+- Existing drei component APIs used here (`OrbitControls`, `Environment`, `PointerLockControls`) are unchanged for our usage patterns.
+
+**React 19:**
+- `forwardRef` is deprecated in favor of ref as a prop — not used anywhere in `src/`.
+- Removed APIs: string refs, `ReactDOM.render`, PropTypes, `defaultProps` on function components — none used in `src/`.
+- Automatic batching unchanged from React 18.
+- Ref cleanup functions are a new capability — opportunity for simplification, not a breaking change.
+
+### Affected Files (at execution time — NOT modified in Phase 27)
+
+Per RESEARCH.md §1 and §2, the following files will need review/changes when the upgrade executes:
+
+- `src/three/ThreeViewport.tsx` — direct R3F + drei imports; `OrbitControls` ref typing update; Strict Mode audit on the camera-restore `useEffect`.
+- `src/three/WalkCameraController.tsx` — direct R3F imports (`useFrame`, `useThree`); smoke-test only, no known API surface break.
+- All `src/three/*Mesh.tsx` files — JSX intrinsics to be typed under the `ThreeElements` type import instead of global JSX namespace.
+- `tsconfig.json` — may need `"types": ["@react-three/fiber"]` per the v9 types resolution pattern.
+- `package.json` — version bumps for react, react-dom, @react-three/fiber, @react-three/drei, @types/react, @types/react-dom.
+
+### Acceptance Criteria (for future execution phase)
+
+Mirroring the acceptance block on GitHub issue #56:
+
+- 3D viewport renders without errors on load.
+- Walk mode (PointerLock) works — camera movement, pointer capture, escape handling.
+- Orbit camera works — pan, zoom, rotate.
+- Textures load on `ProductMesh` (existing async texture pathway intact).
+- All tests pass (once test coverage lands per Test Coverage Gaps section below).
+- No React hook errors in the browser console during navigation, tool switching, or 3D view interaction.
+
+### Citations
+
+- R3F v9 Migration Guide: [r3f.docs.pmnd.rs/tutorials/v9-migration-guide](https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide)
+- React 19 release blog: [react.dev/blog/2024/12/05/react-19](https://react.dev/blog/2024/12/05/react-19)
+- drei releases: [github.com/pmndrs/drei/releases](https://github.com/pmndrs/drei/releases)
+
+### Tracking
+
+GitHub [issue #56](https://github.com/micahbank2/room-cad-renderer/issues/56) is the persistent external tracking artifact for this upgrade and will stay OPEN until execution lands. This `CONCERNS.md` section is the in-repo mirror of that tracking state.
+
 ## Known Bugs
 
 **3D export broken in current state:**

--- a/.planning/phases/27-upgrade-tracking/27-01-PLAN.md
+++ b/.planning/phases/27-upgrade-tracking/27-01-PLAN.md
@@ -1,0 +1,224 @@
+---
+phase: 27-upgrade-tracking
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .planning/codebase/CONCERNS.md
+autonomous: true
+requirements: [TRACK-01]
+must_haves:
+  truths:
+    - "CONCERNS.md contains a `## R3F v9 / React 19 Upgrade` heading"
+    - "The new section names all three target majors (`^9.0.0`, `^10.0.0`, `^19.0.0`)"
+    - "The new section contains the fixed sequence phrase `R3F v9 → drei v10 → React 19`"
+    - "The new section cites at least one canonical upstream link (R3F v9 migration guide or React 19 blog)"
+    - "The new section documents current pinned versions verbatim from package.json"
+    - "The new section mentions the React 19 hook-error blocker language consistent with existing Tech Debt bullet"
+  artifacts:
+    - path: .planning/codebase/CONCERNS.md
+      provides: "New `## R3F v9 / React 19 Upgrade` section appended below existing Tech Debt list"
+      contains: "## R3F v9 / React 19 Upgrade"
+  key_links:
+    - from: .planning/codebase/CONCERNS.md
+      to: "R3F v9 migration guide"
+      via: "markdown link"
+      pattern: "r3f\\.docs\\.pmnd\\.rs/tutorials/v9-migration-guide"
+    - from: .planning/codebase/CONCERNS.md
+      to: "GitHub issue #56"
+      via: "markdown link or issue reference"
+      pattern: "issues/56|#56"
+---
+
+<objective>
+Add a new `## R3F v9 / React 19 Upgrade` section to `.planning/codebase/CONCERNS.md` that documents the full upgrade path per user decisions D-01 through D-04.
+
+Purpose: Capture the upgrade plan as a persistent in-repo artifact so that when R3F v9 stabilization timing aligns with a future execution phase, the target versions, sequence, blockers, and affected files are already written down. Satisfies TRACK-01 success criterion #1.
+
+Output: An appended section in `.planning/codebase/CONCERNS.md` covering: Current State, Target Versions, Upgrade Sequence, Known Blockers, Per-Package Breaking Changes (summary), Affected Files, Acceptance Criteria, and Citations.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/codebase/CONCERNS.md
+@.planning/phases/27-upgrade-tracking/27-CONTEXT.md
+@.planning/phases/27-upgrade-tracking/27-RESEARCH.md
+@.planning/phases/27-upgrade-tracking/27-VALIDATION.md
+@package.json
+
+<interfaces>
+Current pinned versions (verified from package.json 2026-04-20):
+- `react` ^18.3.1
+- `react-dom` ^18.3.1
+- `@types/react` ^18.3.18
+- `@types/react-dom` ^18.3.5
+- `@react-three/fiber` ^8.17.14
+- `@react-three/drei` ^9.122.0
+- `three` ^0.183.2
+- `@types/three` ^0.183.1
+
+Target versions (per D-02, locked):
+- `react` ^19.0.0
+- `react-dom` ^19.0.0
+- `@react-three/fiber` ^9.0.0
+- `@react-three/drei` ^10.0.0
+- `three` unchanged
+- `@types/react` / `@types/react-dom` ^19.0.0
+
+Files in src/ that import @react-three/fiber or @react-three/drei (per RESEARCH.md §1):
+- src/three/ThreeViewport.tsx (Canvas, useFrame, OrbitControls, Environment, PointerLockControls)
+- src/three/WalkCameraController.tsx (useFrame, useThree)
+
+Canonical citations (per D-03 and RESEARCH.md §8 "Recommended minimum citations"):
+- https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide
+- https://react.dev/blog/2024/12/05/react-19
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Append new upgrade section to CONCERNS.md</name>
+  <files>.planning/codebase/CONCERNS.md</files>
+  <read_first>
+    - .planning/codebase/CONCERNS.md (the file being edited — note existing structure: `## Tech Debt` list at top, then `## Known Bugs`, `## Security Considerations`, etc. New section goes BELOW the Tech Debt bullets but before `## Known Bugs`, OR at the bottom of the file — planner discretion, but D-04 says "below the existing Tech Debt bulleted list")
+    - .planning/phases/27-upgrade-tracking/27-RESEARCH.md §1 (Current State — table of current + target versions)
+    - .planning/phases/27-upgrade-tracking/27-RESEARCH.md §2 (R3F v9 breaking changes relevant to this codebase)
+    - .planning/phases/27-upgrade-tracking/27-RESEARCH.md §3 (drei v10 breaking changes)
+    - .planning/phases/27-upgrade-tracking/27-RESEARCH.md §4 (React 19 changes relevant to SPA)
+    - .planning/phases/27-upgrade-tracking/27-RESEARCH.md §5 (Known Blockers — hook error class fixed by v9)
+    - .planning/phases/27-upgrade-tracking/27-RESEARCH.md §6 (Upgrade Sequence Verification — peer-dep rationale)
+    - .planning/phases/27-upgrade-tracking/27-RESEARCH.md §7 (Release Status)
+    - .planning/phases/27-upgrade-tracking/27-CONTEXT.md D-01 through D-04 (locked decisions)
+    - package.json (verify current pinned versions before writing them)
+  </read_first>
+  <action>
+Append a new section to `.planning/codebase/CONCERNS.md` immediately after the last bullet of the `## Tech Debt` list (i.e., after the "Library view filter checkboxes are non-functional" bullet, and before `## Known Bugs`). Use the EXACT heading text:
+
+```
+## R3F v9 / React 19 Upgrade
+```
+
+The section MUST include the following subsections and values (copy exactly — no paraphrasing of version strings, heading text, or the sequence phrase):
+
+### Current State
+A short paragraph plus a table listing the current pinned versions (read these from package.json at execute time; as of 2026-04-20 the verified values are):
+- `react` `^18.3.1`
+- `react-dom` `^18.3.1`
+- `@types/react` `^18.3.18`
+- `@types/react-dom` `^18.3.5`
+- `@react-three/fiber` `^8.17.14`
+- `@react-three/drei` `^9.122.0`
+- `three` `^0.183.2`
+- `@types/three` `^0.183.1`
+
+### Target Versions
+Table listing target pinned versions (per D-02):
+- `react` `^19.0.0`
+- `react-dom` `^19.0.0`
+- `@types/react` `^19.0.0`
+- `@types/react-dom` `^19.0.0`
+- `@react-three/fiber` `^9.0.0`
+- `@react-three/drei` `^10.0.0`
+- `three` unchanged
+- `@types/three` unchanged
+
+Note the conceptual latest stables verified during research (R3F 9.6.0, drei 10.7.7, React 19.2.x) but pin to the major ranges per D-02.
+
+### Upgrade Sequence
+Write the phrase `R3F v9 → drei v10 → React 19` exactly (D-02 locked sequence). Explain in prose that this is the CONCEPTUAL sequence (R3F v9 is the gatekeeper because drei v10 peer-requires R3F v9, and React 19 is peer-required by both); in practice a single-PR `npm install` covers all four peer-deps at once (per RESEARCH.md §6 Option A). Include the example install command from RESEARCH.md §6 Option A:
+```
+npm install react@^19 react-dom@^19 @react-three/fiber@^9 @react-three/drei@^10 @types/react@^19 @types/react-dom@^19
+```
+
+### Known Blockers
+- Use the exact phrase "hook errors with React 19" (language consistent with existing Tech Debt bullet — required per CONTEXT §specifics).
+- State that upstream status as of 2026-04-20 shows R3F v9 stable, drei v10 stable, React 19 GA — so the blocker is resolved at upstream level; execution is deferred to a future phase, not blocked on ecosystem readiness.
+- Note React 19.2 reconciler nuance: pin React 19.2.x at execution time to match tested R3F v9 matrix (per RESEARCH.md §4).
+
+### Per-Package Breaking Changes (Summary)
+Three short subsections or bullet groups — one per package. Pull from RESEARCH.md §2, §3, §4. Include:
+- **R3F v9:** JSX namespace deprecated → use `ThreeElements`; Strict Mode double-render verification needed for `useFrame` imperative code; affected: `src/three/ThreeViewport.tsx` and `src/three/WalkCameraController.tsx` import sites plus all `src/three/*Mesh.tsx` JSX-intrinsic usage.
+- **drei v10:** Manual `ContextBridge` removed (not used here); peer-requires `@react-three/fiber@^9` and React 19; existing drei component API (OrbitControls, Environment, PointerLockControls) unchanged for our usage.
+- **React 19:** `forwardRef` deprecated (not used in `src/`); removed string refs / `ReactDOM.render` / PropTypes / defaultProps (not used); automatic batching unchanged; ref cleanup functions (opportunity, not a break).
+
+### Affected Files (at execution time — NOT modified in Phase 27)
+List the exact file paths from RESEARCH.md §1 and §2:
+- `src/three/ThreeViewport.tsx` — direct imports; `OrbitControls` ref typing; Strict Mode audit on camera restore useEffect
+- `src/three/WalkCameraController.tsx` — direct imports; smoke-test only
+- All `src/three/*Mesh.tsx` files — JSX intrinsics under `ThreeElements` type
+- `tsconfig.json` — may need `"types": ["@react-three/fiber"]` per v9 types pattern
+- `package.json` — version bumps
+
+### Acceptance Criteria (for future execution phase)
+Mirror the issue #56 acceptance block: 3D viewport renders, walk mode works, orbit camera works, textures load, all tests pass, no hook errors in console.
+
+### Citations
+Include at least these two markdown links (per D-03 minimum citations):
+- R3F v9 Migration Guide: https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide
+- React 19 release blog: https://react.dev/blog/2024/12/05/react-19
+
+May optionally include drei releases link: https://github.com/pmndrs/drei/releases
+
+### Tracking
+Note that GitHub issue #56 is the persistent tracking artifact and will stay OPEN until execution lands. Include a markdown link: `[issue #56](https://github.com/micahbank2/room-cad-renderer/issues/56)`.
+
+**Strict rules:**
+- Do NOT modify any other section of CONCERNS.md in this task (the Tech Debt "React 18 downgrade" bullet rewrite is a separate plan — 27-02).
+- Do NOT change any file outside `.planning/codebase/CONCERNS.md`.
+- Do NOT edit `package.json` (D-07) — this is a documentation-only phase.
+- Do NOT edit anything in `src/` (D-08).
+  </action>
+  <verify>
+    <automated>rg -n "^## R3F v9 / React 19 Upgrade$" .planning/codebase/CONCERNS.md && rg -c "\\^9\\.0\\.0" .planning/codebase/CONCERNS.md && rg -c "\\^10\\.0\\.0" .planning/codebase/CONCERNS.md && rg -c "\\^19\\.0\\.0" .planning/codebase/CONCERNS.md && rg -F "R3F v9 → drei v10 → React 19" .planning/codebase/CONCERNS.md && rg -F "r3f.docs.pmnd.rs/tutorials/v9-migration-guide" .planning/codebase/CONCERNS.md && rg -F "hook errors with React 19" .planning/codebase/CONCERNS.md && test -z "$(git diff package.json)" && test -z "$(git status --porcelain -- src/)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "^## R3F v9 / React 19 Upgrade$" .planning/codebase/CONCERNS.md` returns exactly one match (heading present)
+    - `rg -F "^9.0.0" .planning/codebase/CONCERNS.md` returns at least one match (R3F v9 target)
+    - `rg -F "^10.0.0" .planning/codebase/CONCERNS.md` returns at least one match (drei v10 target)
+    - `rg -F "^19.0.0" .planning/codebase/CONCERNS.md` returns at least one match (React 19 target)
+    - `rg -F "R3F v9 → drei v10 → React 19" .planning/codebase/CONCERNS.md` returns at least one match (sequence phrase verbatim, including the arrow character →)
+    - `rg -F "r3f.docs.pmnd.rs/tutorials/v9-migration-guide" .planning/codebase/CONCERNS.md` returns at least one match (R3F canonical citation)
+    - `rg -F "react.dev/blog/2024/12/05/react-19" .planning/codebase/CONCERNS.md` returns at least one match (React 19 canonical citation)
+    - `rg -F "hook errors with React 19" .planning/codebase/CONCERNS.md` returns at least one match (blocker language matches existing Tech Debt bullet)
+    - `rg -F "^18.3.1" .planning/codebase/CONCERNS.md` returns at least one match (current React version documented)
+    - `rg -F "^8.17.14" .planning/codebase/CONCERNS.md` returns at least one match (current R3F version documented)
+    - `rg -F "^9.122.0" .planning/codebase/CONCERNS.md` returns at least one match (current drei version documented)
+    - `rg -F "src/three/ThreeViewport.tsx" .planning/codebase/CONCERNS.md` returns at least one match (affected file named)
+    - `git diff package.json` produces no output (D-07 guardrail)
+    - `git status --porcelain -- src/` produces no output (D-08 guardrail)
+  </acceptance_criteria>
+  <done>
+    New `## R3F v9 / React 19 Upgrade` section committed in `.planning/codebase/CONCERNS.md` containing all required subsections, exact version strings, locked sequence phrase, blocker language, canonical citations, and affected-files list. No changes to `package.json` or `src/`.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+Run the full acceptance command from Task 1 verify block. Additionally confirm:
+- `wc -l .planning/codebase/CONCERNS.md` shows the file is longer than the 172 baseline lines (grew by the new section)
+- `git diff --stat .planning/codebase/CONCERNS.md` shows only additions (no deletions in this plan — deletions belong to 27-02)
+</verification>
+
+<success_criteria>
+- `## R3F v9 / React 19 Upgrade` heading exists exactly once in CONCERNS.md
+- All three target majors (^9.0.0, ^10.0.0, ^19.0.0) present
+- Sequence phrase "R3F v9 → drei v10 → React 19" present verbatim
+- At least one canonical link present (R3F migration guide OR React 19 blog — both recommended)
+- `git diff package.json` is empty
+- `git status -- src/` is empty
+- Plan contributes to TRACK-01 acceptance checks 1, 2, 3 (VALIDATION.md)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/27-upgrade-tracking/27-01-SUMMARY.md` per template.
+</output>

--- a/.planning/phases/27-upgrade-tracking/27-01-SUMMARY.md
+++ b/.planning/phases/27-upgrade-tracking/27-01-SUMMARY.md
@@ -1,0 +1,125 @@
+---
+phase: 27-upgrade-tracking
+plan: 01
+subsystem: docs
+tags: [react, react-three-fiber, drei, three, upgrade-tracking, concerns]
+
+# Dependency graph
+requires:
+  - phase: 27-upgrade-tracking
+    provides: "CONTEXT.md decisions D-01..D-04, RESEARCH.md current+target versions, VALIDATION.md TRACK-01 criteria"
+provides:
+  - "New `## R3F v9 / React 19 Upgrade` section in `.planning/codebase/CONCERNS.md` documenting current pinned versions, target majors, locked upgrade sequence, known blockers, per-package breaking changes, affected files, acceptance criteria, and canonical citations"
+  - "In-repo mirror of GitHub issue #56 tracking state so the upgrade plan persists across sessions"
+affects: [27-02-PLAN (rewrite Tech Debt bullet as pointer), 27-03-PLAN (README roadmap line), future-r3f-v9-upgrade-execution-phase]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Documentation-only phase pattern: append new CONCERNS.md section with verbatim version strings and canonical upstream citations"
+
+key-files:
+  created: []
+  modified:
+    - ".planning/codebase/CONCERNS.md"
+
+key-decisions:
+  - "Placed new section between the last Tech Debt bullet (Library view filter checkboxes) and `## Known Bugs` — matches D-04 placement guidance ('below the existing Tech Debt bulleted list')"
+  - "Included all three canonical citation candidates (R3F v9 guide, React 19 blog, drei releases) even though D-03 only required the first two, since the third is low-cost and satisfies RESEARCH.md §8 recommended-minimum completeness"
+  - "Documented both the conceptual sequence (R3F v9 → drei v10 → React 19) and the practical single-PR install command, per RESEARCH.md §6 Option A — prevents a future executor from staging the four peer-dep bumps across separate PRs into invalid intermediate states"
+
+patterns-established:
+  - "Upgrade-tracking-in-CONCERNS.md: document deferred major-version upgrades as a structured section with Current State / Target Versions / Upgrade Sequence / Known Blockers / Per-Package Breaking Changes / Affected Files / Acceptance Criteria / Citations / Tracking subsections, mirrored against an open GitHub issue"
+
+requirements-completed: [TRACK-01]
+
+# Metrics
+duration: ~10min
+completed: 2026-04-20
+---
+
+# Phase 27 Plan 01: Document R3F v9 / React 19 Upgrade in CONCERNS.md Summary
+
+**Appended a structured 105-line `## R3F v9 / React 19 Upgrade` section to `.planning/codebase/CONCERNS.md` capturing current pinned versions, locked target majors (`^9.0.0` R3F, `^10.0.0` drei, `^19.0.0` React), upgrade sequence, upstream blocker status, affected files, and canonical citations — no `package.json` or `src/` changes.**
+
+## Performance
+
+- **Duration:** ~10 min
+- **Started:** 2026-04-20T17:55Z (approx)
+- **Completed:** 2026-04-20T18:05:24Z
+- **Tasks:** 1 / 1
+- **Files modified:** 1
+
+## Accomplishments
+
+- In-repo tracking artifact for the deferred React 19 + R3F v9 + drei v10 upgrade now lives in `CONCERNS.md`, satisfying TRACK-01 success criterion #1.
+- All current pinned versions verified verbatim against `package.json` at execute time (react ^18.3.1, @react-three/fiber ^8.17.14, @react-three/drei ^9.122.0, etc.) and recorded in a structured table alongside target majors.
+- Locked upgrade sequence `R3F v9 → drei v10 → React 19` captured with the exact arrow character, and the practical single-PR `npm install` command is included to prevent invalid intermediate peer-dep states.
+- Canonical upstream citations present: R3F v9 migration guide, React 19 release blog, drei releases.
+- GitHub [issue #56](https://github.com/micahbank2/room-cad-renderer/issues/56) is linked as the persistent external tracking artifact.
+- Zero changes to `package.json` (D-07) and zero changes to anything in `src/` (D-08).
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Append new upgrade section to CONCERNS.md** — `4f7ebe5` (docs)
+
+**Plan metadata commit:** (to be created after this SUMMARY + STATE + ROADMAP updates)
+
+## Files Created/Modified
+
+- `.planning/codebase/CONCERNS.md` — appended new `## R3F v9 / React 19 Upgrade` section between the last Tech Debt bullet and `## Known Bugs`. 105 insertions, 0 deletions. File grew from 172 → 276 lines.
+
+## Decisions Made
+
+- **Placement:** New section placed immediately after the last `## Tech Debt` bullet ("Library view filter checkboxes are non-functional") and before `## Known Bugs`. This matches D-04's "below the existing Tech Debt bulleted list" language and keeps the Tech Debt bullet list intact for plan 27-02 to later rewrite-as-pointer.
+- **Sequence phrase:** Used the exact arrow character `→` (U+2192) per verify block `rg -F "R3F v9 → drei v10 → React 19"` requirement.
+- **Version strings:** Kept every version string backtick-quoted and verbatim from `package.json`, never paraphrased.
+- **Citations:** Included all three candidate canonical links even though only two were required minimum, since the third adds negligible cost and aids future executors.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. All acceptance criteria in the plan's verify block passed on first run (after adjusting an `rg -E` syntax flag during verification, which was a tool-usage issue, not a deviation in output).
+
+## Issues Encountered
+
+- Minor: `rg -E "issues/56|#56"` failed with "unknown encoding" — ripgrep uses default PCRE2/regex without the `-E` flag. Re-ran without `-E` and the pattern matched correctly (two hits in CONCERNS.md). No impact on the output artifact.
+
+## User Setup Required
+
+None — documentation-only phase. No external service configuration or credentials needed.
+
+## Verification Evidence
+
+All acceptance criteria from the plan verify block PASSED:
+
+- `rg -n "^## R3F v9 / React 19 Upgrade$" .planning/codebase/CONCERNS.md` → 1 match (line 91)
+- `rg -c "\^9\.0\.0"` → 1 (target R3F major present)
+- `rg -c "\^10\.0\.0"` → 1 (target drei major present)
+- `rg -c "\^19\.0\.0"` → 4 (target React/react-dom/@types occurrences present)
+- `rg -F "R3F v9 → drei v10 → React 19"` → 1 match (sequence phrase verbatim)
+- `rg -F "r3f.docs.pmnd.rs/tutorials/v9-migration-guide"` → 1 match
+- `rg -F "react.dev/blog/2024/12/05/react-19"` → 1 match
+- `rg -F "hook errors with React 19"` → 2 matches (consistent with existing Tech Debt bullet)
+- Current version strings (`^18.3.1`, `^8.17.14`, `^9.122.0`, `^18.3.18`, `^18.3.5`) all present
+- `src/three/ThreeViewport.tsx` named in Affected Files
+- `issues/56` reference present (2 hits)
+- `git diff package.json` → empty (D-07 PASS)
+- `git status --porcelain -- src/` → empty (D-08 PASS)
+- `git diff --stat .planning/codebase/CONCERNS.md` → `105 insertions(+)`, 0 deletions — confirms "additions only" rule from verification block
+
+## Self-Check: PASSED
+
+File `.planning/codebase/CONCERNS.md` exists and contains the new section at line 91.
+Commit `4f7ebe5` exists in `git log --oneline`.
+
+## Next Phase Readiness
+
+- Wave 1 gate complete for phase 27. Wave 2 plans `27-02` (rewrite Tech Debt "React 18 downgrade" bullet as pointer to the new section) and `27-03` (README roadmap line) are now unblocked and can proceed in parallel.
+- No blockers for the future execution phase that will actually perform the upgrade — upstream ecosystem is GA-ready per RESEARCH.md §7. Execution timing is a scheduling decision, not a technical blocker.
+
+---
+*Phase: 27-upgrade-tracking*
+*Completed: 2026-04-20*

--- a/.planning/phases/27-upgrade-tracking/27-02-PLAN.md
+++ b/.planning/phases/27-upgrade-tracking/27-02-PLAN.md
@@ -1,0 +1,136 @@
+---
+phase: 27-upgrade-tracking
+plan: 02
+type: execute
+wave: 2
+depends_on: ["27-01"]
+files_modified:
+  - .planning/codebase/CONCERNS.md
+autonomous: true
+requirements: [TRACK-01]
+must_haves:
+  truths:
+    - "The existing 'React 18 downgrade' bullet in Tech Debt has been rewritten as a pointer to the new `## R3F v9 / React 19 Upgrade` section"
+    - "No duplicate content exists between the pointer bullet and the full new section"
+    - "The Tech Debt list remains scannable (short pointer, not a duplicated plan)"
+  artifacts:
+    - path: .planning/codebase/CONCERNS.md
+      provides: "Updated Tech Debt bullet that references the new section"
+      contains: "see § R3F v9 / React 19 Upgrade"
+  key_links:
+    - from: "Tech Debt: React 18 downgrade bullet"
+      to: "## R3F v9 / React 19 Upgrade section"
+      via: "prose pointer"
+      pattern: "see .*R3F v9 / React 19 Upgrade"
+---
+
+<objective>
+Rewrite the existing "React 18 downgrade (was React 19):" bullet at the top of the `## Tech Debt` list in `.planning/codebase/CONCERNS.md` to be a short pointer to the new section created in plan 27-01.
+
+Purpose: Per D-04, the Tech Debt list must stay scannable. The detailed upgrade plan now lives in its dedicated section (added by 27-01). The Tech Debt bullet should become a one-line pointer so readers scanning the list still see the debt item but get the full plan by following the reference. Satisfies VALIDATION.md acceptance check #4.
+
+Output: Updated "React 18 downgrade" bullet that points to the new `## R3F v9 / React 19 Upgrade` section, with all detailed fix content removed (it's redundant with the new section).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/codebase/CONCERNS.md
+@.planning/phases/27-upgrade-tracking/27-CONTEXT.md
+@.planning/phases/27-upgrade-tracking/27-RESEARCH.md
+@.planning/phases/27-upgrade-tracking/27-VALIDATION.md
+@.planning/phases/27-upgrade-tracking/27-01-PLAN.md
+
+<interfaces>
+Current bullet (CONCERNS.md lines 7-11, verbatim — verify at execute time):
+
+```
+**React 18 downgrade (was React 19):**
+- Issue: React was pinned to `^18.3.1` to maintain compatibility with `@react-three/fiber` v8 and `@react-three/drei` v9, which do not fully support React 19. This is an explicit constraint, not an oversight.
+- Files: `package.json`
+- Impact: Cannot use React 19 features (server components, improved `use()` hook, improved transitions). Will need to track R3F's React 19 support timeline.
+- Fix approach: Upgrade to `@react-three/fiber` v9 (when stable) before bumping React to 19.
+```
+
+Target structure per D-04: "Keep the existing short React 18 downgrade bullet in Tech Debt as a pointer ('see § R3F v9 / React 19 Upgrade below') so that section remains scannable."
+
+Existing CONCERNS.md Tech Debt format (four-field bullets): Issue / Files / Impact / Fix approach — preserve this shape per CONTEXT §code_context "Reusable Assets".
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Rewrite the React 18 downgrade bullet as a pointer</name>
+  <files>.planning/codebase/CONCERNS.md</files>
+  <read_first>
+    - .planning/codebase/CONCERNS.md lines 1-15 (the existing bullet to rewrite — locate exactly; in the current file it lives at lines 7-11, but execute-time line numbers may have shifted after plan 27-01 if 27-01 inserted above it; the heading `**React 18 downgrade (was React 19):**` is the anchor)
+    - .planning/codebase/CONCERNS.md entire file — confirm the new `## R3F v9 / React 19 Upgrade` section exists (plan 27-01 precondition)
+    - .planning/phases/27-upgrade-tracking/27-CONTEXT.md D-04 (rewrite-as-pointer directive)
+    - .planning/phases/27-upgrade-tracking/27-VALIDATION.md acceptance #4 ("the existing 'React 18 downgrade' bullet in Tech Debt has been rewritten as a pointer to the new section")
+  </read_first>
+  <action>
+Locate the bullet headed by `**React 18 downgrade (was React 19):**` in `.planning/codebase/CONCERNS.md` (currently lines 7-11 of the file). Replace it with a short pointer bullet that preserves the four-field shape (Issue / Files / Impact / Fix approach) but whose Fix-approach field directs the reader to the new section.
+
+Replacement content (use this exact structure; prose may be adjusted for flow but MUST retain the "see § R3F v9 / React 19 Upgrade" reference and MUST NOT duplicate the detailed content that now lives in the new section):
+
+```
+**React 18 downgrade (was React 19):**
+- Issue: React is pinned to `^18.3.1` because `@react-three/fiber` v8 and `@react-three/drei` v9 had hook errors with React 19 at the time the pin was set.
+- Files: `package.json`
+- Impact: Cannot use React 19 features (improved `use()` hook, improved transitions, ref cleanup functions).
+- Fix approach: see § R3F v9 / React 19 Upgrade below for the full upgrade plan (target versions, sequence, affected files, citations). Tracked in [issue #56](https://github.com/micahbank2/room-cad-renderer/issues/56).
+```
+
+**Strict rules:**
+- Do NOT remove the bullet entirely — keep it as a scannable entry in the Tech Debt list.
+- Do NOT duplicate the detailed upgrade content (target versions, sequence, per-package breaking changes) inside this bullet — that lives in the new section only.
+- Do NOT edit any other Tech Debt bullet.
+- Do NOT edit `package.json` (D-07) or anything in `src/` (D-08).
+- Preserve the existing four-field bullet shape used throughout the Tech Debt list.
+
+**Important:** This plan depends on 27-01 having landed the `## R3F v9 / React 19 Upgrade` section. If that section is missing, this task's pointer would dangle — abort and report back.
+  </action>
+  <verify>
+    <automated>rg -F "see § R3F v9 / React 19 Upgrade" .planning/codebase/CONCERNS.md && rg -n "^\\*\\*React 18 downgrade" .planning/codebase/CONCERNS.md && rg -n "^## R3F v9 / React 19 Upgrade$" .planning/codebase/CONCERNS.md && ! rg -F "Upgrade to `@react-three/fiber` v9 (when stable) before bumping React to 19" .planning/codebase/CONCERNS.md && test -z "$(git diff package.json)" && test -z "$(git status --porcelain -- src/)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -F "see § R3F v9 / React 19 Upgrade" .planning/codebase/CONCERNS.md` returns at least one match (pointer text present)
+    - `rg -n "^\\*\\*React 18 downgrade" .planning/codebase/CONCERNS.md` still returns exactly one match (bullet kept, not removed)
+    - `rg -n "^## R3F v9 / React 19 Upgrade$" .planning/codebase/CONCERNS.md` returns exactly one match (the pointer target section still exists from plan 27-01)
+    - `rg -F "Upgrade to \`@react-three/fiber\` v9 (when stable) before bumping React to 19" .planning/codebase/CONCERNS.md` returns ZERO matches (old detailed Fix-approach wording replaced)
+    - `rg -F "issues/56" .planning/codebase/CONCERNS.md` returns at least one match (tracking issue linked)
+    - `git diff package.json` produces no output (D-07 guardrail)
+    - `git status --porcelain -- src/` produces no output (D-08 guardrail)
+    - `git diff .planning/codebase/CONCERNS.md` shows both additions (pointer) AND deletions (old Fix-approach line)
+  </acceptance_criteria>
+  <done>
+    "React 18 downgrade" Tech Debt bullet rewritten as a short pointer to the new `## R3F v9 / React 19 Upgrade` section. Detailed fix content removed. Bullet still discoverable via scan of the Tech Debt list. Tracking issue #56 linked from the pointer.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+Run acceptance commands from Task 1 verify block. Additionally:
+- Visual inspection: Tech Debt list reads cleanly top-to-bottom; the React 18 bullet is now ~4 lines not ~5-lines-of-detail.
+- `git diff .planning/codebase/CONCERNS.md` shows the replacement is surgical (not a full-file rewrite).
+</verification>
+
+<success_criteria>
+- Tech Debt "React 18 downgrade" bullet present but rewritten to pointer form
+- Pointer phrase "see § R3F v9 / React 19 Upgrade" exists verbatim
+- Old detailed Fix-approach content removed (no duplication with new section)
+- Pointer target section from plan 27-01 still exists
+- `git diff package.json` is empty
+- `git status -- src/` is empty
+- Plan closes VALIDATION.md acceptance check #4
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/27-upgrade-tracking/27-02-SUMMARY.md` per template.
+</output>

--- a/.planning/phases/27-upgrade-tracking/27-02-SUMMARY.md
+++ b/.planning/phases/27-upgrade-tracking/27-02-SUMMARY.md
@@ -1,0 +1,95 @@
+---
+phase: 27-upgrade-tracking
+plan: 02
+subsystem: docs
+tags: [concerns, tech-debt, react-19, r3f-v9, pointer-refactor]
+
+requires:
+  - phase: 27-upgrade-tracking
+    provides: "## R3F v9 / React 19 Upgrade section in CONCERNS.md (added by plan 27-01)"
+provides:
+  - "Tech Debt 'React 18 downgrade' bullet rewritten as short pointer to the new section"
+  - "Removed duplicated detailed fix content from Tech Debt list"
+  - "Inline link to tracking issue #56 from the pointer bullet"
+affects: [future-react-19-execution-phase, concerns-maintenance]
+
+tech-stack:
+  added: []
+  patterns: ["Tech Debt bullets referencing a dedicated section instead of duplicating its plan"]
+
+key-files:
+  created: []
+  modified:
+    - .planning/codebase/CONCERNS.md
+
+key-decisions:
+  - "Kept the four-field bullet shape (Issue / Files / Impact / Fix approach) for consistency with the rest of the Tech Debt list"
+  - "Linked GitHub issue #56 directly from the Fix-approach line so scanners can jump to the persistent tracker"
+
+patterns-established:
+  - "Pointer-bullet pattern: when a Tech Debt item has a dedicated full-plan section in CONCERNS.md, the Tech Debt bullet shrinks to a pointer ('see § …') to keep the list scannable"
+
+requirements-completed: [TRACK-01]
+
+duration: 3min
+completed: 2026-04-20
+---
+
+# Phase 27 Plan 02: Tech Debt Pointer Rewrite Summary
+
+**Rewrote the 'React 18 downgrade' Tech Debt bullet in CONCERNS.md into a 4-line pointer to the new `## R3F v9 / React 19 Upgrade` section, removing duplicated fix detail and linking tracking issue #56.**
+
+## Performance
+
+- **Duration:** ~3 min
+- **Started:** 2026-04-20T18:07:20Z (approx)
+- **Completed:** 2026-04-20T18:08:30Z
+- **Tasks:** 1
+- **Files modified:** 1
+
+## Accomplishments
+- Shortened the Tech Debt React 18 bullet to a pointer while preserving its four-field shape
+- Eliminated duplicated upgrade plan content between the bullet and the new full section
+- Added inline reference to GitHub tracking issue #56 from the Fix-approach line
+
+## Task Commits
+
+1. **Task 1: Rewrite the React 18 downgrade bullet as a pointer** - `8d1aac5` (docs)
+
+## Files Created/Modified
+- `.planning/codebase/CONCERNS.md` — replaced lines 7-11 with a pointer-style bullet (3 insertions, 3 deletions; surgical edit, full section at line 91 untouched)
+
+## Decisions Made
+- Preserved the four-field bullet shape used across all Tech Debt entries rather than collapsing to a one-liner — keeps the list visually uniform while still removing duplicated content.
+- Linked issue #56 directly in the pointer bullet so scanners hitting Tech Debt first can jump straight to the external tracker without needing to scroll to the full section.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- VALIDATION.md acceptance check #4 (Tech Debt bullet rewritten as pointer) is satisfied.
+- Plan 27-03 (requirements + traceability updates) is unblocked and runs in parallel in Wave 2.
+- No `package.json` or `src/` changes: D-07 and D-08 guardrails honored (verified via `git diff package.json` + `git status --porcelain -- src/`, both empty).
+
+---
+*Phase: 27-upgrade-tracking*
+*Completed: 2026-04-20*
+
+## Self-Check: PASSED
+
+- FOUND: .planning/codebase/CONCERNS.md
+- FOUND: .planning/phases/27-upgrade-tracking/27-02-SUMMARY.md
+- FOUND commit: 8d1aac5 (Task 1)
+- Verified: pointer text "see § R3F v9 / React 19 Upgrade" present
+- Verified: old Fix-approach wording absent
+- Verified: `## R3F v9 / React 19 Upgrade` target section still exists at line 91
+- Verified: `git diff package.json` empty, `git status -- src/` empty

--- a/.planning/phases/27-upgrade-tracking/27-03-PLAN.md
+++ b/.planning/phases/27-upgrade-tracking/27-03-PLAN.md
@@ -1,0 +1,194 @@
+---
+phase: 27-upgrade-tracking
+plan: 03
+type: execute
+wave: 2
+depends_on: ["27-01"]
+files_modified: []
+autonomous: true
+requirements: [TRACK-01]
+user_setup:
+  - service: github-cli
+    why: "Post a comment on GitHub issue #56"
+    env_vars: []
+    dashboard_config:
+      - task: "Ensure `gh` CLI is authenticated (already authenticated per recent Phase 26 work on issues #42 / #43)"
+        location: "Terminal: `gh auth status`"
+must_haves:
+  truths:
+    - "GitHub issue #56 has a new comment posted"
+    - "GitHub issue #56 state remains OPEN after the comment"
+    - "The comment body references the new `## R3F v9 / React 19 Upgrade` section in CONCERNS.md"
+    - "The comment body includes the locked sequence phrase `R3F v9 → drei v10 → React 19`"
+    - "The comment body names all three target majors (^9.0.0, ^10.0.0, ^19.0.0)"
+  artifacts:
+    - path: "GitHub issue #56"
+      provides: "New comment summarizing the documented upgrade plan"
+      contains: "R3F v9 → drei v10 → React 19"
+  key_links:
+    - from: "Issue #56 new comment"
+      to: ".planning/codebase/CONCERNS.md § R3F v9 / React 19 Upgrade"
+      via: "markdown link to repo file path"
+      pattern: "\\.planning/codebase/CONCERNS\\.md"
+---
+
+<objective>
+Post a new comment on GitHub issue #56 that summarizes the documented upgrade plan and links back to the new `## R3F v9 / React 19 Upgrade` section added in plan 27-01. Leave the issue OPEN (D-05), do not change milestone/labels/assignees (D-06).
+
+Purpose: Satisfies TRACK-01 acceptance check #2 (GitHub issue #56 updated with the documented upgrade plan and stays open as the tracking artifact) and VALIDATION.md acceptance check #7 (issue has a new comment, state still OPEN). Keeps GitHub issue in sync with in-repo documentation so the issue is a usable index into the plan.
+
+Output: One new comment on issue #56 with the plan summary and repo link. Zero other changes.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/phases/27-upgrade-tracking/27-CONTEXT.md
+@.planning/phases/27-upgrade-tracking/27-RESEARCH.md
+@.planning/phases/27-upgrade-tracking/27-VALIDATION.md
+@.planning/phases/27-upgrade-tracking/27-01-PLAN.md
+
+<interfaces>
+D-05 (locked): Add a comment to issue #56 linking to the new CONCERNS.md section. Do NOT rewrite the issue body. Issue stays OPEN.
+D-06 (locked): No milestone / label / assignee changes on #56.
+D-07 (locked): Zero `package.json` changes in this phase.
+D-08 (locked): No changes to any `src/` files.
+
+Upstream status (per RESEARCH.md §5 and §7, verified 2026-04-20):
+- R3F v9 stable (latest 9.6.0)
+- drei v10 stable (latest 10.7.7)
+- React 19 GA (19.2.x)
+- Original "hook error" blocker resolved upstream by R3F v9
+
+Canonical citations (per D-03):
+- https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide
+- https://react.dev/blog/2024/12/05/react-19
+
+gh CLI pattern (already authenticated per STATE.md Phase 26 closeout of #42/#43):
+```
+gh issue comment 56 --body-file <path-to-comment-body.md>
+gh issue view 56 --json state,comments
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Post upgrade-plan comment on GitHub issue #56</name>
+  <files></files>
+  <read_first>
+    - .planning/codebase/CONCERNS.md (confirm the `## R3F v9 / React 19 Upgrade` section exists from plan 27-01 — this comment links to it)
+    - .planning/phases/27-upgrade-tracking/27-CONTEXT.md D-05, D-06, D-07, D-08 (scope guardrails for this plan)
+    - .planning/phases/27-upgrade-tracking/27-RESEARCH.md §5 (Known Blockers — "upstream ready, execution deferred" framing)
+    - .planning/phases/27-upgrade-tracking/27-VALIDATION.md acceptance #7 (issue has new comment, state OPEN)
+    - Run `gh issue view 56 --json state,title,url` first to confirm issue is currently OPEN and capture its URL
+  </read_first>
+  <action>
+1. Verify gh auth: run `gh auth status`. If not authenticated, stop and surface an auth checkpoint to the user.
+
+2. Verify issue #56 is currently OPEN: run `gh issue view 56 --json state --jq '.state'` — must return `OPEN`. If `CLOSED`, stop and ask the user (do not reopen without direction).
+
+3. Write the comment body to a temp file (e.g., `/tmp/issue-56-comment.md`). Use this structure (prose may be refined but required strings in acceptance_criteria MUST appear verbatim):
+
+```markdown
+## Upgrade plan documented (2026-04-20)
+
+The full R3F v9 / React 19 upgrade plan is now documented in-repo at [`.planning/codebase/CONCERNS.md` § R3F v9 / React 19 Upgrade](https://github.com/micahbank2/room-cad-renderer/blob/main/.planning/codebase/CONCERNS.md#r3f-v9--react-19-upgrade).
+
+### Target versions
+- `react` `^19.0.0` / `react-dom` `^19.0.0`
+- `@react-three/fiber` `^9.0.0`
+- `@react-three/drei` `^10.0.0`
+- `three` unchanged
+
+### Upgrade sequence
+R3F v9 → drei v10 → React 19
+
+(R3F v9 is the gatekeeper: drei v10 peer-requires fiber v9, and both peer-require React 19. In practice one `npm install` covers all peer-deps in a single lockfile transaction.)
+
+### Upstream status (as of 2026-04-20)
+- R3F v9: stable (latest 9.6.0)
+- drei v10: stable (latest 10.7.7)
+- React 19: GA (19.2.x)
+- Original "hook errors with React 19" blocker is resolved upstream by R3F v9.
+
+### Canonical references
+- [R3F v9 Migration Guide](https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide)
+- [React 19 release blog](https://react.dev/blog/2024/12/05/react-19)
+
+### Status
+This issue stays OPEN as the tracking artifact. Execution is deferred to a dedicated future phase (not part of v1.5 Phase 27, which is documentation-only). No `package.json` or `src/` changes in this phase.
+```
+
+4. Post the comment:
+```
+gh issue comment 56 --body-file /tmp/issue-56-comment.md
+```
+
+5. Verify:
+```
+gh issue view 56 --json state,comments --jq '{state: .state, comment_count: (.comments | length), latest: .comments[-1].body}'
+```
+Confirm:
+- `state == "OPEN"`
+- Latest comment body contains "R3F v9 → drei v10 → React 19"
+- Latest comment body contains "`.planning/codebase/CONCERNS.md`"
+
+6. Clean up the temp file: `rm /tmp/issue-56-comment.md`
+
+**Strict rules:**
+- Do NOT close the issue (D-05, D-06).
+- Do NOT edit issue body, title, milestone, labels, or assignees (D-06).
+- Do NOT modify `package.json` (D-07).
+- Do NOT modify anything in `src/` (D-08).
+- Do NOT modify `.planning/codebase/CONCERNS.md` in this plan (that belongs to 27-01 / 27-02).
+- This plan's `files_modified` is intentionally empty — the only side effect is the GitHub comment.
+  </action>
+  <verify>
+    <automated>gh issue view 56 --json state --jq '.state' | grep -x "OPEN" && gh issue view 56 --json comments --jq '.comments[-1].body' | grep -F "R3F v9 → drei v10 → React 19" && gh issue view 56 --json comments --jq '.comments[-1].body' | grep -F ".planning/codebase/CONCERNS.md" && gh issue view 56 --json comments --jq '.comments[-1].body' | grep -F "^9.0.0" && gh issue view 56 --json comments --jq '.comments[-1].body' | grep -F "^10.0.0" && gh issue view 56 --json comments --jq '.comments[-1].body' | grep -F "^19.0.0" && test -z "$(git diff package.json)" && test -z "$(git status --porcelain -- src/)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `gh issue view 56 --json state --jq '.state'` returns exactly `OPEN` (D-05, D-06, VALIDATION #7)
+    - `gh issue view 56 --json comments --jq '.comments | length'` returns a number ≥ 1 higher than before this task ran (new comment posted)
+    - Latest comment body contains `R3F v9 → drei v10 → React 19` verbatim (locked sequence)
+    - Latest comment body contains `.planning/codebase/CONCERNS.md` (repo-path reference)
+    - Latest comment body contains `^9.0.0` (R3F target major)
+    - Latest comment body contains `^10.0.0` (drei target major)
+    - Latest comment body contains `^19.0.0` (React target major)
+    - Latest comment body contains at least one of: `r3f.docs.pmnd.rs/tutorials/v9-migration-guide` or `react.dev/blog/2024/12/05/react-19` (canonical citation per D-03)
+    - `gh issue view 56 --json milestone,labels,assignees` returns values unchanged from pre-task snapshot (D-06 — no meta changes)
+    - `git diff package.json` produces no output (D-07 guardrail)
+    - `git status --porcelain -- src/` produces no output (D-08 guardrail)
+    - `git status --porcelain` shows no new or modified files from this plan (files_modified is empty)
+  </acceptance_criteria>
+  <done>
+    New comment posted on GitHub issue #56 summarizing the documented upgrade plan, referencing the `.planning/codebase/CONCERNS.md` section, with locked sequence phrase and all three target majors present. Issue remains OPEN. No repo files modified by this plan.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+Full acceptance check set from Task 1. Additionally:
+- `gh issue view 56 --web` (or browser-visit URL) — manual readability check (listed in VALIDATION.md as the single Manual-Only verification for this phase).
+- Confirm no accidental local file changes: `git status` should be clean after this plan (aside from any SUMMARY.md the execute workflow writes).
+</verification>
+
+<success_criteria>
+- Issue #56 has a new comment with all required content strings
+- Issue #56 state == OPEN
+- Issue #56 milestone / labels / assignees unchanged
+- `git diff package.json` is empty
+- `git status -- src/` is empty
+- Plan closes VALIDATION.md acceptance check #7
+- Phase 27 is now fully executed end-to-end across plans 27-01, 27-02, 27-03
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/27-upgrade-tracking/27-03-SUMMARY.md` per template. Include the issue-comment URL (`gh issue view 56 --json url --jq '.url'` + `#issuecomment-<id>`) as an artifact reference.
+</output>

--- a/.planning/phases/27-upgrade-tracking/27-03-SUMMARY.md
+++ b/.planning/phases/27-upgrade-tracking/27-03-SUMMARY.md
@@ -1,0 +1,126 @@
+---
+phase: 27-upgrade-tracking
+plan: 03
+subsystem: infra
+tags: [github, gh-cli, tracking-issue, documentation, r3f, react-19]
+
+# Dependency graph
+requires:
+  - phase: 27-upgrade-tracking
+    provides: "27-01 wrote the `## R3F v9 / React 19 Upgrade` section in .planning/codebase/CONCERNS.md that this plan links to"
+provides:
+  - "Comment posted on GitHub issue #56 summarizing the documented upgrade plan"
+  - "Tracking issue #56 remains OPEN as the canonical long-lived artifact for the R3F v9 / React 19 upgrade"
+  - "External (GitHub) index in sync with in-repo documentation (CONCERNS.md)"
+affects: [future-r3f-upgrade-execution-phase]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Comment-only sync pattern: repo docs are the source of truth; tracking issue gets a dated comment pointing back to the in-repo section (issue body / milestone / labels / assignees untouched)."
+
+key-files:
+  created:
+    - ".planning/phases/27-upgrade-tracking/27-03-SUMMARY.md"
+  modified: []
+
+key-decisions:
+  - "Post a new comment instead of editing the issue body (D-05 / D-06): preserves original context, creates dated trail."
+  - "Link to CONCERNS.md via absolute GitHub blob URL with anchor so the link works from the GitHub issue page without a checkout."
+  - "Keep issue OPEN — the upgrade is documented but deferred to a future dedicated phase, not executed in v1.5."
+
+patterns-established:
+  - "Tracking-issue-as-index: long-lived GitHub tracking issues stay OPEN and accumulate dated comments linking to in-repo `.planning/codebase/*.md` sections rather than being rewritten."
+  - "Zero-code plan: a GSD plan can ship with `files_modified: []` when the only side effect is on an external system (here, a GitHub comment). Guardrails (D-07, D-08) enforce this via `git diff` / `git status` checks."
+
+requirements-completed: [TRACK-01]
+
+# Metrics
+duration: 4min
+completed: 2026-04-20
+---
+
+# Phase 27 Plan 03: Update GitHub Tracking Issue #56 Summary
+
+**Dated upgrade-plan comment posted on GH issue #56 linking to `.planning/codebase/CONCERNS.md § R3F v9 / React 19 Upgrade`; issue stays OPEN, no repo files modified.**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-04-20T (execution start)
+- **Completed:** 2026-04-20
+- **Tasks:** 1
+- **Files modified:** 0 (repo) — 1 external side effect (GitHub comment)
+
+## Accomplishments
+- Posted comment on issue #56: https://github.com/micahbank2/room-cad-renderer/issues/56#issuecomment-4283199813
+- Verified issue #56 remains OPEN with milestone (`v1.5 Performance & Tech Debt`), label (`enhancement`), and assignees unchanged
+- Satisfied TRACK-01 acceptance #2 and VALIDATION.md acceptance #7
+- Closed out Phase 27 end-to-end across plans 27-01, 27-02, 27-03
+
+## Task Commits
+
+This plan's `files_modified` is intentionally empty — no per-task commit was produced. The only side effect is the GitHub comment (external system). The final metadata commit captures SUMMARY.md + STATE.md + ROADMAP.md updates.
+
+1. **Task 1: Post upgrade-plan comment on GitHub issue #56** — no commit (zero repo changes by design; enforced by D-07 / D-08 guardrails)
+
+**Plan metadata commit:** (final docs commit captures this SUMMARY + STATE + ROADMAP)
+
+## Files Created/Modified
+- `.planning/phases/27-upgrade-tracking/27-03-SUMMARY.md` — this file
+
+**External artifact (not in repo):**
+- GitHub comment on issue #56: https://github.com/micahbank2/room-cad-renderer/issues/56#issuecomment-4283199813
+  - Contains locked sequence phrase: `R3F v9 → drei v10 → React 19`
+  - Contains repo-path reference: `.planning/codebase/CONCERNS.md`
+  - Contains all three target majors: `^9.0.0`, `^10.0.0`, `^19.0.0`
+  - Contains canonical citations: R3F v9 migration guide, React 19 release blog
+
+## Decisions Made
+- **Comment, not issue-body rewrite (D-05 / D-06):** Preserves the original issue context authored by the user; the dated comment forms a chronological trail that future readers can follow.
+- **Absolute GitHub blob URL for the CONCERNS.md link:** Ensures the link resolves from the GitHub issue page for any reader, without requiring a local checkout.
+- **Temp file for the comment body (`/tmp/issue-56-comment.md`), then deleted:** Keeps the multi-line markdown body exact (no shell escaping of `→` or backticks), and leaves no residue in the repo or `/tmp`.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None.
+
+## User Setup Required
+None - `gh` CLI was already authenticated (carried over from Phase 26 work on issues #42 / #43, per STATE.md). No environment variable changes.
+
+## Acceptance Criteria Verification
+
+All Task 1 acceptance criteria verified post-comment:
+
+| Criterion | Result |
+| --- | --- |
+| Issue #56 state == `OPEN` | PASS (`OPEN`) |
+| New comment count ≥ 1 higher (was 0 → now 1) | PASS |
+| Comment body contains `R3F v9 → drei v10 → React 19` | PASS |
+| Comment body contains `.planning/codebase/CONCERNS.md` | PASS |
+| Comment body contains `^9.0.0` | PASS |
+| Comment body contains `^10.0.0` | PASS |
+| Comment body contains `^19.0.0` | PASS |
+| Comment body contains R3F v9 migration guide URL | PASS (`r3f.docs.pmnd.rs/tutorials/v9-migration-guide`) |
+| Milestone / labels / assignees unchanged | PASS (milestone `v1.5 Performance & Tech Debt`, label `enhancement`, assignees `[]`) |
+| `git diff package.json` empty (D-07) | PASS (0 lines) |
+| `git status --porcelain -- src/` empty (D-08) | PASS (0 files) |
+
+## Next Phase Readiness
+- Phase 27 is now fully executed end-to-end (plans 27-01, 27-02, 27-03 all complete).
+- Tracking issue #56 is the canonical long-lived artifact for the upgrade work; future execution phase should link back to it and to `.planning/codebase/CONCERNS.md § R3F v9 / React 19 Upgrade`.
+- No blockers introduced.
+
+## Self-Check: PASSED
+
+- FOUND: `.planning/phases/27-upgrade-tracking/27-03-SUMMARY.md` (this file)
+- FOUND: External comment https://github.com/micahbank2/room-cad-renderer/issues/56#issuecomment-4283199813 (verified via `gh issue view 56`)
+- No task commits expected (plan `files_modified: []` by design) — verified via `git status --porcelain` clean pre-metadata-commit
+
+---
+*Phase: 27-upgrade-tracking*
+*Completed: 2026-04-20*

--- a/.planning/phases/27-upgrade-tracking/27-CONTEXT.md
+++ b/.planning/phases/27-upgrade-tracking/27-CONTEXT.md
@@ -1,0 +1,102 @@
+# Phase 27: Upgrade Tracking - Context
+
+**Gathered:** 2026-04-20
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Document the R3F v9 → drei v10 → React 19 upgrade path in `.planning/codebase/CONCERNS.md`, and update GitHub issue #56 with the plan. This phase ships **documentation only** — no `package.json` changes, no runtime code changes, no dependency bumps. Issue #56 stays OPEN as the tracking artifact; execution happens in a future phase once R3F v9 is stable.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Documentation Content
+- **D-01:** Depth is **moderate**: current pinned versions, known blockers, upgrade sequence (R3F v9 → drei v10 → React 19), and acceptance criteria. Maps 1:1 to phase success criterion #1 without over-investing in a speculative future upgrade.
+- **D-02:** Specify **specific pinned target versions** — e.g., `@react-three/fiber@^9.0.0`, `@react-three/drei@^10.0.0`, `react@^19.0.0`, `react-dom@^19.0.0`. Gives future-me a clear target; trivial to update if versions drift by execution time.
+- **D-03:** Include **light external research** — quick web/GitHub check for current R3F v9 release status. Cite 1-2 authoritative links (e.g., R3F GitHub milestone/release, React 19 compatibility issue thread) so the blocker claim is traceable.
+
+### Documentation Placement
+- **D-04:** Add a **new dedicated `## R3F v9 / React 19 Upgrade` section** to `.planning/codebase/CONCERNS.md`, placed below the existing Tech Debt bulleted list. Keep the existing short "React 18 downgrade" bullet in Tech Debt as a pointer ("see § R3F v9 / React 19 Upgrade below") so that section remains scannable.
+
+### GitHub Issue #56 Update
+- **D-05:** **Add a comment** to issue #56 linking to the new CONCERNS.md section and summarizing the upgrade plan. Leave the existing issue body intact (it is already a clean summary). Issue stays OPEN.
+- **D-06:** Do NOT change the milestone, labels, or assignees on #56.
+
+### Scope Guardrails
+- **D-07:** Zero `package.json` changes in this phase. A verification step should assert `git diff package.json` is empty at phase close (success criterion #3).
+- **D-08:** No changes to any `src/` files. Only `.planning/codebase/CONCERNS.md` and GitHub issue #56 are touched.
+
+### Claude's Discretion
+- Exact prose/wording of the new CONCERNS.md section
+- Specific headings / subsection breakdown within the new section (as long as it covers: current versions, blockers, sequence, acceptance)
+- Which 1-2 research links to cite (Claude picks the most authoritative, current sources during planning/research)
+- Format of the issue #56 comment (markdown body, bullet structure)
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Roadmap & Requirements
+- `.planning/ROADMAP.md` § Phase 27: Upgrade Tracking — phase goal, depends-on, success criteria
+- `.planning/REQUIREMENTS.md` § TRACK-01 — source-of-truth requirement, verifiable acceptance, linked to issue #56
+
+### Existing Codebase Docs to Extend
+- `.planning/codebase/CONCERNS.md` — target file for the new section. Existing "React 18 downgrade" bullet at the top of Tech Debt is the anchor to cross-reference.
+- `.planning/codebase/STACK.md` — reference for current pinned versions of React, R3F, drei (must match what the new section cites)
+
+### External Tracking Artifact
+- GitHub issue [#56](https://github.com/micahbank2/room-cad-renderer/issues/56) — "Tracking: R3F v9 / React 19 upgrade path" — the tracking artifact that must be updated with a comment and kept OPEN
+
+### Package Versions (Read-only — do not modify)
+- `package.json` — current pinned versions: `react@^18.3.1`, `react-dom@^18.3.5`, `@react-three/fiber@^8.17.14`, `@react-three/drei@^9.122.0`, `three@^0.183.2`
+
+### Memory
+- STATE.md Phase 27 spec (memory S241): confirms documentation-only scope and no `package.json` changes
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- **CONCERNS.md structure** — existing file uses "Issue / Files / Impact / Fix approach" four-field bullets under a `## Tech Debt` heading. The new section does NOT have to conform (it is a larger upgrade-plan document), but the short pointer bullet that stays in Tech Debt should keep the existing field shape.
+- **`gh issue comment` via the gh CLI** — standard workflow for updating issue #56. No PAT setup needed (already authenticated per recent phase work on issues #42 / #43).
+
+### Established Patterns
+- **Docs-only phases commit artifacts under `.planning/`** — no `src/` touches. Matches pattern of prior planning/research commits across Phases 24-26.
+- **Phase verification uses GitHub issue state as an acceptance signal** — consistent with Phase 26's closeout of #42/#43. Here: #56 must stay OPEN at phase close.
+
+### Integration Points
+- **No runtime integration points.** This phase deliberately avoids touching any code path.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- **Upgrade sequence is fixed:** `@react-three/fiber` v9 first → `@react-three/drei` v10 (compatible range) → then `react` + `react-dom` v19. This order is already stated in the phase success criteria and in the existing CONCERNS.md bullet; the new section should repeat it verbatim with reasoning (R3F v9 is the gatekeeper on React 19 compatibility).
+- **Blocker citation:** must explicitly mention "hook errors with React 19" (the language used in existing CONCERNS.md) so the new section reinforces rather than contradicts the existing short bullet.
+- **Acceptance criteria in the doc itself should mirror the issue #56 acceptance block** already on the issue (3D viewport renders, walk mode + orbit camera + textures work, all tests pass) — keeps a single source of truth.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **Actually executing the upgrade** — explicitly out of scope. Belongs in a future phase (likely a new milestone after v1.5) once R3F v9 is stable.
+- **Test matrix / rollback runbook** — considered under "comprehensive" doc depth; deferred because (a) the R3F v9 API surface isn't final and (b) the execution phase will author a fresh, current runbook.
+- **Breaking-changes table** — same reasoning as test matrix. Wait for the execution phase.
+- **Other dependency upgrades** (Vite 8→latest, Tailwind v4 minor bumps, Zustand 5→latest) — not covered by TRACK-01. Different issue, different phase.
+
+</deferred>
+
+---
+
+*Phase: 27-upgrade-tracking*
+*Context gathered: 2026-04-20*

--- a/.planning/phases/27-upgrade-tracking/27-DISCUSSION-LOG.md
+++ b/.planning/phases/27-upgrade-tracking/27-DISCUSSION-LOG.md
@@ -1,0 +1,87 @@
+# Phase 27: Upgrade Tracking - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-04-20
+**Phase:** 27-upgrade-tracking
+**Areas discussed:** Doc depth, Placement, Versions, Research, Issue #56 update
+
+---
+
+## Doc depth
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Moderate | Current pinned versions, known blockers, upgrade sequence (R3F v9 → drei v10 → React 19), acceptance criteria. Matches phase success criteria 1:1 without over-investing. | ✓ |
+| Minimal stub | Just bullets: current versions + blocker note + sequence. Shortest — risks under-specifying acceptance. | |
+| Comprehensive | Moderate + rollback notes, breaking-changes table, test matrix, verification plan. More work; may become stale before execution. | |
+
+**User's choice:** Moderate (Recommended)
+**Notes:** Recommended option selected — downstream planner should mirror the issue #56 acceptance block inside the new section so there's a single source of truth.
+
+---
+
+## Placement
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| New dedicated section | Add '## R3F v9 / React 19 Upgrade' section below the existing Tech Debt list. Keeps the short existing bullet as a pointer. | ✓ |
+| Expand existing bullet in place | Replace the current 'React 18 downgrade' bullet with an expanded version. Keeps under 'Tech Debt' but makes that bullet much longer than neighbors. | |
+
+**User's choice:** New dedicated section (Recommended)
+**Notes:** Keep the existing short bullet in Tech Debt but rewrite it as a pointer to the new section to preserve scannability.
+
+---
+
+## Versions
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Specific pinned targets | Cite concrete target versions (e.g., @react-three/fiber@^9, @react-three/drei@^10, react@^19). Clear goal; easy to update. | ✓ |
+| Version-agnostic | 'Latest stable R3F v9 / drei v10 / React 19 at execution time' with no version numbers. Ages better but vaguer. | |
+
+**User's choice:** Specific pinned targets (Recommended)
+**Notes:** Cite `^9.0.0` / `^10.0.0` / `^19.0.0` — revise during execution phase if versions drift.
+
+---
+
+## Research
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Light research | Quick web search for R3F v9 release status, cite 1-2 authoritative links. | ✓ |
+| Just restate CONCERNS.md | No external research — paraphrase 'hook errors with React 19'. | |
+| Deep research | Read R3F v9 changelog, drei v10 compatibility notes, React 19 migration guide; cite specific breaking changes. Likely overkill. | |
+
+**User's choice:** Light research (Recommended)
+**Notes:** Priority links: R3F GitHub milestone/release notes, React 19 compatibility issue thread. Claude picks best sources during research/planning.
+
+---
+
+## Issue #56 update
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Comment with plan | Leave existing body intact; add comment linking to new CONCERNS.md section with full plan. Preserves history; stays OPEN. | ✓ |
+| Replace body + comment | Rewrite issue body with full upgrade plan and add a short comment noting the update. | |
+| Replace body only | Just rewrite the issue body; no comment. Cleanest final state; loses audit trail. | |
+
+**User's choice:** Comment with plan (Recommended)
+**Notes:** Issue #56 stays OPEN as the tracking artifact. No milestone/label/assignee changes.
+
+---
+
+## Claude's Discretion
+
+- Exact prose of the new CONCERNS.md section
+- Subsection structure within the new section (required coverage: current versions, blockers, sequence, acceptance)
+- Which 1-2 specific external links to cite
+- Format/structure of the issue #56 comment
+
+## Deferred Ideas
+
+- Actually executing the upgrade — future phase after R3F v9 stabilizes
+- Test matrix / rollback runbook — defer to execution phase
+- Breaking-changes table — defer to execution phase
+- Unrelated dependency upgrades (Vite, Tailwind, Zustand) — not in TRACK-01

--- a/.planning/phases/27-upgrade-tracking/27-RESEARCH.md
+++ b/.planning/phases/27-upgrade-tracking/27-RESEARCH.md
@@ -1,0 +1,258 @@
+# Phase 27: Upgrade Tracking - Research
+
+**Researched:** 2026-04-20
+**Domain:** Dependency upgrade planning (R3F v9 / drei v10 / React 19)
+**Confidence:** HIGH on current versions and upstream status; MEDIUM on drei v10 specific breaking changes (release notes are sparse)
+
+## Summary
+
+Phase 27 is a **documentation-only** phase. Output is (1) a new `## R3F v9 / React 19 Upgrade` section in `.planning/codebase/CONCERNS.md` and (2) a comment on GitHub issue #56 linking to it. Zero code or `package.json` changes.
+
+As of 2026-04-20 the upgrade path is **clearer than when issue #56 was filed** — R3F v9 is stable (latest 9.6.0), drei v10 is stable (latest 10.7.7), and React 19 is GA (19.2.x). The original blocker (R3F v8 hook errors with React 19) is resolved by R3F v9. The upgrade is now a straightforward sequence, still correctly ordered as **R3F v9 → drei v10 → React 19**, because drei v10 requires R3F v9 as a peer, and the safest migration pattern is to lift the R3F/drei pair before the React core bump.
+
+**Primary recommendation:** Documentation should cite R3F v9.6.0, drei v10.7.7, React 19.2.x as target versions, point at the official R3F v9 migration guide as the canonical source for breaking changes, and keep issue #56 OPEN with an updated plan (execution is still deferred — no code yet).
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- **D-01** Documentation depth is moderate: current pinned versions, known blockers, upgrade sequence (R3F v9 → drei v10 → React 19), acceptance criteria.
+- **D-02** Specify concrete pinned target versions (`@react-three/fiber@^9.0.0`, `@react-three/drei@^10.0.0`, `react@^19.0.0`, `react-dom@^19.0.0`).
+- **D-03** Light external research with 1–2 authoritative links cited.
+- **D-04** Add a new dedicated `## R3F v9 / React 19 Upgrade` section to `.planning/codebase/CONCERNS.md` **below** the existing Tech Debt bullets. Rewrite the existing "React 18 downgrade" bullet in Tech Debt as a pointer ("see § R3F v9 / React 19 Upgrade below").
+- **D-05** Add a **comment** to GitHub issue #56 linking to the new section. Do **not** rewrite the issue body. Issue stays OPEN.
+- **D-06** No milestone / label / assignee changes on #56.
+- **D-07** Zero `package.json` changes. Verification must assert `git diff package.json` is empty at phase close.
+- **D-08** Only two files touched: `.planning/codebase/CONCERNS.md` and GitHub issue #56. No `src/` changes.
+
+### Claude's Discretion
+- Exact prose of the new CONCERNS.md section
+- Specific headings / subsection breakdown within the new section (required coverage: current versions, blockers, sequence, acceptance)
+- Which 1–2 external links to cite
+- Format of the issue #56 comment
+
+### Deferred Ideas (OUT OF SCOPE)
+- Actually executing the upgrade — future phase after R3F v9 stabilizes (now stable, but execution still deferred this phase)
+- Test matrix / rollback runbook
+- Breaking-changes table
+- Other dependency upgrades (Vite, Tailwind, Zustand)
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| TRACK-01 | R3F v9 / React 19 upgrade path documented and tracked via GH #56 | Sections 1–7 below give the planner everything needed: current pinned versions, release status of each target, breaking changes to cite, affected files in `src/three/`, upgrade ordering rationale, and peer-dep confirmation. |
+</phase_requirements>
+
+## Project Constraints (from CLAUDE.md)
+
+- Root CLAUDE.md mandates GSD workflow for any repo edits — this phase executes via `/gsd:execute-phase`, so that is satisfied.
+- Project CLAUDE.md describes R3F as **lazy-loaded** (`React.lazy()`) and lists current usage limited to `src/three/`. Upgrade impact is scoped to that folder for source-code purposes, but Phase 27 is explicitly not touching source.
+- Global rule: any `git push` on a non-main branch requires an open PR. Planner must include a PR step after any push.
+
+## 1. Current State
+
+### Pinned versions (`package.json`, verified 2026-04-20)
+
+| Package | Current range | Target (documentation) |
+|---------|---------------|------------------------|
+| `react` | `^18.3.1` | `^19.0.0` |
+| `react-dom` | `^18.3.1` | `^19.0.0` |
+| `@types/react` | `^18.3.18` | `^19.0.0` |
+| `@types/react-dom` | `^18.3.5` | `^19.0.0` |
+| `@react-three/fiber` | `^8.17.14` | `^9.0.0` |
+| `@react-three/drei` | `^9.122.0` | `^10.0.0` |
+| `three` | `^0.183.2` | unchanged (three is R3F/drei agnostic) |
+| `@types/three` | `^0.183.1` | unchanged |
+
+Note the CONTEXT.md line cites `react-dom@^18.3.5` — `package.json` actually shows `^18.3.1`. Planner should use the verified value.
+
+### Files that import from `@react-three/fiber` or `@react-three/drei`
+
+Only two files directly import these packages (confirmed via grep on `src/three/`):
+
+1. `src/three/ThreeViewport.tsx` — imports `Canvas`, `useFrame` from fiber; `OrbitControls`, `Environment`, `PointerLockControls` from drei.
+2. `src/three/WalkCameraController.tsx` — imports `useFrame`, `useThree` from fiber.
+
+Other files under `src/three/` (`WallMesh`, `ProductMesh`, `CeilingMesh`, `FloorMesh`, `CustomElementMesh`, `Lighting`, `wainscotStyles`, `productTextureCache`, `floorTexture`, `walkCollision`) use only R3F JSX intrinsics (`<mesh>`, `<group>`, etc.) and `three` directly — they will be affected by the R3F v9 **JSX namespace change** (ThreeElements) but do not import fiber/drei symbols.
+
+Mention in research to help planner: `src/three/ThreeViewport.tsx` is **lazy-loaded** from `src/App.tsx` via `React.lazy()`, so any R3F v9 entry-point tweaks are contained to that module.
+
+## 2. R3F v9 Migration — Breaking Changes Relevant to This Codebase
+
+**Canonical source:** [R3F v9 Migration Guide](https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide) — the official, short, versioned doc. This is the single best link to cite in CONCERNS.md.
+
+### Relevant breaking changes
+
+| Change | Affects our code? | Notes |
+|--------|-------------------|-------|
+| **JSX namespace deprecated; use `ThreeElements` interface** | Yes — every `src/three/*Mesh.tsx` file uses JSX intrinsics like `<mesh>`, `<group>`, `<planeGeometry>`, `<meshStandardMaterial>`. If we have `declare global { namespace JSX { ... } }` anywhere or strict TS types keyed on the old JSX namespace, they need to switch to `ThreeElements`. | React 19 deprecates global `JSX` namespace merging; R3F v9's `ThreeElements` replaces the old `@react-three/fiber` global-augmentation pattern. |
+| **Strict-mode behaviour changes** | Possibly — `Canvas` renders children twice in Strict Mode on React 19. Must verify `useFrame`-driven imperative mutations in `WalkCameraController.tsx` and `ThreeViewport.tsx` (camera lerp at line 84-103) are idempotent. | A re-render that re-runs the lerp setup from stale refs could mis-target the camera on first frame. Not a certain bug — flag for execution-phase testing. |
+| **`useLoader` supports external loader re-use** | Not applicable — we don't use `useLoader`. | Our textures are constructed manually in `floorTexture.ts` and `productTextureCache.ts`. |
+| **Event-system / raycaster internals** | Low risk — we don't attach custom raycasters. Drei `OrbitControls` / `PointerLockControls` handle all pointer events. | Worth a smoke test post-upgrade. |
+| **React 19 peer dep required** | Yes — R3F v9 peer-requires React ≥ 19 (or ≥ 18 in practice per v9.6 compatibility matrix; verify at execution time). | This is why the upgrade **must not** leave R3F v9 installed alongside React 18 long-term. |
+
+### Files in this codebase that will likely need edits during execution
+
+- `src/three/ThreeViewport.tsx` — `OrbitControls` ref typing (currently `useRef<any>`); Strict Mode audit for the useEffect camera restore logic.
+- `src/three/WalkCameraController.tsx` — `useFrame` / `useThree` usage remains API-compatible; smoke-test only.
+- All `src/three/*Mesh.tsx` files — JSX intrinsics: verify type resolution under `ThreeElements` on strict TS.
+- `tsconfig.json` — may need `"types": ["@react-three/fiber"]` or an equivalent reference per v9 types pattern.
+
+Planner does **not** need to make any of these edits in Phase 27 — the research only lists them so the CONCERNS.md section can name the affected areas.
+
+## 3. drei v10 Migration — Breaking Changes
+
+**Canonical sources:**
+- [`@react-three/drei` releases](https://github.com/pmndrs/drei/releases) (latest 10.7.7)
+- [drei discussion #2213 — React 19 & R3F v9 support](https://github.com/pmndrs/drei/discussions/2213)
+- [drei issue #1086 — Deprecate ContextBridge](https://github.com/pmndrs/drei/issues/1086)
+
+### Relevant breaking changes
+
+| Change | Affects our code? | Notes |
+|--------|-------------------|-------|
+| **Manual context-bridge code removed** | No — we don't use `<ContextBridge>`. We use R3F's automatic context forwarding via R3F v9. | ContextBridge was the drei v9 workaround for React 18's missing context propagation into R3F roots. |
+| **Peer dep: requires `@react-three/fiber@^9`** | Yes — this is why the ordering is fixed (see §6). | `drei@^10` will refuse to install with `fiber@^8`. |
+| **Peer dep: requires React 19** | Yes — per drei v10 peer range. | Minor historical note: drei 10.0.x had some transitive `use-sync-external-store` conflicts with React 19 (zustand transitive via tunnel-rat); resolved in later patches. |
+| **`OrbitControls` API** | No observable change — same props (`target`, `maxPolarAngle`, `minDistance`, `enableDamping`, `onChange`, `ref`) still supported. | Our usage in `ThreeViewport.tsx` lines 168-184 should work unchanged. |
+| **`Environment` API** | No observable change — `preset` prop still supported. | Our `preset="apartment"` usage (line 121) should work unchanged. |
+| **`PointerLockControls` API** | No observable change — `maxPolarAngle` / `minPolarAngle` props still supported. | Our usage line 187 should work unchanged. |
+
+Confidence: MEDIUM. drei release notes are historically terse and v10 specifically lists only a handful of breaking items. Planner should cite "see drei GitHub releases for v10.x patch-level changes" rather than attempt an exhaustive table.
+
+## 4. React 19 Migration — Relevant to This Codebase
+
+**Canonical source:** [React 19 release blog post](https://react.dev/blog/2024/12/05/react-19)
+
+### Relevant breaking / behavior changes
+
+| Change | Affects our code? | Notes |
+|--------|-------------------|-------|
+| **`forwardRef` deprecated; ref is a regular prop on function components** | Low impact — we do not currently use `forwardRef` anywhere in `src/` (verified). The R3F `Canvas` internally manages refs; our `OrbitControls` ref usage (line 169) uses drei's ref forwarding, which drei v10 already adapts for us. | Only a concern if we later add wrapper components around Mesh components. |
+| **Removed: string refs, `ReactDOM.render`, `module pattern components`, `PropTypes`, default props on function components** | No impact — we don't use any of these. | Confirmed via grep for `propTypes`/`defaultProps`: none in `src/`. |
+| **Automatic batching already present in 18** | No impact — we were already on 18's batching behavior. | |
+| **JSX transform — global `JSX` namespace conflicts** | Paired with R3F v9's `ThreeElements` — see §2. | Resolved as part of the R3F v9 upgrade, not a separate step. |
+| **Ref cleanup functions** | Opportunity, not a break — `useRef` callbacks can now return cleanup fns. Could clean up the manual cleanup pattern in `orbitControlsRef` but not required. | Defer to execution phase. |
+| **`useMemo` / `useCallback` behavior** | No change vs React 18; mentioned only because issue #56 implies it may be a concern — it is not. | Skip mention in CONCERNS.md. |
+| **Server Components, Actions, `useOptimistic`, Server Actions** | Not applicable — SPA, no server runtime. | Skip mention in CONCERNS.md. |
+
+### React 19 idiosyncrasy to flag
+
+React 19.2 bumped the internal reconciler in a non-backward-compatible way. The R3F team adopted a compat shim; R3F v9.6.0 supports React **19.0 through 19.2**. Planner should cite this in CONCERNS.md as "pin React 19.2.x at execution time to match tested R3F v9 matrix" — do **not** jump to a React 19.3+ preview if one ships.
+
+## 5. Known Blockers (Issue #56 context)
+
+### Original blocker (from CONCERNS.md today)
+> "React was pinned to `^18.3.1` to maintain compatibility with `@react-three/fiber` v8 and `@react-three/drei` v9, which do not fully support React 19."
+
+### Upstream status (verified 2026-04-20)
+- **R3F v9 is stable.** Latest release **v9.6.0** (approx. 2026-04-14, "6 days ago"). The v9 line explicitly targets React 19.
+- **drei v10 is stable.** Latest release **v10.7.7** (published approximately 2025-11; 5 months ago).
+- **React 19 is GA.** Latest 19.2.x series.
+- The "hook error" class of bugs reported against R3F v8 + React 19 (GH issues [#3268](https://github.com/pmndrs/react-three-fiber/issues/3268), [#3471](https://github.com/pmndrs/react-three-fiber/issues/3471)) were the motivation for v9 and are fixed by upgrading.
+- There is a class of **`Invalid hook call` bugs in R3F v9.1 when XR/createStore patterns are used outside component scope** (GH issues [pmndrs/xr#433](https://github.com/pmndrs/xr/issues/433), [pmndrs/xr#441](https://github.com/pmndrs/xr/issues/441)). **Does not affect us** — we do not use `@react-three/xr`.
+
+### Conclusion
+Issue #56's blocker is **resolved at the upstream level**. The issue stays OPEN per D-05 because **we have not yet executed the upgrade in this repo**, not because the ecosystem isn't ready. The updated comment should reflect this: "upstream ready, execution deferred to a dedicated phase."
+
+## 6. Upgrade Sequence Verification
+
+**Stated sequence:** R3F v9 → drei v10 → React 19.
+
+### Peer-dep reality
+- `@react-three/drei@^10` peer-requires `@react-three/fiber@^9` → **drei v10 cannot be installed before R3F v9.**
+- `@react-three/fiber@^9` peer-requires `react@^19` (practical requirement; some early 9.x releases accepted 18 via shim, but v9.6 aligns on 19) → **React 19 must accompany or follow R3F v9.**
+- `@react-three/drei@^10` peer-requires `react@^19` → **React 19 must be installed before or alongside drei v10.**
+
+### Resolved install order for a future execution phase
+
+Option A (recommended, single-PR upgrade):
+```
+npm install react@^19 react-dom@^19 @react-three/fiber@^9 @react-three/drei@^10 @types/react@^19 @types/react-dom@^19
+```
+All four peer-deps resolve in one lockfile transaction. Matches how the React ecosystem usually upgrades.
+
+Option B (literal sequence from CONTEXT): impossible in a single `npm install` because drei v10 peer-requires React 19. But the **documentation sequence** "R3F v9 → drei v10 → React 19" is still the correct way to describe the upgrade **conceptually** (gatekeeper → dependent helper lib → React core). The CONCERNS.md section should present it as conceptual sequence, not as three literal install steps. Planner: make that distinction explicit in prose.
+
+## 7. Release Status (as of 2026-04-20)
+
+| Package | Latest stable | Status | Suitable target? |
+|---------|---------------|--------|------------------|
+| `react` | 19.2.x | GA (released 2024-12-05, stable for ~16 months) | Yes |
+| `react-dom` | 19.2.x | GA | Yes |
+| `@react-three/fiber` | 9.6.0 | GA on v9 line; 9.6.0 is recent (~6 days) | Yes — pin `^9.0.0` per D-02 |
+| `@react-three/drei` | 10.7.7 | GA on v10 line; settled (~5 months old) | Yes — pin `^10.0.0` per D-02 |
+| `three` | 0.183.2 currently pinned; latest upstream may differ | Unchanged for this phase | No action needed |
+
+**Bottom line:** All three target packages are stable. Issue #56 can continue as a tracking issue for the still-unexecuted upgrade; nothing in the ecosystem is blocking the work.
+
+## 8. Citations
+
+### R3F
+- [R3F v9 Migration Guide](https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide) — primary doc to cite in CONCERNS.md
+- [R3F Releases (GitHub)](https://github.com/pmndrs/react-three-fiber/releases) — release history, latest 9.6.0
+- [R3F Fiber CHANGELOG.md](https://github.com/pmndrs/react-three-fiber/blob/master/packages/fiber/CHANGELOG.md) — per-version breaking-change log
+- [R3F GH issue #3268](https://github.com/pmndrs/react-three-fiber/issues/3268) — v8 hook error with React 19 (original blocker class)
+- [R3F GH issue #3471](https://github.com/pmndrs/react-three-fiber/issues/3471) — early v9 hook issues (resolved)
+- [R3F GH issue #3222](https://github.com/pmndrs/react-three-fiber/issues/3222) — React experimental branch tracking
+- [`@react-three/fiber` on npm](https://www.npmjs.com/package/@react-three/fiber) — version confirmation
+
+### drei
+- [drei Releases (GitHub)](https://github.com/pmndrs/drei/releases) — release history, latest 10.7.7
+- [drei discussion #2213 — React 19 & R3F v9 Supported?](https://github.com/pmndrs/drei/discussions/2213) — confirms v10 stance on React 19
+- [drei issue #1086 — Deprecate ContextBridge](https://github.com/pmndrs/drei/issues/1086) — v10 primary breaking change rationale
+- [drei issue #2260 — React 19 compatibility](https://github.com/pmndrs/drei/issues/2260) — migration discussion
+- [drei issue #2430 — react to ^19, drei to ^10](https://github.com/pmndrs/drei/issues/2430) — peer-dep migration thread
+
+### React 19
+- [React 19 release blog post](https://react.dev/blog/2024/12/05/react-19) — primary doc
+- [React `forwardRef` reference (deprecation)](https://react.dev/reference/react/forwardRef)
+- [React GH issue #31613 — forwardRef props referential stability](https://github.com/facebook/react/issues/31613) — known React 19 behavioral nuance (not blocking for us)
+
+### Community / context
+- [Medium: "I Upgraded Three Apps to React 19. Here's What Broke" by Zoe](https://medium.com/@quicksilversel/i-upgraded-three-apps-to-react-19-heres-what-broke-648087c7217b) — real-world R3F + React 19 upgrade gotchas
+
+### Recommended minimum citations in CONCERNS.md (per D-03 "1–2 links")
+1. [R3F v9 Migration Guide](https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide)
+2. [React 19 release blog post](https://react.dev/blog/2024/12/05/react-19)
+
+## Validation Architecture
+
+Phase 27 is **documentation-only**. Nyquist validation collapses to file-content assertions, not a test-framework run.
+
+### Acceptance checks (for `/gsd:verify-work`)
+1. `.planning/codebase/CONCERNS.md` contains a heading matching `## R3F v9 / React 19 Upgrade`.
+2. That section mentions **all three** target versions (`^9.0.0`, `^10.0.0`, `^19.0.0`) and the ordering phrase "R3F v9 → drei v10 → React 19".
+3. That section cites at least one of the canonical links (R3F v9 migration guide or React 19 blog post).
+4. The existing "React 18 downgrade" bullet in Tech Debt has been rewritten as a pointer to the new section.
+5. `git diff package.json` produces **no output** at phase close (D-07).
+6. `git status -- src/` shows no modifications (D-08).
+7. GitHub issue #56 has a new comment (via `gh issue comment 56 --body-file ...`) and state is still `OPEN`.
+
+### Tooling
+- Grep/`rg` checks for steps 1–4 (can run from CI or locally).
+- `gh issue view 56 --json state,comments` for step 7.
+- `git diff` / `git status` for steps 5–6.
+
+### Framework
+No unit or integration tests are appropriate for this phase. `vitest` is available in the repo but not exercised here. Existing test suite should still pass (sanity: `npm run test:quick`) but that is a general safeguard, not phase-specific validation.
+
+### Wave 0 gaps
+None. All validation is string/file-state matching against artifacts this phase produces.
+
+## Metadata
+
+**Confidence breakdown:**
+- Current pinned versions: HIGH — read directly from `package.json`.
+- R3F v9 release status & breaking changes: HIGH — official migration guide + release notes.
+- drei v10 release status: HIGH — npm + GitHub releases.
+- drei v10 specific breaking changes beyond ContextBridge removal: MEDIUM — v10 release notes are thin; relied on discussions and issue threads.
+- React 19 breaking changes relevant to SPA: HIGH — official release blog.
+- Original R3F v8 + React 19 hook error: HIGH — multiple GitHub issues document it; fixed by v9.
+- Ordering rationale (peer-dep verification): HIGH — drei v10 peer-dep on R3F v9 is explicit in release notes / issue #2430.
+
+**Research date:** 2026-04-20
+**Valid until:** 2026-05-20 (30 days — packages are stable but React / R3F minor releases happen frequently; re-verify specific version numbers at execution time).

--- a/.planning/phases/27-upgrade-tracking/27-VALIDATION.md
+++ b/.planning/phases/27-upgrade-tracking/27-VALIDATION.md
@@ -1,0 +1,90 @@
+---
+phase: 27
+slug: upgrade-tracking
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-04-20
+---
+
+# Phase 27 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+>
+> **Note:** Phase 27 is documentation-only. Validation collapses to file-content assertions and `gh` CLI state checks, not a test-framework run. Traditional test sampling does not apply.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | none (documentation-only phase) |
+| **Config file** | none |
+| **Quick run command** | `rg "## R3F v9 / React 19 Upgrade" .planning/codebase/CONCERNS.md` |
+| **Full suite command** | `bash .planning/phases/27-upgrade-tracking/verify.sh` (created in Wave 0 if needed) |
+| **Estimated runtime** | ~2 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run the matching grep check from the acceptance list below
+- **After every plan wave:** Re-run all grep checks + `gh issue view 56 --json state`
+- **Before `/gsd:verify-work`:** All 7 acceptance checks must pass
+- **Max feedback latency:** ~2 seconds (grep/gh calls)
+
+---
+
+## Per-Task Verification Map
+
+Populated by planner when PLAN.md is authored. Each task row lists its acceptance check.
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| _TBD — planner fills this in after creating tasks_ | | | TRACK-01 | file-content | grep | — | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Acceptance Checks (from RESEARCH.md Validation Architecture)
+
+1. `.planning/codebase/CONCERNS.md` contains a heading matching `## R3F v9 / React 19 Upgrade`.
+2. That section mentions all three target versions (`^9.0.0`, `^10.0.0`, `^19.0.0`) and the ordering phrase `R3F v9 → drei v10 → React 19`.
+3. That section cites at least one canonical link (R3F v9 migration guide or React 19 blog post).
+4. The existing "React 18 downgrade" bullet in Tech Debt has been rewritten as a pointer to the new section.
+5. `git diff package.json` produces no output at phase close (scope guardrail D-07).
+6. `git status -- src/` shows no modifications (scope guardrail D-08).
+7. GitHub issue #56 has a new comment and state is still `OPEN`.
+
+---
+
+## Wave 0 Requirements
+
+- [ ] None — no test files or fixtures needed for a documentation-only phase.
+
+*Existing infrastructure covers all phase requirements: `rg`, `git`, `gh` CLI.*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Issue #56 comment readability | TRACK-01 | Human review of comment prose | After posting comment, view `gh issue view 56` and confirm the upgrade plan reads clearly |
+
+*All other phase behaviors have automated (grep/gh) verification.*
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have automated verify commands (grep or gh)
+- [ ] Sampling continuity: every task has an inline check (no framework test run needed)
+- [ ] Wave 0 not needed — no test scaffolding required
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 5s
+- [ ] `nyquist_compliant: true` set in frontmatter once planner fills Per-Task Verification Map
+
+**Approval:** pending

--- a/.planning/phases/27-upgrade-tracking/27-VERIFICATION.md
+++ b/.planning/phases/27-upgrade-tracking/27-VERIFICATION.md
@@ -1,0 +1,96 @@
+---
+phase: 27-upgrade-tracking
+verified: 2026-04-20T00:00:00Z
+status: passed
+score: 7/7 acceptance checks verified
+---
+
+# Phase 27: Upgrade Tracking Verification Report
+
+**Phase Goal:** R3F v9 / React 19 upgrade path is documented and the blocking issue is tracked so it can be executed when R3F v9 stabilizes.
+**Verified:** 2026-04-20
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| #   | Truth                                                                                           | Status     | Evidence |
+| --- | ----------------------------------------------------------------------------------------------- | ---------- | -------- |
+| 1   | Upgrade path documented in-repo with target versions + sequence + blockers + citations          | VERIFIED   | CONCERNS.md lines 91–189 (checks 1–3 pass) |
+| 2   | Existing Tech Debt bullet now points to the new section instead of duplicating content          | VERIFIED   | CONCERNS.md line 11 pointer "see § R3F v9 / React 19 Upgrade below" (check 4) |
+| 3   | GitHub issue #56 has updated tracking state and remains OPEN as the canonical tracker           | VERIFIED   | `gh issue view 56` → state=OPEN, 1 comment present (check 7) |
+| 4   | Scope guardrails held: no package.json or src/ changes in this phase                            | VERIFIED   | `git diff 94b0fb3..HEAD --stat -- package.json src/` empty (checks 5–6) |
+
+**Score:** 4/4 truths verified
+
+### Acceptance Checks (VALIDATION.md §Acceptance Checks)
+
+| # | Check | Result | Evidence |
+|---|-------|--------|----------|
+| 1 | CONCERNS.md contains `## R3F v9 / React 19 Upgrade` heading | PASS | Found at line 91 |
+| 2 | Section mentions `^9.0.0`, `^10.0.0`, `^19.0.0` and sequence phrase `R3F v9 → drei v10 → React 19` | PASS | Lines 118–123 (versions), line 131 (sequence phrase with U+2192 arrow) |
+| 3 | Section cites at least one canonical link | PASS | R3F v9 migration guide (line 188), React 19 release blog (line 189) |
+| 4 | Tech Debt "React 18 downgrade" bullet rewritten as pointer | PASS | Line 11: "see § R3F v9 / React 19 Upgrade below ... Tracked in issue #56" |
+| 5 | `git diff package.json` empty at phase close | PASS | 0 lines of output |
+| 6 | `git status -- src/` shows no modifications | PASS | 0 files; `git diff 94b0fb3..HEAD --stat -- src/` empty across entire phase |
+| 7 | Issue #56 has new comment and state=OPEN | PASS | `gh issue view 56 --json state,comments`: state="OPEN", comment_count=1, body starts "## Upgrade plan documented (2026-04-20)" |
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `.planning/codebase/CONCERNS.md` (new § R3F v9 / React 19 Upgrade) | ~100+ lines covering current versions, targets, sequence, blockers, affected files, citations | VERIFIED | Section spans lines 91–189+, commit 4f7ebe5 adds 105 lines |
+| `.planning/codebase/CONCERNS.md` (Tech Debt pointer) | Short pointer bullet linking to new section + issue #56 | VERIFIED | Commit 8d1aac5 rewrite; line 11 contains "see § R3F v9 / React 19 Upgrade below" and issue #56 link |
+| GitHub issue #56 comment | Dated comment linking back to CONCERNS.md, listing target versions + sequence | VERIFIED | Comment id 4283199813 present; issue state=OPEN |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|----|--------|---------|
+| Tech Debt bullet (line 11) | § R3F v9 / React 19 Upgrade (line 91) | "see § R3F v9 / React 19 Upgrade below" phrase | WIRED | Pointer text present and target heading exists |
+| Tech Debt bullet (line 11) | GitHub issue #56 | Markdown link `[issue #56](https://github.com/...)` | WIRED | Link present in pointer |
+| GitHub issue #56 | CONCERNS.md § R3F v9 / React 19 Upgrade | Absolute blob URL in comment | WIRED | Comment body references `.planning/codebase/CONCERNS.md § R3F v9 / React 19 Upgrade` |
+
+### Data-Flow Trace (Level 4)
+
+N/A — documentation-only phase. No dynamic data rendering to trace.
+
+### Behavioral Spot-Checks
+
+SKIPPED — documentation-only phase with no runnable entry points produced by this phase (guardrails D-07/D-08 explicitly prevent any runtime code changes).
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|-------------|--------|----------|
+| TRACK-01 | 27-01, 27-02, 27-03 | R3F v9 / React 19 upgrade path documented and tracked | SATISFIED | CONCERNS.md § R3F v9 / React 19 Upgrade + Tech Debt pointer + GitHub issue #56 comment (OPEN) |
+
+### Anti-Patterns Found
+
+None. Scanned CONCERNS.md for TODO/FIXME/placeholder — no stub markers found in the new section. Content is substantive: ~100 lines covering Current State, Target Versions, Upgrade Sequence, Known Blockers, Affected Files, Acceptance Criteria, and Citations.
+
+### Scope Guardrail Audit
+
+| Guardrail | Expectation | Result |
+|-----------|-------------|--------|
+| D-07 (no package.json changes) | `git diff 94b0fb3..HEAD -- package.json` empty | PASS (0 lines) |
+| D-08 (no src/ changes) | `git diff 94b0fb3..HEAD -- src/` empty | PASS (0 files touched across 5 phase commits: 4f7ebe5, 868580f, 8d1aac5, dce80de, 11b321d) |
+
+Phase 27 commits touched only: `.planning/REQUIREMENTS.md`, `.planning/ROADMAP.md`, `.planning/STATE.md`, `.planning/codebase/CONCERNS.md`, and `.planning/phases/27-upgrade-tracking/*`.
+
+### Human Verification Required
+
+Per VALIDATION.md §Manual-Only Verifications, one item is flagged for human review:
+
+1. **Issue #56 comment readability** — Human review of the comment prose on `gh issue view 56` to confirm the upgrade plan reads clearly. This is a UX/readability check not verifiable programmatically. All structural content checks (target versions, sequence phrase, CONCERNS.md link, citations) have passed automated verification.
+
+### Gaps Summary
+
+None. All 7 acceptance checks from VALIDATION.md pass. Scope guardrails D-07 and D-08 held across every Phase 27 commit. Requirement TRACK-01 is satisfied by the combination of the new CONCERNS.md section, the Tech Debt pointer rewrite, and the dated comment on open issue #56.
+
+---
+
+_Verified: 2026-04-20_
+_Verifier: Claude (gsd-verifier)_


### PR DESCRIPTION
## Summary
- Phase 27 (Upgrade Tracking) — complete (3/3 plans, 7/7 acceptance checks)
- v1.5 milestone (Performance & Tech Debt) — complete (4/4 phases, 15/15 plans)
- Documentation-only: appended `## R3F v9 / React 19 Upgrade` section to `.planning/codebase/CONCERNS.md`, rewrote Tech Debt bullet as pointer, posted tracking comment on issue #56

## Plans
- 27-01: Append upgrade section to CONCERNS.md
- 27-02: Rewrite React 18 downgrade bullet as pointer
- 27-03: Post upgrade-plan comment on GitHub issue #56 (stays OPEN)

## Guardrails (held)
- D-07: zero package.json changes
- D-08: zero src/ changes
- D-05/D-06: issue #56 remains OPEN; milestone/labels/assignees untouched

## Test plan
- [ ] Review CONCERNS.md § R3F v9 / React 19 Upgrade for readability
- [ ] Review issue #56 tracking comment prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)