### PR TITLE
Docs + UX: Pascal audit, Issues-as-Living-System rule, 3D look-up fix

### DIFF
--- a/.claude/commands/gsd-sync-issues.md
+++ b/.claude/commands/gsd-sync-issues.md
@@ -1,0 +1,122 @@
+# /gsd:sync-issues
+
+Reconcile GitHub Issues with planning state. Detects and fixes drift between:
+- Open issues that actually shipped
+- Shipped features that don't have closure comments
+- New bugs / UAT gaps that should be issues but aren't
+- Orphan phase milestones
+
+Non-destructive by default — shows proposed actions and asks before applying.
+
+---
+
+## When to use
+
+- After a phase ships (catches issues that should have been closed by the PR)
+- After a milestone completes (catches stragglers)
+- After a big bug-fix session (catches bugs in UAT that never became issues)
+- Periodically (once per milestone minimum) to catch generic drift
+- Before demos / reviews where the issues list will be seen externally
+
+## What it does (step by step)
+
+### 1. Load planning state
+
+```bash
+# Shipped phases
+find .planning/phases -name "*-VERIFICATION.md" | sort
+# Backlog entries
+grep -E "^### Phase 999\." .planning/ROADMAP.md
+# UAT gaps (open + deferred)
+find .planning/phases -name "*-HUMAN-UAT.md" -exec grep -l "status: failed\|status: partial\|status: deferred" {} \;
+# Completed-milestone archives
+ls .planning/milestones/
+```
+
+### 2. Load GH state
+
+```bash
+gh issue list --repo $REPO --limit 500 --state all --json number,title,state,labels,closedAt,body
+gh label list --repo $REPO --json name
+gh milestone list --repo $REPO --json number,title,state
+```
+
+### 3. Cross-reference and compute drift
+
+For each OPEN issue:
+- Does its title / body match a shipped feature? → Propose: close with phase reference
+- Does it lack a lifecycle label (`planned` / `backlog` / `deferred` / `tech-debt`)? → Propose: add one based on body content
+- Is it referenced in ROADMAP.md backlog but has no `backlog` label? → Propose: add label
+
+For each planning entry WITHOUT a GH issue:
+- Backlog 999.X without issue → Propose: create issue with `backlog` label
+- UAT Gap with `status: failed` or `deferred` without issue → Propose: create issue with `bug` label
+- New phase in roadmap without tracking issue → Propose: create tracking issue
+
+For each CLOSED issue:
+- Does the close comment reference a phase / PR? → OK
+- No reference, closed recently? → Propose: add reference comment (manual verification first)
+
+### 4. Label taxonomy check
+
+Ensure all labels from the CLAUDE.md taxonomy exist. Create missing ones:
+
+```bash
+gh label create "backlog" --color "fbca04" --description "Parked in roadmap backlog (999.x) — not yet in active phase"
+gh label create "planned" --color "0075ca" --description "Scoped for a future phase in ROADMAP.md"
+gh label create "deferred" --color "bfd4f2" --description "Explicitly deferred beyond current milestone"
+gh label create "tech-debt" --color "d73a4a" --description "Refactor / upgrade / cleanup item"
+gh label create "competitor-insight" --color "5319e7" --description "Idea borrowed from competitor analysis"
+# etc — see CLAUDE.md table
+```
+
+### 5. Present drift report
+
+Output format:
+
+```
+## Issues Drift Report
+
+### Actions ready to apply (safe)
+- [ ] Close #61: shipped in Phase 32 — add reference comment
+- [ ] Add label `backlog` to #70 (currently missing)
+- [ ] Create issue for UAT Gap 1 in 32-HUMAN-UAT.md (wallpaper regression)
+
+### Actions needing human confirmation (risky)
+- [ ] #25 labeled `planned` but no phase scheduled — move to `backlog` or drop label?
+- [ ] #48 has label `enhancement` only; body references "pending mockups" — add `blocked` label? (label doesn't exist yet)
+
+### No action needed
+  ✓ Label taxonomy is complete
+  ✓ All shipped phases have closing PRs linked
+  ✓ 18 of 20 open issues have proper lifecycle labels
+```
+
+### 6. Apply (with user confirmation)
+
+Ask: `Apply all safe actions? [y/N]` — on yes, run the gh commands and report completion.
+
+Never auto-create issues without showing the proposed title + body first.
+Never auto-close issues without showing the reason + references.
+
+---
+
+## Arguments
+
+- `--dry-run` (default) — only report drift, don't modify anything
+- `--apply` — skip the confirmation prompt and apply all safe actions
+- `--scope <area>` — narrow to one area: `backlog`, `shipped`, `uat`, `labels`, `milestones`
+
+## Exit behavior
+
+After running, output:
+- Summary of actions taken
+- Remaining drift that needs manual attention
+- Link to the issues list for visual confirmation
+
+## Implementation notes
+
+- This skill reads ROADMAP.md, all `*-VERIFICATION.md` and `*-HUMAN-UAT.md` files, and calls `gh` CLI
+- It must handle rate limiting (gh API has 5000 req/hour, which is plenty but pause if approaching)
+- All network calls should be idempotent (closing an already-closed issue is a no-op, not an error)
+- Respect the CLAUDE.md label taxonomy — don't invent new labels without explicit user request

