### PR TITLE
Phase 44: Reduced-motion sweep (A11Y-01) — v1.10 milestone closer

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -116,7 +116,7 @@
 **Requirements:** A11Y-01
 **UI hint:** yes (subtle — observable only with `prefers-reduced-motion: reduce` set)
 **Plans:**
-- [ ] 44-01-sweep — wall-side camera snap + SAVING spinner conditional animate-spin (2 code commits + SUMMARY commit)
+1/1 plans complete
 
 ---
 
@@ -158,7 +158,7 @@
 | ~~41. Per-Surface Tile-Size Override~~ | n/a | CANCELLED   | 2026-04-25 (deferred to Phase 999.3) |
 | 42. Per-Surface tileSizeFt Bug Fix | 1/1 | Complete   | 2026-04-25 |
 | 43. UI Polish Bundle | 1/1 | Complete   | 2026-04-25 |
-| 44. Reduced-Motion Sweep | 0/1 | In progress | - |
+| 44. Reduced-Motion Sweep | 1/1 | Complete   | 2026-04-25 |
 
 ## Backlog
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -115,7 +115,8 @@
 **Depends on:** Phase 33 (`useReducedMotion` hook); Phase 30 (snap guide animation); existing `cameraAnimTarget` lerp in ThreeViewport.
 **Requirements:** A11Y-01
 **UI hint:** yes (subtle — observable only with `prefers-reduced-motion: reduce` set)
-**Plans:** TBD (est. 1 plan, ~1-2 commits)
+**Plans:**
+- [ ] 44-01-sweep — wall-side camera snap + SAVING spinner conditional animate-spin (2 code commits + SUMMARY commit)
 
 ---
 
@@ -157,7 +158,7 @@
 | ~~41. Per-Surface Tile-Size Override~~ | n/a | CANCELLED   | 2026-04-25 (deferred to Phase 999.3) |
 | 42. Per-Surface tileSizeFt Bug Fix | 1/1 | Complete   | 2026-04-25 |
 | 43. UI Polish Bundle | 1/1 | Complete   | 2026-04-25 |
-| 44. Reduced-Motion Sweep | 0/0 | Not started | - |
+| 44. Reduced-Motion Sweep | 0/1 | In progress | - |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,12 +4,12 @@ milestone: v1.10
 milestone_name: Evidence-Driven UX Polish
 status: executing
 stopped_at: v1.9 milestone archived
-last_updated: "2026-04-25T20:59:14.669Z"
+last_updated: "2026-04-25T21:32:03.356Z"
 progress:
   total_phases: 2
-  completed_phases: 0
-  total_plans: 1
-  completed_plans: 0
+  completed_phases: 1
+  total_plans: 2
+  completed_plans: 1
 ---
 
 # Project State
@@ -19,15 +19,15 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-25 — v1.10 Evidence-Driven UX Polish scoped)
 
 **Core value:** Jessica can see her future room with her actual furniture before spending money.
-**Current focus:** Phase 43 — ui-polish-bundle
+**Current focus:** Phase 44 — reduced-motion-sweep
 
 ## Current Position
 
-Phase: 43 (ui-polish-bundle) — EXECUTING
+Phase: 44 (reduced-motion-sweep) — EXECUTING
 Milestone: v1.10 Evidence-Driven UX Polish
 Phases: 2 (43, 44) — none planned yet
 Plan: 1 of 1
-Status: Executing Phase 43
+Status: Executing Phase 44
 
 **Next milestone committed:** v1.11 Pascal Feature Set (Phases 45–48) — formal scoping via `/gsd:new-milestone` after v1.10 ships. Per-node saved camera + Focus, room display modes, rooms hierarchy tree, auto-generated material swatch thumbnails.
 

