### PR TITLE
Rescope v1.9: cancel Phase 40 + 41, add Phase 42 (BUG-01)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -39,25 +39,27 @@ See `.planning/ROADMAP.md` for links to each milestone archive.
 
 ## Current Milestone: v1.9 Polish & Feedback
 
-**Goal:** Close v1.8 carry-over tech debt, ship two parked backlog features Jessica has already asked for (ceiling resize handles, per-surface texture tile-size override), and gather real-use feedback to inform v2.0 scoping.
+**Goal:** Close v1.8 carry-over tech debt, gather real-use feedback to inform v2.0 scoping, and ship the bug-fix actions that emerge from the feedback signal.
 
-**Target features:**
-- **VERIFICATION.md backfill (POLISH-01)** — Retroactive verification reports for Phases 35/36/37. Closes AUDIT-01 carry-over from v1.8.
-- **Real-use feedback session (FEEDBACK-01)** — Scheduled ~1-hour session with Jessica using the app for real tasks. Output is a ranked-priority document at `.planning/feedback/v1.9-jessica-session.md` that becomes the v2.0 scope input. Includes Phase 35 HUMAN-UAT review.
-- **Ceiling resize handles (CEIL-01 — Phase 999.1 promotion)** — Drag-resize edge handles on ceilings, mirroring the Phase 31 pattern (`widthFtOverride` / `depthFtOverride` / single-undo drag transactions / Alt disables smart-snap).
-- **Per-surface texture tile-size override (TILE-01 — Phase 999.3 / GH #105 promotion)** — Optional `tileSizeOverrideFt` per floor / wall.wallpaper / ceiling that scales texture for design effect (preview wide-plank vs narrow-plank in same room without re-uploading).
+**Final shape (after 2026-04-25 mid-milestone re-scope):**
+- ✅ **VERIFICATION.md backfill (POLISH-01 / Phase 38)** — Retroactive verification reports for Phases 35/36/37. Closes AUDIT-01 carry-over from v1.8.
+- ✅ **Real-use feedback signal (FEEDBACK-01 / Phase 39)** — Async 5-question questionnaire (CONTEXT D-08 pivot from in-person hybrid). Result: zero friction reported, zero new wishes beyond GH backlog, all 3 Phase 35 HUMAN-UAT items confirmed.
+- 🔄 **Phase 40 (CEIL-01 — ceiling resize) — CANCELLED** mid-milestone. Jessica reported zero pain on ceilings ("went fine"). Re-deferred to Phase 999.1 backlog for v2.0+ revisit pending demand signal.
+- 🔄 **Phase 41 (TILE-01 — full design-effect tile override) — CANCELLED** mid-milestone. Jessica reported zero pain on texture sizing ("feels right"). Full design-effect feature re-deferred to Phase 999.3 backlog for v2.0+ revisit.
+- ⏳ **Phase 42 (BUG-01) — added** mid-milestone as the v1.9 closer. Closes [GH #96](https://github.com/micahbank2/room-cad-renderer/issues/96) per-surface `tileSizeFt` isolation bug. Real defect, ships regardless of Jessica's signal.
 
-**Phase numbering:** continues from 37. Phases 38–41.
+**Phase numbering:** Phases 38, 39, 42 active in v1.9. Phases 40 and 41 are cancelled-in-flight (preserved in audit trail with CANCELLED markers).
 
-**Sequencing intent:** Phase 38 (docs) → Phase 39 (Jessica feedback) → Phases 40-41 (committed but reorderable based on Phase 39 output). If Phase 39 surfaces something more painful than 999.1/999.3, Phases 40-41 get bumped to v2.0+.
+**Sequencing intent:** Phase 38 → Phase 39 → mid-milestone re-scope → Phase 42 closes v1.9. Re-scope honors the original milestone hedge ("Phases 40-41 explicitly subject to Phase 39 reordering") rather than building on hypothesis-only after feedback contradicted the hypotheses.
 
-**Out of v1.9:** Lighting controls, walk-mode improvements, layout templates, multi-room navigation, export workflow, AI-assisted layout, mobile/iPad, backend + auth + cloud sync, R3F v9 / React 19 upgrade, per-surface rotation/offset/seam-smoothing — all deferred to v2.0+ pending FEEDBACK-01 results.
+**Out of v1.9:** Lighting controls, walk-mode improvements, layout templates, multi-room navigation, export workflow, AI-assisted layout, mobile/iPad, backend + auth + cloud sync, R3F v9 / React 19 upgrade, per-surface rotation/offset/seam-smoothing — all deferred to v2.0+ pending FEEDBACK-01 results. Plus, post-rescope: full design-effect tile-size override (Phase 999.3) and ceiling drag-resize (Phase 999.1) deferred too.
 
-**Why this milestone, why now:** v1.8 was big and fast (4 phases in 3 days). Real-use signal beats guesswork for the next major capability bet. Closing the carry-over tech debt and shipping the two specific features Jessica's already named keeps the surface tight while feedback informs v2.0.
+**Why this milestone, why now:** v1.8 was big and fast (4 phases in 3 days). Real-use signal beats guesswork. The honest outcome — Jessica's signal contradicted two of the three planned features — is itself the milestone's most valuable artifact: it prevented building on hypothesis. v1.9 is small but real.
 
 **Tech debt acknowledged + accepted:**
 - 6 pre-existing vitest failures permanently accepted (Phase 37 D-02); CI vitest stays disabled
 - Phase 26 R3F v9 / React 19 upgrade still gated on R3F v9 stability (#56)
+- v1.9 mid-milestone re-scope is itself a validation of the "Phase 39 first" sequencing — feedback BEFORE feature commit caught the wrong bet before money got spent on it
 
 <details>
 <summary>v1.8 milestone (now shipped)</summary>

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -36,26 +36,21 @@ source: v1.8 carry-over tech debt + parked backlog (999.1 + 999.3) + real-use fe
   - **Verifiable:** Document exists at the named path. Contains: (a) ≥3 specific friction points she hit during real use (with what task she was trying to do), (b) ≥3 "I wish it could…" feature requests with her own framing, (c) Phase 35 HUMAN-UAT review covering eye-level pose interpretation + easeInOutCubic feel + active-highlight contrast (each marked confirmed / adjust / reject), (d) a top-3 ranked-priority list synthesized from the session.
   - **Acceptance:** Doc reflects an actual session, not invented content. Top-3 list explicitly informs Phase 40/41 ordering for v1.9 AND seeds the v2.0 scope discussion. Items not actionable in v1.9 captured as backlog (999.x).
 
-### Ceiling Resize Handles (CEIL)
+### Per-Surface Texture Tile-Size Bug Fix (BUG)
 
-- [ ] **CEIL-01** — Ceilings (custom-elements with `kind: "ceiling"`) can be drag-resized via edge handles like products and walls. Mirrors the Phase 31 pattern.
-  - **Source:** Phase 999.1 backlog. Originally captured 2026-04-21 during Phase 32 T4 human UAT (Jessica) — pre-existing gap, not Phase 32 scope.
-  - **Verifiable:** Select a ceiling in 2D → 4 edge handles render (N/S/E/W). Drag a handle → ceiling resizes along that axis only, with `widthFtOverride` / `depthFtOverride` written to `PlacedCustomElement` (mirrors Phase 31 product/custom-element resize). Single-undo: `past.length` increments by exactly 1 per drag cycle. Alt/Option disables smart-snap during the drag (grid-snap still applies). 3D ceiling mesh re-renders at the new dimensions. Reset action clears the override.
-  - **Acceptance:** Reuses `resolveEffectiveCustomDims` resolver. Reuses Phase 31 single-undo drag-transaction pattern (mousedown push history, NoHistory mid-drag, no extra entries). Reuses Phase 25 fast-path (`renderOnAddRemove: false` + `_dragActive` flag). Smart-snap scene includes wall edges + other ceiling edges (per Phase 30 D-08b extension).
-
-### Per-Surface Texture Tile-Size Override (TILE)
-
-- [ ] **TILE-01** — Each surface (floor, wall.wallpaper side, ceiling) can have an optional per-placement texture tile-size override that scales the texture for design effect without changing the catalog tile size.
-  - **Source:** [GH #105](https://github.com/micahbank2/room-cad-renderer/issues/105) / Phase 999.3 backlog. Discovered 2026-04-25 during Phase 35 HUMAN-UAT — Jessica asked why wood oak doesn't scale up with the floor; confirmed real-world tiling is correct, this is the natural follow-up enhancement.
-  - **Verifiable:** Apply `wood-oak` texture to a floor → texture tiles at catalog size (e.g., 0.5 ft plank width × N planks across the floor). In the floor material picker (or a new "Tile size" affordance), enter a custom tile size in feet+inches (reusing Phase 29 parser) → texture re-tiles at the new size; one IDB entry, one catalog reference, one per-placement override. Reset clears the override → texture returns to catalog size. Override survives page reload. Override is per-surface — same texture on a different floor renders independently.
-  - **Acceptance:** New optional fields: `floor.tileSizeOverrideFt?: number`, `wall.wallpaper.tileSizeOverrideFt?: number`, `ceiling.tileSizeOverrideFt?: number`. Default `undefined` (uses catalog tile size). Renderer math: `texture.repeat = surface_dim / (override ?? catalog.tileSizeFt)`. UI: small `+`/`-` stepper or feet+inches input in the material picker showing effective tile size + reset button. Snapshot persists override per-surface. Orphan-safe (deleting the texture clears the override along with the assignment).
+- [ ] **BUG-01** — When the same user-uploaded texture is applied to multiple surfaces (floor + wall, two walls, etc.), each surface honors its own `tileSizeFt` independently. Currently changing the tile size on one surface affects all surfaces sharing that texture ([GH #96](https://github.com/micahbank2/room-cad-renderer/issues/96)).
+  - **Source:** [GH #96](https://github.com/micahbank2/room-cad-renderer/issues/96). Re-scoped from full TILE-01 design-effect override (deferred to v2.0+) per Phase 39 feedback recommendation accepted 2026-04-25 — Jessica's Q4 confirmed catalog-default tile sizing feels right, but the per-surface bug exists regardless of whether she has noticed it.
+  - **Verifiable:** Apply user-texture X to floor with `tileSizeFt=8`. Apply same user-texture X to a wall with `tileSizeFt=4`. Both surfaces render at their own tile size — floor planks 8 ft, wall planks 4 ft. Snapshot stores the per-surface tile size on the surface assignment, not on the catalog entry. Page reload preserves both. Catalog tile size stays a default-only fallback.
+  - **Acceptance:** Per-surface `tileSizeFt` lives on the surface assignment (`floor.tileSizeFt`, `wall.wallpaper.tileSizeFt`, `ceiling.tileSizeFt`) — NOT on the user-texture catalog entry alone. Renderer reads from surface override; falls back to catalog default if surface override missing. Snapshot serializes the per-surface value. Migration handles existing snapshots that wrote tile size to the catalog (back-fill the surface override on read). Tests assert both-surfaces-different-tile-sizes invariant.
 
 ---
 
 ## Future Requirements (Deferred to v2.0+)
 
-These items are intentionally **out of v1.9** and will be revisited based on FEEDBACK-01 results:
+These items are intentionally **out of v1.9**. The CEIL-01 / TILE-01 deferrals were promoted from v1.9 scope to v2.0+ on 2026-04-25 after Phase 39 feedback signal showed Jessica reported zero pain on either area. They remain valid candidate work — just not warranted on hypothesis-only.
 
+- **CEIL-01** (was v1.9 Phase 40) — Ceilings drag-resizable via edge handles like products and walls. Mirrors Phase 31 pattern. **Deferred:** Jessica's Phase 39 Q5 said ceilings "went fine" — no signaled pain. Phase 999.1 backlog. Revisit if a future feedback session surfaces actual ceiling-resize friction.
+- **TILE-01** (was v1.9 Phase 41 — full design-effect override) — Optional per-placement `tileSizeOverrideFt` that scales textures for design effect (preview wide-plank vs narrow-plank in same room without re-uploading). **Deferred:** Jessica's Phase 39 Q4 said catalog-default tile sizing "feels right" — design-effect override is hypothesis-only. The narrower BUG-01 (#96 fix above) lands the per-surface isolation that's actually required regardless. Phase 999.3 backlog. Revisit when a future feedback session surfaces design-effect demand.
 - **Lighting controls** — directional light angle, ambient intensity, time-of-day presets
 - **Walk-mode improvements** — head bob, transition smoothness, collision
 - **Layout templates** — pre-built room layouts for common scenarios
@@ -67,16 +62,26 @@ These items are intentionally **out of v1.9** and will be revisited based on FEE
 - **R3F v9 / React 19 upgrade** — still gated on R3F v9 stability (#56)
 - **Per-surface rotation / offset / seam-smoothing** — beyond TILE-01 scope; revisit in v2.0+ texture polish
 
+### Phase 39 v2.0 scope seeds (curated GH issues)
+
+Items surfaced from Phase 39's "GH backlog IS the wishlist" insight. v2.0 scoping starts here:
+
+- **UX polish trio:** [#97](https://github.com/micahbank2/room-cad-renderer/issues/97) (Properties panel in 3D/split), [#98](https://github.com/micahbank2/room-cad-renderer/issues/98) (muted text contrast), [#99](https://github.com/micahbank2/room-cad-renderer/issues/99) (Properties panel onboarding)
+- **Quick wins:** [#100](https://github.com/micahbank2/room-cad-renderer/issues/100) (default templates need ceilings), [#101](https://github.com/micahbank2/room-cad-renderer/issues/101) (SAVED badge too small), [#76](https://github.com/micahbank2/room-cad-renderer/issues/76) (`prefers-reduced-motion` for snap guides + camera tweens)
+- **Pascal competitor-insight set:** [#79](https://github.com/micahbank2/room-cad-renderer/issues/79) (per-node saved camera + Focus), [#80](https://github.com/micahbank2/room-cad-renderer/issues/80) (room display modes — solo/explode), [#78](https://github.com/micahbank2/room-cad-renderer/issues/78) (rooms hierarchy sidebar tree), [#77](https://github.com/micahbank2/room-cad-renderer/issues/77) (auto-generate material swatch thumbnails)
+- **PBR extensions:** [#81](https://github.com/micahbank2/room-cad-renderer/issues/81) (AO + displacement + emissive)
+
 ## Traceability
 
 Phase → requirement mapping. Plan column filled by `/gsd:plan-phase` when each phase is planned.
 
 | Requirement | Phase | Plan(s) |
 | ----------- | ----- | ------- |
-| POLISH-01 | Phase 38 | TBD |
-| FEEDBACK-01 | Phase 39 | TBD |
-| CEIL-01 | Phase 40 | TBD |
-| TILE-01 | Phase 41 | TBD |
+| POLISH-01 | Phase 38 | 38-01 |
+| FEEDBACK-01 | Phase 39 | 39-01, 39-02 |
+| BUG-01 | Phase 42 (added 2026-04-25 mid-milestone — final v1.9 phase) | TBD |
+| ~~CEIL-01~~ | ~~Phase 40~~ → CANCELLED 2026-04-25; deferred to v2.0+ (Phase 999.1 backlog) | n/a |
+| ~~TILE-01~~ | ~~Phase 41~~ → CANCELLED 2026-04-25; deferred to v2.0+ (Phase 999.3 backlog) | n/a |
 
 ---
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -87,10 +87,12 @@
 
 **Goal:** Close v1.8 carry-over tech debt, ship two parked backlog features Jessica has already asked for, and gather real-use feedback to inform v2.0 scoping.
 
-**Sequencing rationale:**
+**Sequencing rationale (as planned):**
 - **Phase 38** (POLISH-01) runs first — pure docs work, no dependency on Jessica's input. Closes AUDIT-01 carry-over.
 - **Phase 39** (FEEDBACK-01) runs second — captures real-use friction BEFORE we commit deeper to ceiling resize / tile-size override. Output may reorder or replace Phases 40-41.
 - **Phase 40** (CEIL-01) and **Phase 41** (TILE-01) run last — committed work but explicitly subject to Phase 39's feedback. If Jessica's pain points are elsewhere, these get bumped to v2.0+.
+
+**Mid-milestone re-scope (2026-04-25):** Phase 39 feedback signal showed Jessica reported zero pain on ceilings ("went fine") and zero pain on texture sizing ("feels right"). Per the milestone's explicit hedge, **Phase 40 (CEIL-01) and Phase 41 (TILE-01) were CANCELLED** and deferred to v2.0+ as Phase 999.1 and Phase 999.3 respectively. **Phase 42 (BUG-01)** was added as the final v1.9 phase — closes [GH #96](https://github.com/micahbank2/room-cad-renderer/issues/96) per-surface `tileSizeFt` sharing bug, which exists regardless of Jessica's signal.
 
 ### Phase Details
 
@@ -110,19 +112,19 @@
 2/2 plans complete
 - [x] 39-02-synthesis — post-session synthesis of `.planning/feedback/v1.9-jessica-session.md` from Micah's notes (gated on session happening + notes supplied)
 
-#### Phase 40: Ceiling Resize Handles (CEIL-01)
-**Goal:** Ceilings can be drag-resized via edge handles like products and walls. Mirrors Phase 31 pattern.
-**Depends on:** Phase 31 (drag-resize pattern + `widthFtOverride` / `depthFtOverride` schema + single-undo drag-transaction).
-**Requirements:** CEIL-01
-**UI hint:** yes
-**Plans:** TBD (est. 1-2 plans; promote Phase 999.1 backlog. Subject to Phase 39 reordering)
+#### ~~Phase 40: Ceiling Resize Handles (CEIL-01)~~ — CANCELLED 2026-04-25
+**Status:** CANCELLED mid-milestone after Phase 39 Q5 feedback ("went fine"). Deferred to v2.0+ as Phase 999.1. CEIL-01 requirement moved to Future Requirements / Deferred section in REQUIREMENTS.md. No plans authored.
 
-#### Phase 41: Per-Surface Texture Tile-Size Override (TILE-01)
-**Goal:** Each surface (floor / wall.wallpaper / ceiling) can have an optional per-placement texture tile-size override that scales the texture for design effect.
-**Depends on:** Phase 34 (user-texture pipeline + RepeatWrapping math).
-**Requirements:** TILE-01
-**UI hint:** yes
-**Plans:** TBD (est. 1-2 plans; promote Phase 999.3 / GH #105 backlog. Subject to Phase 39 reordering)
+#### ~~Phase 41: Per-Surface Texture Tile-Size Override (TILE-01)~~ — CANCELLED 2026-04-25
+**Status:** CANCELLED mid-milestone after Phase 39 Q4 feedback ("feels right"). Deferred to v2.0+ as Phase 999.3. TILE-01 requirement moved to Future Requirements / Deferred section in REQUIREMENTS.md. The narrower per-surface bug fix lives in Phase 42 below. No plans authored.
+
+#### Phase 42: Per-Surface tileSizeFt Bug Fix (BUG-01)
+**Goal:** When the same user-uploaded texture is applied to multiple surfaces, each surface honors its own `tileSizeFt` independently. Closes [GH #96](https://github.com/micahbank2/room-cad-renderer/issues/96).
+**Depends on:** Phase 34 (user-texture pipeline). Independent of cancelled Phases 40/41.
+**Requirements:** BUG-01
+**UI hint:** no (data-model fix; existing UI surfaces already pass `tileSizeFt`)
+**Plans:** TBD (est. 1 plan; data-model migration + renderer-resolution change + tests; v1.9 milestone closer)
+**Added:** 2026-04-25 mid-milestone after Phase 39 acceptance.
 
 ---
 
@@ -138,36 +140,41 @@
 | 37. Tech-Debt Sweep | 1/1 | Complete   | 2026-04-25 |
 | 38. VERIFICATION.md Backfill | 0/0 | Not started | - |
 | 39. Real-Use Feedback Session | 2/2 | Complete   | 2026-04-25 |
-| 40. Ceiling Resize Handles | 0/0 | Not started | - |
-| 41. Per-Surface Tile-Size Override | 0/0 | Not started | - |
+| ~~40. Ceiling Resize Handles~~ | n/a | CANCELLED   | 2026-04-25 (deferred to Phase 999.1) |
+| ~~41. Per-Surface Tile-Size Override~~ | n/a | CANCELLED   | 2026-04-25 (deferred to Phase 999.3) |
+| 42. Per-Surface tileSizeFt Bug Fix | 0/1 | Not started | - |
 
 ## Backlog
 
-### Phase 999.1: Ceiling resize handles (BACKLOG)
+### Phase 999.1: Ceiling resize handles (BACKLOG — re-deferred from v1.9)
 
-**Goal:** [Captured for future planning] Extend drag-to-resize handles from Phase 31 (products + custom-elements) to cover ceilings. Ceilings (customElements with `kind: "ceiling"`) currently have no resize handles — users can only move or delete and redraw. Mirror Phase 31's width/depth override pattern (`widthFtOverride` / `depthFtOverride`, single-undo drag transaction, Alt disables smart-snap).
+**Goal:** Extend drag-to-resize handles from Phase 31 (products + custom-elements) to cover ceilings. Ceilings (customElements with `kind: "ceiling"`) currently have no resize handles — users can only move or delete and redraw. Mirror Phase 31's width/depth override pattern (`widthFtOverride` / `depthFtOverride`, single-undo drag transaction, Alt disables smart-snap).
 
-**Requirements:** TBD
-**Plans:** 1/1 plans complete
+**Requirements:** CEIL-01 (re-parked here from v1.9 Phase 40 cancellation 2026-04-25)
+**Plans:** 0 plans
 
 Plans:
-- [ ] TBD (promote with /gsd:review-backlog when ready)
+- [ ] TBD (promote with /gsd:review-backlog or v2.0 milestone scoping)
 
-**Discovered:** 2026-04-21 during Phase 32 T4 human UAT (Jessica) — pre-existing, not Phase 32 scope.
+**Discovered:** 2026-04-21 during Phase 32 T4 human UAT (Jessica) — pre-existing.
+**Promoted to v1.9 as Phase 40 (CEIL-01)** during 2026-04-25 v1.9 scoping.
+**Re-deferred 2026-04-25** after Phase 39 feedback signal showed Jessica reported zero pain on ceilings ("went fine"). Building drag-resize on hypothesis-only would be guessing; revisit when a future feedback session surfaces actual ceiling-resize friction.
 
 ### Phase 999.2: Wallpaper + wallArt view-toggle regression — PROMOTED to Phase 36 under v1.8
 
 Originally captured 2026-04-21 Phase 32 T4 human UAT. Promoted into v1.8 as Phase 36 (VIZ-10). See Phase 36 Details above.
 
-### Phase 999.3: Per-surface texture tile-size override (BACKLOG)
+### Phase 999.3: Per-surface texture tile-size override — design-effect (BACKLOG — re-deferred from v1.9)
 
 **Goal:** Let users scale a texture for design effect on a single surface without re-uploading. e.g., preview the same wood floor at 6"/12"/18" plank widths in the same room. Default behavior (real-world tiling via `RepeatWrapping`) stays correct; override is optional per surface.
 
-**Requirements:** TBD
+**Requirements:** TILE-01 (re-parked here from v1.9 Phase 41 cancellation 2026-04-25). Distinct from BUG-01 (#96 fix in v1.9 Phase 42) which only handles per-surface `tileSizeFt` isolation, not the full design-effect override UI.
 **GH Issue:** [#105](https://github.com/micahbank2/room-cad-renderer/issues/105)
 **Plans:** 0 plans
 
 Plans:
-- [ ] TBD (promote with /gsd:review-backlog when ready, likely v1.9+ texture polish)
+- [ ] TBD (promote with /gsd:review-backlog or v2.0 milestone scoping)
 
-**Discovered:** 2026-04-25 during Phase 35 HUMAN-UAT — user asked why wood oak doesn't grow with the floor. Confirmed by-design behavior; captured as a natural follow-up enhancement. CLAUDE.md already flags "Texture tiling controls beyond real-world size" as out of scope for v1.8.
+**Discovered:** 2026-04-25 during Phase 35 HUMAN-UAT — user asked why wood oak doesn't grow with the floor. Confirmed by-design behavior; captured as a natural follow-up enhancement.
+**Promoted to v1.9 as Phase 41 (TILE-01)** during 2026-04-25 v1.9 scoping.
+**Re-deferred 2026-04-25** after Phase 39 feedback signal showed Jessica reported zero pain on texture sizing ("feels right"). Full design-effect override is hypothesis-only; the narrower BUG-01 fix (Phase 42) handles the per-surface isolation that's needed regardless. Revisit design-effect scaling when a future feedback session surfaces demand.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -30,12 +30,15 @@ Phases: 4 (38, 39, 40, 41) — none planned yet
 Plan: 1 of 2
 Status: Executing Phase 39
 
-## v1.9 Phase Sequence
+## v1.9 Phase Sequence (after 2026-04-25 mid-milestone re-scope)
 
-1. **Phase 38** — POLISH-01: VERIFICATION.md backfill for Phases 35/36/37 (closes AUDIT-01)
-2. **Phase 39** — FEEDBACK-01: real-use session with Jessica → ranked-priority doc that informs v2.0
-3. **Phase 40** — CEIL-01: ceiling resize handles (Phase 999.1 promotion) — subject to Phase 39 reordering
-4. **Phase 41** — TILE-01: per-surface texture tile-size override (Phase 999.3 / GH #105 promotion) — subject to Phase 39 reordering
+1. ✅ **Phase 38** — POLISH-01: VERIFICATION.md backfill for Phases 35/36/37 (closes AUDIT-01)
+2. ✅ **Phase 39** — FEEDBACK-01: async 5-question questionnaire with Jessica → zero friction, zero new wishes, all HUMAN-UAT confirmed
+3. 🔄 ~~**Phase 40** — CEIL-01~~ → **CANCELLED 2026-04-25**, re-deferred to Phase 999.1 backlog (Jessica said ceilings "went fine")
+4. 🔄 ~~**Phase 41** — TILE-01~~ → **CANCELLED 2026-04-25**, re-deferred to Phase 999.3 backlog (Jessica said texture sizing "feels right")
+5. ⏳ **Phase 42** — BUG-01: per-surface `tileSizeFt` isolation, closes GH #96. Final v1.9 phase. Plan + execution pending.
+
+After Phase 42 ships: `/gsd:audit-milestone v1.9` → `/gsd:complete-milestone v1.9` → `/gsd:new-milestone` for v2.0.
 
 Last activity: 2026-04-25
 


### PR DESCRIPTION
## Summary

Records the v1.9 mid-milestone rescope you accepted in [PR #112](https://github.com/micahbank2/room-cad-renderer/pull/112). Pure docs PR — REQUIREMENTS / ROADMAP / PROJECT / STATE only.

## Decisions formalized

| Phase | Was | Now |
|-------|-----|-----|
| **40** | Ceiling resize handles (CEIL-01) | **CANCELLED** — re-deferred to Phase 999.1 backlog. Jessica said ceilings "went fine." |
| **41** | Per-surface tile-size override (TILE-01) | **CANCELLED** — re-deferred to Phase 999.3 backlog. Jessica said texture sizing "feels right." |
| **42** | _new_ | **Per-surface \`tileSizeFt\` isolation bug fix (BUG-01)** — closes [GH #96](https://github.com/micahbank2/room-cad-renderer/issues/96). Real defect; ships regardless of feedback signal. |

## Why this is the right move

The v1.9 milestone explicitly hedged: "Phases 40-41 explicitly subject to Phase 39 reordering. If Jessica's pain points are elsewhere, these get bumped to v2.0+." Phase 39 surfaced exactly that — her signal contradicted the hypotheses behind both phases. Honoring the hedge prevents building on hypothesis-only.

The mid-milestone rescope is itself the most valuable artifact of v1.9: it validates the "feedback first" sequencing pattern. Wrong bet caught before money got spent on it.

## What ships in v1.9 (final)

- ✅ Phase 38 — VERIFICATION.md backfill (PR #110, awaiting merge)
- ✅ Phase 39 — Feedback signal (PR #112 merged)
- 🔄 Phase 40 — Cancelled
- 🔄 Phase 41 — Cancelled
- ⏳ Phase 42 — BUG-01 #96 fix (pending plan + execution)

After Phase 42 ships → audit + complete-milestone → \`/gsd:new-milestone\` for v2.0 with the curated GH-issue starting input from Phase 39's v2.0 scope seeds.

## v2.0 starting input (already curated)

Per Phase 39's v2.0 scope seeds:
- UX polish trio: [#97](https://github.com/micahbank2/room-cad-renderer/issues/97), [#98](https://github.com/micahbank2/room-cad-renderer/issues/98), [#99](https://github.com/micahbank2/room-cad-renderer/issues/99)
- Quick wins: [#100](https://github.com/micahbank2/room-cad-renderer/issues/100), [#101](https://github.com/micahbank2/room-cad-renderer/issues/101), [#76](https://github.com/micahbank2/room-cad-renderer/issues/76)
- Pascal competitor-insight set: [#79](https://github.com/micahbank2/room-cad-renderer/issues/79), [#80](https://github.com/micahbank2/room-cad-renderer/issues/80), [#78](https://github.com/micahbank2/room-cad-renderer/issues/78), [#77](https://github.com/micahbank2/room-cad-renderer/issues/77)
- PBR extensions: [#81](https://github.com/micahbank2/room-cad-renderer/issues/81)

## Test plan

- [ ] Skim REQUIREMENTS.md — confirm CEIL-01/TILE-01 deferred section reads honestly
- [ ] Skim ROADMAP.md — confirm Phase 40/41 cancellation markers + Phase 42 entry are correct
- [ ] Skim PROJECT.md Current Milestone — confirm final v1.9 shape

After merge: \`/gsd:plan-phase 42\` to scope the BUG-01 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)