--- a/.planning/competitive/pascal-audit.md
+++ b/.planning/competitive/pascal-audit.md
@@ -1,0 +1,190 @@
+# Competitive Audit: Pascal Editor
+
+**Audited:** 2026-04-21
+**Source:** [github.com/pascalorg/editor](https://github.com/pascalorg/editor) (Turborepo monorepo)
+**Tech stack:** Next.js + React Three Fiber + WebGPU + Zustand + Zundo + Zod + IndexedDB
+
+---
+
+## Executive summary
+
+Pascal Editor is an **architect-oriented** 3D building editor. Our tool is **interior-design oriented**. The two target different buyers with different needs — Pascal thinks in Site → Building → Level → Zone → Items; we think in Rooms → Walls → Finishes (paint, wallpaper, wainscoting, art, furniture).
+
+**Where Pascal is stronger:** UX chrome (keyboard shortcuts UI, context menus, hierarchical sidebar tree), architectural primitives (stairs, slabs, roofs, multi-level buildings with display modes), schema rigor (Zod validation, systems/renderers separation).
+
+**Where we're stronger:** Interior finishes (paint system with Farrow & Ball library, wallpaper kinds, wainscoting styles, crown molding, wall art with framing, custom-element uploads, PBR materials), dimension editing, smart-snap, auto-save UX.
+
+**Recommendation:** Do NOT broaden our scope toward architectural primitives. Do adopt Pascal's UX chrome patterns, schema discipline, and the "level modes" (stacked/exploded/solo) pattern adapted to our room-centric model.
+
+---
+
+## Architecture comparison
+
+| Dimension | Pascal | Ours | Notes |
+|-----------|--------|------|-------|
+| Rendering | React Three Fiber + WebGPU | R3F + WebGL | WebGPU gives Pascal post-processing upside. For our current scope WebGL is fine; revisit post-v1.7. |
+| State | 3 Zustand stores (`useScene`, `useViewer`, `useEditor`) | 2 (`cadStore`, `uiStore`) | Their split `useViewer` (camera/selection) out of `useEditor` (tool/panel) is cleaner. Worth considering if our uiStore bloats. |
+| Undo/redo | Zundo (library) | Custom structuredClone snapshots | We already ship; no urgent swap. But Zundo handles branches + time-travel cleanly if we ever want those. |
+| Persistence | IndexedDB | IndexedDB (idb-keyval) | Parity. |
+| Schema validation | Zod schemas for every node type | TypeScript only (compile-time) | Zod adds runtime safety for deserialized snapshots. Real value when we ship cloud sync (v2) or user-imported files. |
+| Architecture pattern | Schemas → Systems (geometry gen) → Renderers (R3F components) | Mostly merged in mesh components | We already have informal split (e.g., `geometry.ts` for math, `CeilingMesh.tsx` for render). Formalizing it would ease testing. |
+| Event bus | Dedicated module | Not present | We use Zustand subscriptions. Event bus is nice for cross-system messages (e.g., "node focused" → multiple systems react) but not urgent. |
+| Spatial queries | Dedicated module (`spatial-queries`) | Inline in tools / `geometry.ts` | Extracting ours into a dedicated module would help as more tools need snap/hit-test logic. |
+
+---
+
+## Node-graph comparison
+
+### Pascal's hierarchy
+```
+Site → Building → Level → Zone → Items
+```
+- **Building** can have multiple levels (floors)
+- **Level** can be stacked, exploded, or soloed (display mode)
+- **Zone** groups items (like logical rooms)
+- **Items** can include: walls, wall-segments, doors, windows, stairs, stair-segments, slabs, roofs, roof-segments, ceilings, fences, scans, guides
+
+### Our hierarchy
+```
+Project → Room(s) → Walls / Ceilings / Floor / Placed Products / Custom Elements / Wall Art / Wallpaper / Paint
+```
+- **Project** has multiple rooms (per cadStore.rooms)
+- **Room** has 2D wall geometry + a height; ceiling is a separate customElement
+- No "building" or "level" concept — single-floor assumption
+
+**Takeaway:** Pascal's multi-level architecture doesn't fit our scope (Jessica plans one home, typically one floor at a time). But the **level display modes (stacked/exploded/solo)** concept adapts beautifully to our rooms: imagine "solo" a single room, "exploded" separate rooms for visual clarity when planning a multi-room project.
+
+---
+
+## Feature-by-feature comparison
+
+### 🟢 We have (Pascal doesn't)
+
+| Feature | Our impl | Why it matters |
+|---------|----------|----------------|
+| Paint system | 132 Farrow & Ball colors + custom hex + lime wash | Core value prop for Jessica |
+| Wallpaper variants | pattern (uploaded) / color / paint kinds | Real-world design flexibility |
+| Wainscoting library | 7 built-in styles + custom heights + per-wall overrides | Differentiator vs pure architect tools |
+| Crown molding | Per-wall height + color | " |
+| Wall art with framing | Frame styles + per-piece art | " |
+| Custom element uploads | User-uploaded images → placed objects | Jessica adds real furniture from Pinterest |
+| Dimension editing | Double-click wall label → feet+inches input | Phase 29 win |
+| Smart snap | Edges + midpoints with purple accent guides + Alt-disable | Phase 30 win |
+| Drag-to-resize | Corner uniform + edge per-axis + wall-endpoint | Phase 31 win |
+| Auto-save + silent restore | 2000ms debounced, pointer-based restore | Phase 28 win |
+| PBR materials | WOOD_PLANK / CONCRETE / PLASTER just shipped | Phase 32 win |
+
+### 🟡 Pascal has, worth adopting
+
+| Feature | Pascal's take | Adopt as |
+|---------|---------------|----------|
+| **Keyboard shortcuts dialog** | `settings-panel/keyboard-shortcuts-dialog.tsx` — a discoverable cheat sheet for all hotkeys | **GH issue: add `?` hotkey opens a shortcuts overlay** |
+| **Node action menu (right-click)** | `components/editor/node-action-menu.tsx` — context menu on selected node (duplicate, delete, lock, focus camera, etc.) | **GH issue: right-click context menu on walls / products / custom-elements** |
+| **Node-level saved cameras** | Every node has optional `camera` field; "focus" button tweens to that viewpoint | **GH issue: per-product/wall "focus camera" action; auto-save camera when manually framed** |
+| **Level display modes (solo/exploded/stacked)** adapted to rooms | Solo = hide other rooms; Exploded = offset rooms visually; Stacked = default | **GH issue: room display modes — solo/explode for multi-room projects** |
+| **Hierarchical sidebar tree** | Site-panel with expandable Level/Building/Roof/Slab/Stair tree nodes | **GH issue: Rooms panel tree — click to select, drag to reorder, visibility toggle per node** |
+| **Full PBR map support** | `MaterialMapsSchema` includes albedo, metalness, roughness, normal, displacement, AO, emissive, bump, alpha, lightmap | **GH issue: extend SurfaceMaterial.pbr to support AO + displacement + emissive** (we have albedo/normal/roughness) |
+| **MaterialTarget enum** | Materials declare what surface types they can apply to | **GH issue: add compatibility checks so UI only shows valid materials per surface** |
+| **Preset thumbnail generator** | `components/editor/preset-thumbnail-generator.tsx` — auto-renders thumbnails for material/product presets from the 3D scene | **GH issue: auto-generate material swatch thumbnails from the actual renderer** |
+| **In-app feedback dialog** | `components/feedback-dialog.tsx` — submit feedback without leaving the app | **GH issue: `Help → Send feedback` dialog with screenshot capture** |
+| **Reduced motion hook** | `hooks/use-reduced-motion.ts` — disables animations for users who set OS preference | **GH issue: honor `prefers-reduced-motion` for smart-snap guides + camera tweens** |
+| **Issue / PR templates** | `.github/ISSUE_TEMPLATE/` with `bug_report.yml` + `feature_request.yml` + PR template | **Do now (below)** |
+| **SETUP.md separate from README** | Dev onboarding in its own file | Low priority; adopt if README gets long |
+| **`.claude/rules/` subdirectory** | Per-subsystem rule files (events.md, layers.md, node-schemas.md, renderers.md, scene-registry.md, selection-managers.md, spatial-queries.md) | **GH issue: split current CLAUDE.md into `.claude/rules/*.md` for discoverability** |
+
+### 🔴 Pascal has, NOT worth adopting for us
+
+| Feature | Why not |
+|---------|---------|
+| Multi-building | Out of scope; Jessica plans one home |
+| Stairs + stair-segments | Out of scope (interior) |
+| Roofs + slabs | Out of scope (we do ceilings, they do roofs) |
+| Fence node type | Out of scope |
+| 3D scan import | Nice idea but way out of scope for our tool's buyer |
+| Audio settings (UI sfx) | Pure polish; not our priority |
+| Guide images | Maybe revisit — uploading a floorplan photo as a guide could help Jessica trace an existing room. LOW priority.  |
+| WebGPU migration | R3F v9 is already tracked (#56). WebGPU is overkill for our scene complexity. |
+
+---
+
+## UX/UI observations (from code + tree structure)
+
+### Pascal's UI chrome strengths
+1. **Tool palette with named tool icons + hotkeys** — clear affordance
+2. **Hierarchical sidebar tree** — see all scene nodes at a glance, drill in to edit
+3. **Right-click node action menu** — fast contextual ops
+4. **Feedback dialog inline** — no leaving to github
+5. **Keyboard shortcuts dialog** — discoverability
+6. **Pascal-branded radio component** (`pascal-radio.tsx`) — consistent UI kit
+7. **Preset thumbnail auto-generation** — thumbnails always in sync with render
+
+### Ours
+1. Tool palette with icons — parity ✓
+2. No hierarchical tree — we show things in separate panels (Floor Material / Custom Elements / Art Library / Wainscot Library / Product Library). Works but creates panel sprawl as features accumulate.
+3. No right-click context menu — right-click does nothing on canvas
+4. No in-app feedback
+5. No shortcuts dialog (shortcuts live only in CLAUDE.md)
+6. Custom CSS classes (obsidian-CAD theme) — consistent but not componentized
+7. Custom logos/thumbnails — product images uploaded by user
+
+### Visual / interaction design patterns worth copying
+- **Unified tree sidebar** (collapsible per-section): Rooms → Walls → Per-wall wainscot/paint/wallpaper → Items
+- **Hotkey cheat sheet overlay** (press `?`)
+- **Right-click context menus** on canvas objects
+- **Camera focus** action per node (double-click a wall in the tree → camera tweens to frame it)
+- **Node visibility toggles** in the tree (hide a wall to see through it)
+
+---
+
+## Prioritized adopt list (to convert into GH issues)
+
+Sorted by **value / effort** ratio for our interior-design tool:
+
+### Tier 1 — Quick wins (each <1 phase, high UX value)
+1. **Keyboard shortcuts dialog** — `?` opens modal listing all V/W/D/N/etc. hotkeys
+2. **In-app feedback dialog** — Help menu → Send feedback (stores to local or emails Micah)
+3. **Right-click context menus** on canvas objects (duplicate / delete / rename / focus camera)
+4. **`.github/ISSUE_TEMPLATE/` + PR template** — stop repeating structure in free-form issues
+5. **Reduced motion support** — respect `prefers-reduced-motion` in snap guides + camera tweens
+6. **Auto-generated material swatch thumbnails** from renderer (replaces manual swatches)
+
+### Tier 2 — Medium effort (1 phase each)
+7. **Rooms hierarchy sidebar tree** — collapsible tree, node visibility toggles, click-to-select-and-focus-camera
+8. **Per-node saved camera** — each wall / product / custom element remembers where it looked best; Focus action tweens to it
+9. **Room display modes** — solo / explode / default (adapt Pascal's level-modes idea to our rooms)
+10. **Extended PBR pipeline** — add AO + displacement + emissive maps to SurfaceMaterial.pbr
+
+### Tier 3 — Architectural refactor (consider before v2)
+11. **`.claude/rules/` subdirectory** — split CLAUDE.md into per-subsystem rule files
+12. **Zod schemas for runtime validation** of serialized CADSnapshot (catches stale-format issues at load time)
+13. **Formal systems/renderers separation** — move geometry generation out of mesh components
+14. **Store split** — factor camera/selection state out of uiStore into a dedicated useViewer store
+
+### Tier 4 — Nice-to-have / experimental
+15. **Guide image** — upload a floorplan photo and trace walls over it
+16. **Material compatibility enum** — materials declare which surface types they target (avoid "concrete walls" if that doesn't make sense)
+17. **Event bus** — if cross-system messaging becomes needed
+
+---
+
+## What we should defend + keep doing better
+
+Our interior-design depth is the moat:
+- Keep adding paint system features (lime wash was a good move)
+- Keep the wall art + wainscoting + crown molding systems rich
+- Custom-element uploads are a Jessica-specific differentiator
+- PBR for interior materials (wood, concrete, plaster) — continue expanding the catalog in Phase 33+
+
+We should NOT:
+- Try to add stairs, roofs, multi-floor. Out of scope.
+- Adopt WebGPU just because Pascal did. Our scene complexity doesn't need it.
+- Imitate Pascal's audio / sound effects. Not our polish priority.
+
+---
+
+## Recommended next actions
+
+1. **Write the Tier 1 items as GH issues** (label: `competitor-insight` + `enhancement`) — they're small, high-value, and can slot into any upcoming phase or become a polish phase of their own (maybe v1.7.5 or v1.8)
+2. **Do the GitHub templates setup immediately** — takes 15 min, standardizes future reporting
+3. **Mention Tier 2–3 in the v1.8 planning conversation** — not immediate but should shape milestone scope
+4. **Revisit this doc** after Phase 33 to see if Zod schemas + systems/renderers split unlock a cleaner Phase 34 (camera presets) implementation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,73 @@ This is a single-user personal tool. Not a SaaS, not a professional CAD app, not
 ## Cross-Cutting Concerns
 <!-- GSD:architecture-end -->
 
+<!-- GSD:issues-living-system-start -->
+## GitHub Issues — Living System
+
+The GitHub Issues tracker is a **living artifact that must stay in sync with planning state**. Drift here creates stale roadmap, duplicate work, and lost context. The following rules are non-optional:
+
+### On bug discovery (outside a fix-on-the-spot flow)
+
+If a bug is found and NOT fixed in the same turn:
+1. Add a ROADMAP backlog entry (phase `999.N` if generic, or inside the active phase's UAT file if scoped)
+2. Create a corresponding GitHub issue with labels `bug` + `backlog` (+ `deferred` if explicitly deferred)
+3. Link the GH issue number back into the ROADMAP / UAT entry
+4. Never leave a bug observation only in a commit message or scratch note
+
+### On phase plan creation (`/gsd:plan-phase`)
+
+For each requirement or feature the phase addresses:
+- If an existing GH issue maps to it → add label `in-progress` (or create one if missing) and reference the issue in the PLAN.md frontmatter or context block
+- If no issue exists and the work is substantive (≥1 plan) → create the issue with `enhancement` label + reference back to the phase
+
+### On PR creation
+
+- Every PR body **must** list `Closes #N` (or `Fixes #N` for bugs) for every issue the PR addresses. Use GitHub's linked-issues UI so merge auto-closes them.
+- If a PR only partially addresses an issue → use `Refs #N` instead and explain what's still pending
+- Add `Spec: .planning/phases/{phase}/{plan}-PLAN.md` for phase PRs so reviewers can navigate to the full plan
+
+### On PR merge
+
+- Verify the auto-closed issues actually closed (rare GH bug: they don't)
+- Any remaining open issue tagged to this phase that the merge did NOT close → either retag `planned` → next phase, or explicitly keep open with a reason
+- Update `.planning/ROADMAP.md` phase status + any backlog entries that moved state
+
+### On phase completion (`gsd-tools phase complete`)
+
+- Phase's HUMAN-UAT.md gaps → corresponding GH issues must exist, with correct status labels (`backlog` / `deferred` / `in-progress`)
+- Phase's VERIFICATION.md score → if `passed-with-carry-over`, each carry-over must be a tracked GH issue
+
+### On milestone completion (`/gsd:complete-milestone`)
+
+- Close the GH milestone (not the issues — those should already be closed as PRs merged)
+- Verify no orphan open issues reference the completed milestone
+- Any carry-over issues → relabel with the next milestone
+
+### Label taxonomy (keep this tight)
+
+| Label | Meaning | Close trigger |
+|-------|---------|---------------|
+| `enhancement` | Feature request | PR that implements it merges |
+| `bug` | Something's broken | PR that fixes it merges |
+| `backlog` | Parked in 999.x or UAT gaps | Promoted to active phase → relabel |
+| `planned` | Scoped for a specific future phase | Phase ships → close with phase ref |
+| `tech-debt` | Refactor / upgrade / cleanup | Ongoing, close when addressed |
+| `deferred` | Explicitly out of scope for current major version | Never auto-close |
+| `competitor-insight` | Borrowed from competitive audit | Same lifecycle as `enhancement` |
+| `ux` | UX / interaction design | Orthogonal tag (combine with others) |
+| `documentation` | Docs work | Orthogonal tag |
+
+### On drift detected
+
+If issues and planning state diverge (e.g., a phase shipped but the GH issue is still open, or a new bug discovered on-screen but no issue exists), run the `/gsd:sync-issues` skill to reconcile.
+
+### Automation status (as of 2026-04-21)
+
+- **Manual**: everything above, enforced by this rule
+- **Semi-automated**: `/gsd:sync-issues` reconciliation skill (see `.claude/commands/gsd-sync-issues.md` if present)
+- **Future**: post-merge hook that auto-closes linked issues and updates ROADMAP.md — not built yet; tracked as separate issue if pursued
+<!-- GSD:issues-living-system-end -->
+
 <!-- GSD:workflow-start source:GSD defaults -->
 ## GSD Workflow Enforcement
 

--- a/src/three/ThreeViewport.tsx
+++ b/src/three/ThreeViewport.tsx
@@ -175,7 +175,10 @@ function Scene({ productLibrary }: Props) {
         <OrbitControls
           ref={orbitControlsRef}
           target={orbitTargetRef.current}
-          maxPolarAngle={Math.PI / 2}
+          // Polar 0 = camera directly above target (looks down); π/2 = horizontal;
+          // π = directly below target (looks up). Allow ~60° of "look up" — enough
+          // to see the ceiling without letting the camera flip or clip under the floor.
+          maxPolarAngle={Math.PI * 0.85}
           minDistance={3}
           maxDistance={80}
           enableDamping


### PR DESCRIPTION
Follow-up PR after #69 merged. Three commits: one small UX fix + two planning/docs deliverables.

## Summary

### 🛠 `cde4d5e` — Fix: 3D orbit can look up now
`OrbitControls.maxPolarAngle` was capped at `π/2` which prevented the camera from orbiting below the target, which in turn prevented tilting up to see the ceiling. Raised to `π * 0.85` (~60° of "look up" range). Stops short of `π` to prevent gimbal flip and to keep the camera above floor at reasonable distances.

### 📋 `22afff7` — Pascal Editor competitive audit + 10 new GH issues
Audited [pascalorg/editor](https://github.com/pascalorg/editor) monorepo structure, schemas, systems, UI components. Identified 16 borrow-candidates across 4 tiers and rejected the rest as out of scope.

- **Doc:** `.planning/competitive/pascal-audit.md` — side-by-side comparison, tier-ranked adopt list, explicit rejections
- **Issues created** (all labeled `competitor-insight`):
  - **Tier 1 quick wins:** #72 keyboard shortcuts dialog · #73 in-app feedback · #74 right-click context menus · #75 GH issue+PR templates · #76 reduced-motion support · #77 auto-generated material thumbnails
  - **Tier 2 (~1 phase each):** #78 rooms tree sidebar · #79 per-node saved cameras · #80 room display modes (solo/explode) · #81 extended PBR pipeline (AO/displacement/emissive)
- **Explicitly NOT adopting:** multi-building, stairs, roofs, slabs, 3D scan, audio UI, WebGPU — out of scope for our interior-design positioning

### 📏 `49d7aaa` — Issues-as-Living-System rule + /gsd:sync-issues command spec

Makes the GH Issues tracker a living artifact rather than a scratch list.

- **Project CLAUDE.md** — new "GitHub Issues — Living System" section with mandatory triggers:
  - On bug discovery (not fixed in same turn) → ROADMAP entry + GH issue both created
  - On PR creation → `Closes #N` / `Fixes #N` references required
  - On PR merge → verify auto-close happened, relabel carry-overs
  - On phase plan / phase completion / milestone completion → corresponding issue lifecycle transitions
  - Label taxonomy table (`enhancement` / `bug` / `backlog` / `planned` / `tech-debt` / `deferred` / `competitor-insight`)
- **Global `~/.claude/CLAUDE.md`** — condensed version of the rule applies across all projects
- **`.claude/commands/gsd-sync-issues.md`** — full spec for a drift-reconciliation command (dry-run default, safe-actions confirmation, respects taxonomy)

### Related cleanup (landed on main before this PR)
- Closed 8 issues that had actually shipped (#17, #23, #44, #46, #49, #50, #60, #61) with phase/PR references
- Created #70 (ceiling resize backlog) + #71 (wallpaper regression deferred)
- Added 6 new labels to formalize the taxonomy
- Re-labeled 13 remaining open issues

## Test plan

- [x] TypeScript clean
- [x] 3D orbit look-up confirmed at http://localhost:5173/
- [x] All affected GH issues still reachable + correctly labeled
- [ ] Reviewer scan: does the CLAUDE.md rule make sense / anything missing?

Closes nothing — this is infrastructure + docs. Tracking items it creates: #72 through #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)