--- a/.planning/phases/44-reduced-motion-sweep/44-01-sweep-PLAN.md
+++ b/.planning/phases/44-reduced-motion-sweep/44-01-sweep-PLAN.md
@@ -1,0 +1,173 @@
+---
+phase_number: 44
+plan_number: 01
+plan_name: sweep
+phase_dir: .planning/phases/44-reduced-motion-sweep
+objective: >
+  Add reduced-motion guards to two animation sites that pre-date Phase 33's
+  D-39 discipline: wall-side camera lerp in ThreeViewport.tsx (snap instead
+  of lerp) and SAVING spinner in Toolbar.tsx (drop animate-spin). v1.10
+  milestone closer.
+requirements_addressed: [A11Y-01]
+depends_on: []
+wave: 1
+autonomous: true
+files_modified:
+  - src/three/ThreeViewport.tsx
+  - src/components/Toolbar.tsx
+must_haves:
+  truths:
+    - "Wall-side camera tween: when prefersReducedMotion is true, camera snaps directly to camPos / lookAt instead of lerping via useFrame. Mirrors Phase 35 preset-tween reduced-motion path."
+    - "SAVING spinner: animate-spin class applied conditionally based on useReducedMotion(). Spinner icon stays visible (semantic meaning preserved); rotation removed."
+    - "Toolbar.tsx imports useReducedMotion (currently not imported)."
+    - "GH #76 closed with PR-reference comment after PR merges. Closing comment notes: snap guides did not need a guard (already render instantly per audit)."
+    - "npm run build succeeds; npx tsc --noEmit clean (pre-existing baseUrl warning ignored)"
+    - "npm test full suite: 6 pre-existing failures unchanged, no new regressions"
+---
+
+# Phase 44 Plan 01 — Reduced-Motion Sweep
+
+## Context
+
+2 atomic code commits + 1 SUMMARY commit. All decisions locked in 44-CONTEXT.md (D-01..D-06).
+
+---
+
+## Task 1 — Wall-side camera lerp guard
+
+**Read first:**
+- `src/three/ThreeViewport.tsx` lines ~215-244 (the `useEffect([wallSideCameraTarget, walls, cameraMode])`)
+- `src/three/ThreeViewport.tsx` Phase 35 preset-tween useEffect — model for the snap-instead-of-lerp branch
+- `src/three/ThreeViewport.tsx` line 67 — `prefersReducedMotion` already destructured here
+
+**Edit:** `src/three/ThreeViewport.tsx`
+
+In the existing wall-side useEffect, when `prefersReducedMotion` is true, snap directly instead of populating `cameraAnimTarget.current`. Sketch:
+
+```tsx
+useEffect(() => {
+  if (!wallSideCameraTarget || cameraMode !== "orbit") return;
+  const wall = walls[wallSideCameraTarget.wallId];
+  if (!wall) return;
+
+  // ...existing camPos / lookAt computation stays the same...
+
+  if (prefersReducedMotion) {
+    // Phase 44 A11Y-01: snap instantly, mirroring Phase 35 preset-tween path.
+    const ctrl = orbitControlsRef.current;
+    if (ctrl?.object) {
+      ctrl.object.position.copy(camPos);
+      ctrl.target.copy(lookAt);
+      ctrl.update();
+    }
+  } else {
+    cameraAnimTarget.current = { pos: camPos, look: lookAt };
+  }
+
+  useUIStore.getState().clearWallSideCameraTarget();
+}, [wallSideCameraTarget, walls, cameraMode, prefersReducedMotion]);
+```
+
+(Adjust to match the actual code's variable names + flow. Add `prefersReducedMotion` to the dependency array.)
+
+**Acceptance:**
+- TypeScript compiles
+- Manual smoke (default motion): trigger wall-side camera target (likely via "face wall side" UI in PropertiesPanel) — camera lerps as before
+- Manual smoke (reduced motion enabled): same trigger — camera snaps directly to wall-side pose, no lerp
+
+**Commit:** `feat(44-01): wall-side camera snaps when prefers-reduced-motion (A11Y-01)
+
+Wraps the existing wall-side useEffect cameraAnimTarget assignment in a
+prefersReducedMotion guard. When reduced-motion is on, snap directly via
+ctrl.object.position.copy() / ctrl.target.copy() — no useFrame lerp.
+Mirrors Phase 35 preset-tween reduced-motion path. Refs #76.`
+
+---
+
+## Task 2 — SAVING spinner guard
+
+**Read first:**
+- `src/components/Toolbar.tsx:280` — `animate-spin` site
+- `src/components/MyTexturesList.tsx:27,44` — existing `useReducedMotion` import + consumer pattern
+
+**Edit:** `src/components/Toolbar.tsx`
+
+(a) Add `useReducedMotion` import at the top of the file (mirror MyTexturesList.tsx:27 style).
+
+(b) Inside `ToolbarSaveStatus` component (around line 259), call the hook: `const reducedMotion = useReducedMotion();`
+
+(c) On line 280, conditionally apply `animate-spin`:
+
+```tsx
+<span
+  className={`material-symbols-outlined text-[14px] text-accent-light ${
+    reducedMotion ? "" : "animate-spin"
+  }`}
+>
+  progress_activity
+</span>
+```
+
+**Acceptance:**
+- TypeScript compiles
+- Manual smoke (default motion): trigger save (any CAD edit + 2s wait) — spinner rotates as before during SAVING state
+- Manual smoke (reduced motion enabled): same trigger — spinner icon visible but does NOT rotate; SAVED still appears after save completes
+
+**Commit:** `feat(44-01): SAVING spinner stops rotating when prefers-reduced-motion (A11Y-01)
+
+Toolbar's progress_activity icon's animate-spin class is now conditional
+on useReducedMotion(). Icon stays visible during the SAVING state (semantic
+meaning preserved); rotation removed. Closes #76 (SAVING spinner half) +
+wraps up A11Y-01.`
+
+---
+
+## Task 3 — SUMMARY + GH #76 close
+
+**Edit:** `.planning/phases/44-reduced-motion-sweep/44-01-sweep-SUMMARY.md` (new)
+
+Standard SUMMARY.md format. Note explicitly:
+- 2 sites guarded; snap guides verified to NOT need a guard (already render instantly — GH #76 problem-statement inaccuracy)
+- Phase 35 preset tween was already guarded (D-39 discipline) — Phase 44 brings older paths to parity
+
+**Close GH #76:**
+
+```bash
+gh issue close 76 --comment "Shipped in **Phase 44 (v1.10 milestone)** —
+- Wall-side camera tween (ThreeViewport.tsx) snaps directly when prefers-reduced-motion is enabled, instead of lerping via useFrame
+- SAVING spinner (Toolbar.tsx) drops animate-spin class when reduced-motion is enabled; icon stays visible
+
+Snap guides (snapGuides.ts) verified to NOT need a guard — they render at static opacity and are instantly added/cleared, so 'fade in/out' from the issue body did not match actual behavior.
+
+Phase 35 camera presets were already guarded (Phase 33 D-39 discipline). Phase 44 brings the older animation paths to parity. PR <#-this-PR>."
+```
+
+**Acceptance:**
+- SUMMARY.md created at `.planning/phases/44-reduced-motion-sweep/44-01-sweep-SUMMARY.md`
+- STATE.md + ROADMAP.md updated (44: 0/0 → 1/1 Complete)
+- GH #76 closed with PR-reference comment
+
+**Commit:** `docs(44-01): complete reduced-motion sweep SUMMARY + state updates
+
+Closes #76. Phase 44 ships 2 reduced-motion guards (wall-side camera +
+SAVING spinner) and documents that snap guides did not need a guard
+(verified during planning). v1.10 milestone closer.
+
+After this commit: /gsd:audit-milestone v1.10 → /gsd:complete-milestone v1.10.`
+
+---
+
+## Plan-level acceptance criteria
+
+- [ ] All 3 tasks executed and committed atomically
+- [ ] `npx tsc --noEmit` clean
+- [ ] `npm test` full suite: 6 pre-existing failures unchanged, no new regressions
+- [ ] Manual smoke for both code changes (default-motion + reduced-motion)
+- [ ] GH #76 CLOSED with PR-reference comment
+- [ ] SUMMARY.md created
+- [ ] STATE.md + ROADMAP.md updated
+
+---
+
+*Plan: 44-01-sweep*
+*Author: orchestrator-inline (CONTEXT.md fully prescriptive)*

--- a/.planning/phases/44-reduced-motion-sweep/44-01-sweep-SUMMARY.md
+++ b/.planning/phases/44-reduced-motion-sweep/44-01-sweep-SUMMARY.md
@@ -1,0 +1,76 @@
+---
+phase: 44-reduced-motion-sweep
+plan: 01
+subsystem: a11y
+tags: [a11y, reduced-motion, polish, milestone-closer]
+requirements: [A11Y-01]
+dependency-graph:
+  requires:
+    - Phase 33 useReducedMotion hook
+    - Phase 35 preset-tween reduced-motion path (model)
+  provides:
+    - Wall-side camera tween honors prefers-reduced-motion (snap directly, no useFrame lerp)
+    - SAVING spinner honors prefers-reduced-motion (icon stays visible, rotation removed)
+  affects:
+    - none beyond declared files_modified
+tech-stack:
+  added: []
+  patterns:
+    - "Reduced-motion guard mirrors Phase 35 preset-tween path: never enter useFrame lerp"
+    - "Spinner stays visible to preserve semantic meaning; only rotation suppressed"
+key-files:
+  created:
+    - .planning/phases/44-reduced-motion-sweep/44-01-sweep-SUMMARY.md
+  modified:
+    - src/three/ThreeViewport.tsx (wall-side useEffect: prefersReducedMotion guard + dependency)
+    - src/components/Toolbar.tsx (useReducedMotion import + conditional animate-spin class)
+decisions:
+  - All 6 CONTEXT decisions (D-01..D-06) honored as-written.
+  - Snap guides verified during planning to NOT need a guard (render at static GUIDE_OPACITY = 0.6, instantly cleared/added — GH #76's 'fade in/out' claim was incorrect). Documented for future audits.
+  - Hover transition-colors micro-transitions left as-is per industry convention (color, not motion).
+deviations:
+  - GH #76 closed with comment noting the snap-guides finding (issue body was partially incorrect).
+  - Plan executed inline by orchestrator (no gsd-executor subagent). Phase scope (~10 lines of code) made inline efficient.
+verification:
+  manual:
+    - Default-motion: trigger wall-side camera target (PropertiesPanel 'face wall side') → camera lerps as before
+    - Reduced-motion (DevTools → Rendering → Emulate prefers-reduced-motion: reduce): same trigger → camera snaps directly, no lerp
+    - Default-motion: any CAD edit + 2s wait → SAVING spinner rotates briefly
+    - Reduced-motion: same trigger → spinner icon visible, no rotation; SAVED appears as before once save completes
+  automated:
+    - npx tsc --noEmit clean (only pre-existing baseUrl deprecation warning)
+    - npm test full suite: 537 passed / 6 failed (pre-existing baseline) / 3 todo
+  human-uat:
+    - Visual smoke for both reduced-motion changes (one-time, after merge)
+test-results:
+  build: succeeds (verified via Vite HMR in preview server)
+  typecheck: clean (1 pre-existing deprecation warning unrelated)
+  unit: 537 passed / 6 failed (pre-existing baseline) / 3 todo
+  e2e: not run (visual presentation changes; manual smoke sufficient)
+  preview-bundle-loaded: yes (cleanly reloaded after both edits)
+---
+
+# Phase 44 Plan 01 — Reduced-Motion Sweep SUMMARY
+
+## What shipped
+
+| # | Commit | What |
+|---|--------|------|
+| 1 | `9b7260f` | Wall-side camera tween snaps directly when `prefersReducedMotion` is true; otherwise uses existing `cameraAnimTarget` lerp. |
+| 2 | `0f41ebd` | SAVING spinner's `animate-spin` class is conditional on `useReducedMotion()`. Icon stays visible during SAVING; rotation only when motion is allowed. |
+
+## What we explicitly did NOT change
+
+**Snap guides (`src/canvas/snapGuides.ts`)** — GH #76's problem statement claimed "accent-purple snap guides fade in/out." Code scout during planning verified: snap guides render at static `GUIDE_OPACITY = 0.6` and are instantly added/cleared via `clearSnapGuides()` + add loop. **No animation exists; no guard needed.** Documented in CONTEXT D-03 + here so future audits don't flag the absence as a gap.
+
+**Hover transition-colors micro-transitions** — Color-only Toolbar/button hover effects (e.g. `transition-colors duration-150`) stay as-is. Industry convention treats `prefers-reduced-motion` as scoped to position/scale/rotation animations. Disabling hover color fades would harm rather than help UX.
+
+## Phase 35 parity achieved
+
+Phase 35 preset tween was already guarded (Phase 33 D-39 discipline). v1.10 brings the older animation paths (wall-side camera lerp from MIC-35; SAVING spinner from Phase 28) to the same standard. v1.10 milestone now closed.
+
+## Phase 44 status
+
+Single plan, complete. v1.10 status: **2 of 2 phases complete.** Ready for `/gsd:audit-milestone v1.10` → `/gsd:complete-milestone v1.10`.
+
+After v1.10 milestone close: `/gsd:new-milestone` for v1.11 Pascal Feature Set (already pre-committed in PROJECT.md + ROADMAP.md).

--- a/.planning/phases/44-reduced-motion-sweep/44-CONTEXT.md
+++ b/.planning/phases/44-reduced-motion-sweep/44-CONTEXT.md
@@ -1,0 +1,93 @@
+# Phase 44: Reduced-Motion Sweep — Context
+
+**Gathered:** 2026-04-25
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Honor `prefers-reduced-motion: reduce` for the older animation paths that pre-date the Phase 33 `useReducedMotion` discipline (D-39). Phase 35 preset tween already does this; bring siblings to parity. v1.10 milestone closer.
+
+**In scope:**
+- Wall-side camera lerp in `ThreeViewport.tsx` (`cameraAnimTarget` + `useFrame` lerp at speed 0.08) — snap instead of lerp
+- SAVING spinner in `Toolbar.tsx` (`animate-spin` class on `progress_activity` icon) — drop the spin
+
+**Out of scope — verified to NOT need a guard:**
+- Snap guides (`src/canvas/snapGuides.ts`) — render at static `GUIDE_OPACITY = 0.6`, added/cleared instantly via `clearSnapGuides()` + add loop. GH #76's "fade" claim doesn't match the actual code; no animation to guard.
+- Phase 35 preset tween — already guarded (reduced-motion → instant snap, never enters `useFrame`)
+- CSS `transition-colors` micro-transitions on hover — these are color-only and not motion in the WCAG-meaningful sense; out of scope per industry convention
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Wall-side camera lerp guard
+- **D-01:** In `ThreeViewport.tsx` `useEffect([wallSideCameraTarget, walls, cameraMode])` (lines ~215-244), when `prefersReducedMotion` is true, do NOT set `cameraAnimTarget.current`. Instead, immediately set `ctrl.object.position` and `ctrl.target` to the computed `camPos` / `lookAt`, then `ctrl.update()`. Then `useUIStore.getState().clearWallSideCameraTarget()` as the existing path does.
+- **Reason:** Mirrors Phase 35 preset-tween reduced-motion path (instant snap, never enters `useFrame`). Snap is honest; shortened linear tween is still motion. The `prefersReducedMotion` value is already destructured at line 67 — no new wiring needed.
+
+### SAVING spinner guard
+- **D-02:** In `Toolbar.tsx:280`, conditionally apply `animate-spin` based on `useReducedMotion()`. Wrap the className in a template literal: `animate-spin` only when reduced-motion is FALSE. Spinner icon stays visible (continues conveying "save in progress") — just doesn't rotate.
+- **Reason:** Continuous rotation is a clear motion target for `prefers-reduced-motion`. Removing the rotation while keeping the icon preserves semantic meaning (icon distinguishes SAVING from SAVED via shape, not animation). `useReducedMotion` will need to be imported into Toolbar.tsx (currently not imported there).
+
+### What we explicitly do NOT change
+- **D-03:** Snap guides need no guard. Documented in SUMMARY.md so future audits don't flag the absence as a gap. GH #76's "fade in/out" claim was incorrect — guides render at static opacity and are instantly cleared/redrawn.
+- **D-04:** CSS `transition-colors duration-150` micro-transitions on hover (Toolbar buttons, etc.) stay as-is. These are color-only transitions, not motion in the accessibility sense. Industry convention treats `prefers-reduced-motion` as scoped to position/scale/rotation animations; disabling hover color fades would harm rather than help UX.
+
+### Plan structure
+- **D-05:** Single plan, 2 atomic code commits + 1 SUMMARY commit (3 total). Keep tests scope to manual verification — both changes are observable visually with `prefers-reduced-motion: reduce` set in DevTools.
+- **Reason:** Each code change is ~5-10 lines. Multi-plan structure would be over-engineering. Atomic commits map 1:1 to (a) `ThreeViewport.tsx` wall-side guard, (b) `Toolbar.tsx` spinner guard.
+
+### Test strategy
+- **D-06:** No new automated tests. Manual smoke per task acceptance — DevTools reduced-motion emulator + observe behavior. Existing test suite must stay green.
+- **Reason:** These are presentation-only changes. Adding a vitest test for "spinner doesn't rotate when reduced-motion is on" would require mocking `window.matchMedia` and asserting className conditional — high ceremony for a 1-line guard. The change's correctness is visually self-evident.
+
+### Claude's Discretion
+- Exact placement of the `prefersReducedMotion` check inside the wall-side `useEffect` (early branch vs. ternary on `cameraAnimTarget.current` assignment — pick whichever reads cleaner)
+- Whether to extract the SAVING-spinner className into a const for readability vs. inline ternary (pick whatever produces the cleaner diff)
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- **`prefersReducedMotion` already destructured in ThreeViewport** at line 67. Wall-side guard just needs to consume it in the existing useEffect — no new wiring.
+- **Toolbar.tsx needs the import added.** Pattern to mirror: `src/components/MyTexturesList.tsx:27` (existing `useReducedMotion` consumer).
+- **Phase 35 preset-tween reduced-motion path** is the clearest model — see `useEffect([pendingPresetRequest, cameraMode, prefersReducedMotion, room])` in ThreeViewport.tsx. Wall-side guard should mirror its "snap instantly, never enter useFrame" branch.
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+### Requirements
+- `.planning/REQUIREMENTS.md` §A11Y-01
+- [GH #76](https://github.com/micahbank2/room-cad-renderer/issues/76)
+
+### Existing code
+- `src/hooks/useReducedMotion.ts` — the hook to consume
+- `src/three/ThreeViewport.tsx:215-244` — wall-side useEffect, target for D-01
+- `src/three/ThreeViewport.tsx` Phase 35 preset-tween useEffect — model for the snap-instead-of-lerp pattern
+- `src/components/Toolbar.tsx:280` — `animate-spin` site, target for D-02
+- `src/components/MyTexturesList.tsx:27,44` — existing useReducedMotion consumer pattern (for Toolbar.tsx import)
+
+### Phase 33 conventions (carry-forward)
+- D-39: every new animation guards on `useReducedMotion()` — this phase brings older paths to that standard
+
+### Out-of-scope verifications
+- `src/canvas/snapGuides.ts` — verified static-opacity, no fade
+
+</canonical_refs>
+
+<deferred>
+## Deferred Ideas
+
+- **Hover transition-colors guards** — D-04 explicitly out of scope. Industry convention treats motion as position/scale/rotation, not color. Revisit only if accessibility audit specifically flags.
+- **Automated tests for reduced-motion behavior** — D-06 explicitly out of scope. Visual self-evidence + existing manual smoke is sufficient for these 2-line changes.
+- **GH #76 "snap guides fade" claim** — verified incorrect; documented in D-03. Issue body inaccuracy, not a real gap.
+
+</deferred>
+
+---
+
+*Phase: 44-reduced-motion-sweep*
+*Context gathered: 2026-04-25*

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,6 +1,7 @@
 import { useUIStore } from "@/stores/uiStore";
 import { useCADStore } from "@/stores/cadStore";
 import { useProjectStore } from "@/stores/projectStore";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { exportRenderedImage } from "@/lib/export";
 import type { ToolType } from "@/types/cad";
 import Tooltip from "@/components/Tooltip";
@@ -258,6 +259,10 @@ const TOOL_SHORTCUTS: Record<ToolType, string> = {
 /** Prominent save indicator in the top toolbar (SAVE-04) */
 function ToolbarSaveStatus() {
   const status = useProjectStore((s) => s.saveStatus);
+  // Phase 44 A11Y-01: drop the SAVING spinner's continuous rotation when
+  // prefers-reduced-motion is on. Icon stays visible (semantic meaning
+  // preserved); rotation removed.
+  const reducedMotion = useReducedMotion();
 
   // D-04 / D-04a: SAVE_FAILED surface — persists (no auto-fade) until store leaves "failed"
   if (status === "failed") {
@@ -277,7 +282,11 @@ function ToolbarSaveStatus() {
     <div className="flex items-center gap-1.5 min-w-[72px]" aria-label="Save status">
       {isSaving ? (
         <>
-          <span className="material-symbols-outlined text-[14px] text-accent-light animate-spin">
+          <span
+            className={`material-symbols-outlined text-[14px] text-accent-light ${
+              reducedMotion ? "" : "animate-spin"
+            }`}
+          >
             progress_activity
           </span>
           <span className="font-mono text-base tracking-widest text-accent-light">

--- a/src/three/ThreeViewport.tsx
+++ b/src/three/ThreeViewport.tsx
@@ -211,7 +211,10 @@ function Scene({ productLibrary }: Props) {
     };
   }, []);
 
-  // MIC-35: animate camera to face selected wall side
+  // MIC-35: animate camera to face selected wall side.
+  // Phase 44 A11Y-01: when prefers-reduced-motion is on, snap directly to the
+  // wall-side pose instead of populating cameraAnimTarget (which drives a
+  // useFrame lerp). Mirrors Phase 35 preset-tween reduced-motion path.
   useEffect(() => {
     if (!wallSideCameraTarget || cameraMode !== "orbit") return;
     const wall = walls[wallSideCameraTarget.wallId];
@@ -232,9 +235,19 @@ function Scene({ productLibrary }: Props) {
     // Camera position: wall center + normal * distance (in 3D coords: x→x, y→up, z→z)
     const camPos = new THREE.Vector3(cx + nx * dist, cy + 2, cz + nz * dist);
     const lookAt = new THREE.Vector3(cx, cy, cz);
-    cameraAnimTarget.current = { pos: camPos, look: lookAt };
+    if (prefersReducedMotion) {
+      // Snap directly — never enter useFrame lerp.
+      const ctrl = orbitControlsRef.current;
+      if (ctrl?.object) {
+        ctrl.object.position.copy(camPos);
+        ctrl.target.copy(lookAt);
+        ctrl.update();
+      }
+    } else {
+      cameraAnimTarget.current = { pos: camPos, look: lookAt };
+    }
     useUIStore.getState().clearWallSideCameraTarget();
-  }, [wallSideCameraTarget, walls, cameraMode]);
+  }, [wallSideCameraTarget, walls, cameraMode, prefersReducedMotion]);
 
   // Phase 35 CAM-02: consume pendingPresetRequest from uiStore.
   // Research §1 cancel-and-restart — startPresetTween captures `from` from


### PR DESCRIPTION
## Summary

Closes A11Y-01 + GH #76. Adds \`useReducedMotion\` guards to two animation sites that pre-date Phase 33 D-39 discipline: wall-side camera lerp + SAVING spinner. **Final v1.10 phase.**

## What changed

| # | Commit | Change |
|---|--------|--------|
| 1 | \`9b7260f\` | \`ThreeViewport.tsx\` wall-side useEffect: when \`prefersReducedMotion\` is on, snap directly via \`ctrl.object.position.copy()\` instead of populating \`cameraAnimTarget\` (which drives \`useFrame\` lerp). Mirrors Phase 35 preset-tween pattern. |
| 2 | \`0f41ebd\` | \`Toolbar.tsx\` ToolbarSaveStatus: \`animate-spin\` class on the SAVING progress_activity icon now conditional on \`useReducedMotion()\`. Icon stays visible (semantic meaning preserved); rotation removed. |

## Honest finding from planning

GH #76's body listed 3 targets. Code scout revealed only **2 are real**:

- ✅ Wall-side camera tween — uses \`useFrame\` lerp. Real. Guarded.
- ✅ SAVING spinner — \`animate-spin\` on \`progress_activity\` icon. Real. Guarded.
- ❌ Snap guides — render at static \`GUIDE_OPACITY = 0.6\` and are instantly added/cleared via \`clearSnapGuides()\` + add loop. **No animation exists; no guard needed.** Documented in CONTEXT D-03 + SUMMARY so future audits don't flag the absence.

## Test results

- \`npx tsc --noEmit\` clean
- \`npm test\` → 537 passed / 6 failed (pre-existing baseline) / 3 todo
- Build succeeds (verified via Vite HMR in preview server)

## Test plan

- [ ] DevTools → Rendering → Emulate \`prefers-reduced-motion: reduce\`
- [ ] Trigger wall-side camera target (e.g. PropertiesPanel "face wall side") → camera snaps directly, no lerp
- [ ] Make any CAD edit + wait 2s → SAVING spinner icon visible but does NOT rotate
- [ ] Disable reduced-motion emulator → both behaviors return to motion

After merge: \`/gsd:audit-milestone v1.10\` → \`/gsd:complete-milestone v1.10\` → \`/gsd:new-milestone\` for v1.11 (Pascal Feature Set, already pre-committed).

Closes A11Y-01.
Refs #76 (already closed; left audit-trail comment).
Spec: \`.planning/phases/44-reduced-motion-sweep/44-01-sweep-PLAN.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)