### PR TITLE
Scope v1.11 Pascal Feature Set

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -47,17 +47,19 @@ See `.planning/ROADMAP.md` for links to each milestone archive.
 
 </details>
 
-## Current Milestone: v1.11 Pascal Feature Set (next to scope)
+## Current Milestone: v1.11 Pascal Feature Set
 
-**Status:** v1.10 shipped 2026-04-25. v1.11 pre-committed in PROJECT + ROADMAP for the 4 Pascal Editor competitor-insight items the user explicitly committed to as the next direction. Formal scoping via `/gsd:new-milestone` produces REQUIREMENTS.md + ROADMAP entry + Phase Details — that's the next step.
+**Goal:** Adopt the 4 strongest features from the Pascal Editor competitive audit. v1.9 Phase 39 deferred these as "speculative"; user explicitly committed to them during v1.10 scoping as the next direction.
 
-**Target features:**
-- **Phase 45 / [#79](https://github.com/micahbank2/room-cad-renderer/issues/79)** — Per-node saved camera with Focus action (each placed product / wall / ceiling can have its own bookmarked camera angle, double-click "Focus" jumps the camera there)
-- **Phase 46 / [#80](https://github.com/micahbank2/room-cad-renderer/issues/80)** — Room display modes (solo / explode) for inspecting individual rooms in isolation or seeing exploded-axonometric layouts
-- **Phase 47 / [#78](https://github.com/micahbank2/room-cad-renderer/issues/78)** — Rooms hierarchy sidebar tree (collapsible, click-to-focus, visibility toggles per-node)
-- **Phase 48 / [#77](https://github.com/micahbank2/room-cad-renderer/issues/77)** — Auto-generated material swatch thumbnails from the renderer (replaces hand-curated swatches in pickers)
+**Target features (4 issues, 4 phases — easy → hard):**
+- **Phase 45 / THUMB-01 / [#77](https://github.com/micahbank2/room-cad-renderer/issues/77)** — Auto-generated material swatch thumbnails from the renderer (replaces hand-curated swatches in pickers)
+- **Phase 46 / TREE-01 / [#78](https://github.com/micahbank2/room-cad-renderer/issues/78)** — Rooms hierarchy sidebar tree (collapsible per-room, click-to-focus, per-node visibility toggle)
+- **Phase 47 / DISPLAY-01 / [#80](https://github.com/micahbank2/room-cad-renderer/issues/80)** — Room display modes (NORMAL / SOLO / EXPLODE) for inspecting individual rooms or seeing exploded layouts
+- **Phase 48 / CAM-04 / [#79](https://github.com/micahbank2/room-cad-renderer/issues/79)** — Per-node saved camera with Focus action (each product/wall/ceiling can bookmark a camera angle; double-click in tree jumps camera there via Phase 35 tween)
 
-**Sequencing intent:** TBD at scoping time. Likely [#77](https://github.com/micahbank2/room-cad-renderer/issues/77) first (cheap, isolated — no schema changes), then [#78](https://github.com/micahbank2/room-cad-renderer/issues/78) (rooms tree depends only on existing room data), then [#80](https://github.com/micahbank2/room-cad-renderer/issues/80) (display modes layer on top of room rendering), then [#79](https://github.com/micahbank2/room-cad-renderer/issues/79) (per-node camera bookmarks need camera-state plumbing extension).
+**Phase numbering:** Phases 45–48 (continues from 44).
+
+**Sequencing intent:** Easy → hard. Phase 45 (cheapest, isolated, no schema changes). Phase 46 (rooms tree depends on existing room data — provides infrastructure for Focus). Phase 47 (display modes layer on top of room rendering + tree's "active room" semantic). Phase 48 (per-node camera reuses Phase 35 tween + Phase 46 tree double-click trigger). Each phase ships a tangible UX win — cancellation of any later phase still leaves earlier phases' value behind.
 
 **Out of v1.11:** Backend / auth / cloud sync / mobile / iPad — major-version leap territory. R3F v9 / React 19 upgrade — still gated on R3F v9 stability ([#56](https://github.com/micahbank2/room-cad-renderer/issues/56)). [#97](https://github.com/micahbank2/room-cad-renderer/issues/97) Properties panel in 3D/split — separate concern. [#81](https://github.com/micahbank2/room-cad-renderer/issues/81) PBR extensions — different domain. Phase 999.1 (ceiling drag-resize) + Phase 999.3 (full design-effect tile override) — re-deferred from v1.9 cancellation; revisit pending demand signal.
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,82 @@
+---
+milestone: v1.11
+milestone_name: Pascal Feature Set
+status: active
+created: 2026-04-25
+source: Pascal Editor competitive audit (.planning/competitive/pascal-audit.md); 4 GH issues filed during v1.7.5 design-system work as competitor-insight
+---
+
+# v1.11 Requirements — Pascal Feature Set
+
+**Milestone goal:** Adopt the 4 strongest features from the Pascal Editor competitive audit. v1.9 Phase 39 deferred these as "speculative" because there was no demand signal at the time; the user explicitly committed to them as the next direction during v1.10 scoping.
+
+**Source:** Pascal audit at `.planning/competitive/pascal-audit.md`. 4 GH issues: [#77](https://github.com/micahbank2/room-cad-renderer/issues/77), [#78](https://github.com/micahbank2/room-cad-renderer/issues/78), [#79](https://github.com/micahbank2/room-cad-renderer/issues/79), [#80](https://github.com/micahbank2/room-cad-renderer/issues/80).
+
+**Success measure:** All 4 Pascal features ship as user-visible improvements. Each is independently shippable — cancellation of any later phase still leaves the earlier phases' value behind.
+
+**Stack:** No new runtime dependencies anticipated. Reuses Phase 33 design tokens / `lucide-react` chrome / `useReducedMotion`, Phase 34 user-texture pipeline, Phase 35 camera infrastructure (`uiStore.cameraMode`, `__setTestCamera`), and `cadStore` room/customElement structure.
+
+**Cross-cutting decisions inherited:**
+- Phase 33 D-33 (icon policy: lucide for new chrome) + D-34 (canonical spacing tokens)
+- Phase 33 D-39 (every new animation guards on `useReducedMotion`)
+- 6 pre-existing vitest failures permanently accepted (Phase 37 D-02); CI vitest stays disabled
+- Substitute-evidence policy formalized in v1.10 (SUMMARY.md is canonical evidence; VERIFICATION.md optional)
+
+**Sequencing intent:** Easy → hard. Each phase ships a tangible UX win; sequencing minimizes upstream-dependency churn.
+
+---
+
+## v1.11 Requirements
+
+### Auto-Generated Material Swatch Thumbnails (THUMB)
+
+- [ ] **THUMB-01** — Material picker swatches are auto-rendered from the live PBR/material pipeline rather than hand-curated static images. Source: [#77](https://github.com/micahbank2/room-cad-renderer/issues/77).
+  - **Verifiable:** Open any material picker (FloorMaterialPicker, SwatchPicker, ceiling material picker via SurfaceMaterialPicker) → each swatch tile renders the actual material that will apply when selected (correct color/tone/PBR feel for the size of the tile). Adding a new material to `src/data/surfaceMaterials.ts` (or equivalent) does NOT require committing a new PNG asset — the swatch generates from the material definition.
+  - **Acceptance:** Renderer-driven thumbnail generation (small offscreen R3F or WebGL canvas, or static-shader fallback for non-PBR materials). Cached per-material so each picker render does not re-paint. Cache invalidates on material edit. Loading state graceful — placeholder hex swatch while async render completes (re-uses Phase 32 `<Suspense>` + `<ErrorBoundary>` pattern).
+
+### Rooms Hierarchy Sidebar Tree (TREE)
+
+- [ ] **TREE-01** — Sidebar gains a Rooms hierarchy tree: collapsible per room, showing the room's contents (walls, ceilings, placed products, custom-element placements) as nested children. Click-to-focus the camera on a node. Per-node visibility toggle. Source: [#78](https://github.com/micahbank2/room-cad-renderer/issues/78).
+  - **Verifiable:** Sidebar shows a "Rooms" panel with one entry per room in `cadStore.rooms`. Expanding a room reveals its child nodes grouped (Walls / Ceilings / Products / Custom Elements). Clicking a child node selects it (drives `uiStore.selectedIds`) AND focuses the camera (re-uses MIC-35 wall-side / Phase 35 preset camera infrastructure). Eye icon next to each node toggles visibility (renderer skips hidden nodes).
+  - **Acceptance:** Reuses `CollapsibleSection` primitive (Phase 33). Selection state is single source of truth via `uiStore.selectedIds` — clicking in tree drives same path as clicking in canvas. Visibility state lives on `uiStore.hiddenIds: Set<string>` (new field) — view-state, not CAD-state, so undo/autosave skip it. Lucide icons for tree (ChevronRight/Down, Eye/EyeOff). Activates per-node Focus action (TREE-CAM-01 below) — but Focus itself ships in CAM-04, not here.
+
+### Room Display Modes (DISPLAY)
+
+- [ ] **DISPLAY-01** — Toolbar (or sidebar) gains a display-mode selector: NORMAL (default — all rooms render), SOLO (only the active room renders, others hidden), EXPLODE (all rooms render with positional offsets so they don't overlap visually — axonometric "exploded" feel). Source: [#80](https://github.com/micahbank2/room-cad-renderer/issues/80).
+  - **Verifiable:** With 3+ rooms in a project, switch the display mode → 3D viewport changes correspondingly. SOLO hides all but `activeRoomId`. EXPLODE preserves all rooms but offsets them along an axis so they read as separate volumes (matches Pascal's "exploded layout" concept). NORMAL is the existing render. Switching modes is instant — no tween (D-39 reduced-motion: snap; design choice: this is a structural mode change, not a transition).
+  - **Acceptance:** New `uiStore.displayMode: "normal" | "solo" | "explode"` field (default `"normal"`). Three toggles in Toolbar (or appropriate UI surface — picker decided in CONTEXT). EXPLODE math: each room offset by `(roomBboxWidth × index)` along X-axis, stacked spacing decided in CONTEXT. Hidden rooms (SOLO mode) skipped at the `Object.values(rooms).map` level in ThreeViewport. View-state only — no cadStore mutations, no undo entries, no autosave triggers.
+
+### Per-Node Saved Camera + Focus Action (CAM)
+
+- [ ] **CAM-04** — Each placed product / wall / ceiling can have a bookmarked camera angle saved on it. Double-clicking the node (in the rooms tree from TREE-01, or via right-click context menu in the canvas) jumps the camera to that bookmarked angle via the same easeInOutCubic tween as Phase 35 presets. Source: [#79](https://github.com/micahbank2/room-cad-renderer/issues/79).
+  - **Verifiable:** Right-click any selected wall / product / ceiling → context menu has "Save current camera here" + "Focus camera here". Save persists `position` + `target` on the node. Focus jumps via the existing presetTween infrastructure (Phase 35). Double-click in TREE-01's tree triggers Focus. Snapshot serializes the camera bookmark per node.
+  - **Acceptance:** New optional fields on `WallSegment`, `PlacedProduct`, `Ceiling`, `PlacedCustomElement`: `savedCameraPos?: [number, number, number]` + `savedCameraTarget?: [number, number, number]`. Focus action drives Phase 35's `pendingPresetRequest` shape (or a new `pendingCameraTarget` sibling — picked in CONTEXT). Reuses easeInOutCubic tween + reduced-motion snap (D-04 inherited from Phase 35). Save/Focus actions are view-only writes that do NOT pollute undo history (per CAM-03 precedent — extended). Right-click context menu uses Phase 33 lucide icons.
+
+---
+
+## Future Requirements (Deferred)
+
+These items remain deferred per prior milestone audits — no change in v1.11:
+
+- **[#97](https://github.com/micahbank2/room-cad-renderer/issues/97) Properties panel in 3D/split** — actual feature, no demand signal. Speculative. Revisit if Jessica or Micah surfaces evidence.
+- **[#81](https://github.com/micahbank2/room-cad-renderer/issues/81) PBR extensions (AO + displacement + emissive)** — feature work without demand. Revisit pending request.
+- **Phase 999.1 — Ceiling drag-resize handles** — re-deferred from v1.9 cancellation.
+- **Phase 999.3 — Full design-effect tile-size override** — re-deferred from v1.9 cancellation.
+- **Lighting controls / walk-mode improvements / layout templates / multi-room nav / export workflow / AI-assisted layout** — feature work without demand.
+- **Backend / auth / cloud sync / sharing / mobile / iPad** — major-version leap; revisit only when an actual reason exists outside our heads.
+- **R3F v9 / React 19 upgrade** — still gated on R3F v9 stability ([#56](https://github.com/micahbank2/room-cad-renderer/issues/56)).
+
+## Traceability
+
+Phase → requirement mapping. Plan column filled by `/gsd:plan-phase` when each phase is planned.
+
+| Requirement | Phase | Plan(s) |
+| ----------- | ----- | ------- |
+| THUMB-01 | Phase 45 | TBD |
+| TREE-01 | Phase 46 | TBD |
+| DISPLAY-01 | Phase 47 | TBD |
+| CAM-04 | Phase 48 | TBD |
+
+---
+
+*Last updated: 2026-04-25*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -14,7 +14,7 @@
 - ✅ **v1.8 3D Realism Completion** — Phases 34–37 (shipped 2026-04-25) — see [milestones/v1.8-ROADMAP.md](milestones/v1.8-ROADMAP.md)
 - ✅ **v1.9 Polish & Feedback** — Phases 38, 39, 42 (Phases 40 + 41 cancelled mid-milestone) — shipped 2026-04-25 — see [milestones/v1.9-ROADMAP.md](milestones/v1.9-ROADMAP.md)
 - ✅ **v1.10 Evidence-Driven UX Polish** — Phases 43–44 (shipped 2026-04-25) — see [milestones/v1.10-ROADMAP.md](milestones/v1.10-ROADMAP.md)
-- 📋 **v1.11 Pascal Feature Set** — Phases 45–48 (planned; next to scope via `/gsd:new-milestone`)
+- 🚧 **v1.11 Pascal Feature Set** — Phases 45–48 (in progress)
 
 ---
 
@@ -99,25 +99,45 @@
 
 ---
 
-## v1.11 Pascal Feature Set — PREVIEW (queued after v1.10)
+## v1.11 Pascal Feature Set
 
-**Status:** PLANNED. Formal scoping via `/gsd:new-milestone` after v1.10 ships. Pre-committed in this milestone-list to make the direction explicit.
+**Goal:** Adopt the 4 strongest features from the Pascal Editor competitive audit. v1.9 Phase 39 deferred these as "speculative" because there was no demand signal at the time; the user explicitly committed to them as the next direction during v1.10 scoping.
 
-**Goal:** Adopt the 4 strongest features from the Pascal Editor competitive audit. v1.9 Phase 39 deferred these as "speculative" because there was no demand signal at the time; the user has explicitly committed to them as the next direction.
+**Source:** Pascal Editor competitive audit (`.planning/competitive/pascal-audit.md`). All 4 issues filed during v1.7.5 design-system work with `competitor-insight` labels.
 
-**Target features:**
-- **Phase 45 / [#79](https://github.com/micahbank2/room-cad-renderer/issues/79)** — Per-node saved camera with Focus action (each placed product / wall / ceiling can have its own bookmarked camera angle, double-click to "Focus" jumps the camera there)
-- **Phase 46 / [#80](https://github.com/micahbank2/room-cad-renderer/issues/80)** — Room display modes (solo / explode) for inspecting individual rooms in isolation or seeing exploded-axonometric layouts
-- **Phase 47 / [#78](https://github.com/micahbank2/room-cad-renderer/issues/78)** — Rooms hierarchy sidebar tree (collapsible, click-to-focus, visibility toggles per-node)
-- **Phase 48 / [#77](https://github.com/micahbank2/room-cad-renderer/issues/77)** — Auto-generated material swatch thumbnails from the renderer (replaces hand-curated swatches in pickers)
+**Sequencing rationale:** Easy → hard. Each phase ships a tangible UX win; later phases depend on earlier infrastructure. Cancellation of any later phase still leaves earlier phases' value behind.
 
-**Phase numbering:** Continues from 44. Pre-allocated 45–48; final count + plan structure decided at v1.11 scoping time.
+### Phase Details
 
-**Source:** Pascal Editor competitive audit (`.planning/competitive/pascal-audit.md`). All 4 issues filed during v1.7.5 design-system work as `competitor-insight` labels.
+#### Phase 45: Auto-Generated Material Swatch Thumbnails (THUMB-01)
+**Goal:** Material picker swatches render from the live PBR/material pipeline rather than hand-curated static images.
+**Depends on:** Phase 32 PBR foundation (texture cache, color-space helper); existing `surfaceMaterials.ts` data + picker components.
+**Requirements:** THUMB-01
+**UI hint:** yes (visible in FloorMaterialPicker / SwatchPicker / ceiling material picker)
+**Plans:** TBD (est. 1-2 plans; offscreen R3F renderer + per-material cache + Suspense fallback)
 
-**Sequencing intent:** Order TBD at scoping time. Likely #77 first (cheap, isolated — no schema changes), then #78 (rooms tree depends only on existing room data), then #80 (display modes layer on top of room rendering), then #79 (per-node camera bookmarks need camera-state plumbing extension). Could parallelize.
+#### Phase 46: Rooms Hierarchy Sidebar Tree (TREE-01)
+**Goal:** Sidebar gains a Rooms tree — collapsible per-room, nested children (walls/ceilings/products/custom-elements), click-to-focus, per-node visibility toggle.
+**Depends on:** Phase 45 (sequencing, not code); Phase 33 `CollapsibleSection` primitive; existing `cadStore.rooms` structure; `uiStore.selectedIds`.
+**Requirements:** TREE-01
+**UI hint:** yes (new Sidebar panel)
+**Plans:** TBD (est. 2 plans; tree component + visibility-toggle wiring + click-to-select; Focus action ships in Phase 48)
 
-**Out of v1.11:** [#97](https://github.com/micahbank2/room-cad-renderer/issues/97) (Properties panel in 3D/split — separate concern), [#81](https://github.com/micahbank2/room-cad-renderer/issues/81) (PBR extensions — different domain), backend / mobile / R3F upgrade (still major-version-leap territory).
+#### Phase 47: Room Display Modes (DISPLAY-01)
+**Goal:** Toolbar (or sidebar) gains a NORMAL / SOLO / EXPLODE display-mode selector.
+**Depends on:** Phase 46 (rooms tree provides "active room" semantic); existing `uiStore.cameraMode` pattern (mirror for `displayMode`).
+**Requirements:** DISPLAY-01
+**UI hint:** yes (new toggle in Toolbar or sidebar)
+**Plans:** TBD (est. 1 plan; uiStore field + ThreeViewport rooms-render branch + toolbar UI)
+
+#### Phase 48: Per-Node Saved Camera + Focus Action (CAM-04)
+**Goal:** Each placed product / wall / ceiling can have a bookmarked camera angle. Double-click in tree (or right-click context menu) jumps camera there via Phase 35 easeInOutCubic tween.
+**Depends on:** Phase 35 preset-tween infrastructure (`pendingPresetRequest` shape); Phase 46 (tree node double-click trigger).
+**Requirements:** CAM-04
+**UI hint:** yes (right-click context menu + tree double-click)
+**Plans:** TBD (est. 1-2 plans; schema additions for savedCamera fields + context menu UI + tween integration)
+
+---
 
 ---
 
@@ -138,6 +158,10 @@
 | 42. Per-Surface tileSizeFt Bug Fix | 1/1 | Complete   | 2026-04-25 |
 | 43. UI Polish Bundle | 1/1 | Complete   | 2026-04-25 |
 | 44. Reduced-Motion Sweep | 1/1 | Complete   | 2026-04-25 |
+| 45. Auto-Gen Material Swatch Thumbnails | 0/0 | Not started | - |
+| 46. Rooms Hierarchy Sidebar Tree | 0/0 | Not started | - |
+| 47. Room Display Modes | 0/0 | Not started | - |
+| 48. Per-Node Saved Camera + Focus | 0/0 | Not started | - |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,13 +1,13 @@
 ---
 gsd_state_version: 1.0
-milestone: TBD
-milestone_name: (next milestone — run /gsd:new-milestone for v1.11 Pascal Feature Set)
-status: idle
-stopped_at: v1.10 milestone shipped 2026-04-25
-last_updated: "2026-04-25T23:30:00.000Z"
-last_activity: 2026-04-25 -- v1.10 archived
+milestone: v1.11
+milestone_name: Pascal Feature Set
+status: scoped
+stopped_at: v1.11 scoped 2026-04-25 — ready for /gsd:plan-phase 45
+last_updated: "2026-04-25T23:45:00.000Z"
+last_activity: 2026-04-25 -- v1.11 milestone scoped
 progress:
-  total_phases: 0
+  total_phases: 4
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -24,10 +24,19 @@ See: .planning/PROJECT.md (updated 2026-04-25 — v1.10 archived; v1.11 Pascal F
 
 ## Current Position
 
-Milestone: TBD (run `/gsd:new-milestone` to formally scope v1.11 Pascal Feature Set)
-Phase: none
+Milestone: v1.11 Pascal Feature Set
+Phases: 4 (45, 46, 47, 48) — none planned yet
 Plan: none
-Status: Idle — milestone v1.10 shipped 2026-04-25 (2 phases, 2 plans, 5/5 reqs, audit passed_with_carry_over with AUDIT-01 systemic resolution)
+Status: Ready for `/gsd:plan-phase 45` (THUMB-01 — auto-generated material swatch thumbnails)
+
+## v1.11 Phase Sequence
+
+1. **Phase 45** — THUMB-01: Auto-generated material swatch thumbnails (#77)
+2. **Phase 46** — TREE-01: Rooms hierarchy sidebar tree (#78)
+3. **Phase 47** — DISPLAY-01: Room display modes (NORMAL/SOLO/EXPLODE) (#80)
+4. **Phase 48** — CAM-04: Per-node saved camera + Focus action (#79)
+
+Easy → hard ordering. Each phase ships a tangible UX win.
 
 ## Last 3 milestones (summary)
 


### PR DESCRIPTION
## Summary

Formally scopes v1.11 — promotes the pre-committed Pascal Feature Set from PREVIEW to active milestone. 4 GH issues (#77, #78, #80, #79) → 4 phases (45-48) → 4 new requirements (THUMB-01, TREE-01, DISPLAY-01, CAM-04).

## Sequencing: easy → hard

| Phase | Req | GH | What |
|-------|-----|-----|------|
| 45 | THUMB-01 | [#77](https://github.com/micahbank2/room-cad-renderer/issues/77) | Auto-generated material swatch thumbnails (cheap, isolated) |
| 46 | TREE-01 | [#78](https://github.com/micahbank2/room-cad-renderer/issues/78) | Rooms hierarchy sidebar tree (prereq for Focus) |
| 47 | DISPLAY-01 | [#80](https://github.com/micahbank2/room-cad-renderer/issues/80) | Room display modes — NORMAL / SOLO / EXPLODE |
| 48 | CAM-04 | [#79](https://github.com/micahbank2/room-cad-renderer/issues/79) | Per-node saved camera + Focus action |

Each phase ships a tangible UX win — cancellation of any later phase still leaves earlier phases' value behind.

## Inherited cross-cutting decisions

- Phase 33 D-33 (lucide for new chrome) + D-34 (canonical spacing tokens)
- Phase 33 D-39 (every new animation guards on \`useReducedMotion\`)
- Phase 35 camera-tween infrastructure (preset tween reused for CAM-04 Focus)
- v1.10 substitute-evidence policy (SUMMARY.md is canonical evidence)

## Out of v1.11

- [#97](https://github.com/micahbank2/room-cad-renderer/issues/97) Properties panel in 3D/split — speculative, no demand signal
- [#81](https://github.com/micahbank2/room-cad-renderer/issues/81) PBR extensions — feature work without demand
- Phase 999.1 (ceiling drag-resize) + Phase 999.3 (full design-effect tile override) — re-deferred from v1.9 cancellation
- Backend / auth / cloud / mobile / iPad — major-version leap; revisit only when an actual reason exists outside our heads
- R3F v9 / React 19 — still gated on R3F v9 stability ([#56](https://github.com/micahbank2/room-cad-renderer/issues/56))

## Files

- \`.planning/REQUIREMENTS.md\` (fresh for v1.11)
- \`.planning/ROADMAP.md\` (v1.11 promoted PREVIEW → active; Phase Details + Progress rows added)
- \`.planning/PROJECT.md\` (Current Milestone refreshed with concrete sequencing)
- \`.planning/STATE.md\` (scoped, ready for \`/gsd:plan-phase 45\`)

## Next step

After merge: \`/gsd:plan-phase 45\` to start Phase 45 (THUMB-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)