### PR TITLE
Phase 66 (TILE-02): per-surface tile-size UI completion — closes v1.16

### DIFF
--- a/.planning/phases/66-tile-02-per-surface-tile-size-ui/66-01-SUMMARY.md
+++ b/.planning/phases/66-tile-02-per-surface-tile-size-ui/66-01-SUMMARY.md
@@ -1,0 +1,74 @@
+---
+phase: 66-tile-02-per-surface-tile-size-ui
+plan: 01
+status: complete
+type: summary
+shipped: 2026-05-06
+commits:
+  - 799d7ec feat(66): per-surface tile-size UI completion (TILE-02, #105)
+---
+
+# Phase 66-01 Summary — TILE-02 (per-surface tile-size UI completion)
+
+## Goal achieved
+
+Phase 42 (BUG-01, v1.9 closer) shipped the data fields:
+- `Wallpaper.scaleFt` — wall pattern repeat distance
+- `FloorMaterial.scaleFt` — floor texture tile size
+- `Ceiling.scaleFt` — ceiling texture tile size
+
+Phase 66 finishes the PropertiesPanel UI so end-users can adjust those overrides per surface, completing the v1.9 deferred work that was re-parked to Phase 999.3.
+
+## Investigation: what existed vs what was missing
+
+| Surface | Data field (Phase 42) | UI BEFORE Phase 66 | Phase 66 change |
+|---------|------------------------|---------------------|------------------|
+| **Floor** | `FloorMaterial.scaleFt` | SCALE (ft) input ✓ at `FloorMaterialPicker.tsx:149` | None needed — already shipped |
+| **Wallpaper** | `Wallpaper.scaleFt` | TILE PATTERN checkbox toggle (stretch ↔ 2ft) at `WallSurfacePanel.tsx:250-255` | Added TILE SIZE (ft) input that appears when tiling is enabled |
+| **Ceiling** | `Ceiling.scaleFt` | None | Added TILE SIZE (ft) input in `CeilingPaintSection.tsx`, visible when a user-uploaded texture is applied |
+
+## Implementation
+
+### `src/components/WallSurfacePanel.tsx`
+- Added `setTileSize(value)` helper alongside the existing `toggleTile()`. Clamps to [0.5, 10] feet.
+- Added a `TILE SIZE (ft)` `<input type="number" step="0.5" min="0.5" max="10">` row beneath the existing TILE PATTERN checkbox. Visible only when `(wp.scaleFt ?? 0) > 0` (tiling on).
+- `data-testid="wallpaper-tile-size"` for future e2e if needed.
+
+### `src/components/CeilingPaintSection.tsx`
+- Added `handleSetTileSize(value)` helper. Clamps to [0.5, 10] feet. Guards on `ceiling.userTextureId` being set (no-op for catalog presets).
+- Added a `TILE SIZE (ft)` input visible when `ceiling.userTextureId && ceiling.scaleFt !== undefined`. Same range/step/clamp as wallpaper.
+- `data-testid="ceiling-tile-size"`.
+
+## Test results
+
+- TypeScript: 0 errors (only pre-existing tsconfig deprecation warning)
+- Vitest: 4 failed / 121 passed (4 pre-existing baseline failures unchanged)
+
+No new tests added. Both UI changes are simple `<input>` fields backed by the same `setWallpaper` / `updateCeiling` actions that already have full test coverage from Phase 17 / Phase 12. The clamp logic is embedded inline (3 lines per surface) — adding dedicated tests for "the input clamps 0.3 to 0.5" felt like over-testing for a 6-LOC clamp pattern.
+
+## Why no new schema / actions / snapshot changes
+
+Phase 42 had already done the heavy lifting:
+- Wallpaper/FloorMaterial/Ceiling all have `scaleFt?: number`
+- `setWallpaper` and `updateCeiling` already accept partial-patch writes
+- 3D rendering already consumes `scaleFt` (FloorMesh, WallMesh, CeilingMesh)
+- 2D rendering uses the same field
+- Snapshot already serializes the field
+
+Phase 66 was purely a UI surface. **NO snapshot version bump, NO new cadStore action, NO type changes.**
+
+## Quick-task pattern
+
+Executed via `/gsd:quick`. Total wall-clock: ~5 minutes (smallest v1.16 phase by a wide margin).
+
+## v1.16 milestone closeout
+
+This is the **last v1.16 phase**. Maintenance pass complete:
+- ✅ Phase 63 — DEBT-06 vitest pollution (investigated + hygiene cleanup)
+- ✅ Phase 64 — BUG-04 wall-texture flake (real bug, useEffect cleanup + timeout bump)
+- ✅ Phase 65 — CEIL-02 ceiling resize handles (Phase 999.1, finally shipped after 2 re-deferrals)
+- ✅ Phase 66 — TILE-02 per-surface tile-size UI completion (Phase 999.3, finally shipped)
+
+**Two backlog items dating back to v1.9 (Phase 999.1 + Phase 999.3) closed in v1.16.** Total wall-clock for the milestone: ~55 minutes across 4 phases.
+
+After UAT + merge: `/gsd:audit-milestone v1.16` → `/gsd:complete-milestone v1.16`.

--- a/src/components/CeilingPaintSection.tsx
+++ b/src/components/CeilingPaintSection.tsx
@@ -34,6 +34,15 @@ export default function CeilingPaintSection({ ceilingId, ceiling }: Props) {
     updateCeiling(ceilingId, { limeWash: checked });
   };
 
+  // Phase 66 (TILE-02, #105): per-ceiling tile-size override. Range 0.5-10 ft.
+  // Visible only when a user-uploaded texture is applied (catalog presets manage
+  // their own scale). Clamps to safe range to prevent zero/negative texture.repeat.
+  const handleSetTileSize = (value: number) => {
+    if (!ceiling.userTextureId) return;
+    const clamped = Math.max(0.5, Math.min(10, value));
+    updateCeiling(ceilingId, { scaleFt: clamped });
+  };
+
   const hasMaterial = Boolean(ceiling.surfaceMaterialId);
 
   return (
@@ -55,6 +64,24 @@ export default function CeilingPaintSection({ ceilingId, ceiling }: Props) {
         onSelectUserTexture={handleCeilingUserTexture}
         selectedUserTextureId={ceiling.userTextureId}
       />
+
+      {/* Phase 66 (TILE-02, #105): per-ceiling tile-size input.
+          Visible only when a user-uploaded texture is applied. */}
+      {ceiling.userTextureId && ceiling.scaleFt !== undefined && (
+        <label className="block">
+          <span className="font-mono text-[9px] text-text-dim block">TILE SIZE (ft)</span>
+          <input
+            type="number"
+            step="0.5"
+            min="0.5"
+            max="10"
+            value={ceiling.scaleFt}
+            onChange={(e) => handleSetTileSize(parseFloat(e.target.value) || 2)}
+            data-testid="ceiling-tile-size"
+            className="w-full font-mono text-[10px] bg-obsidian-high text-accent-light border border-outline-variant/30 px-2 py-1 rounded-sm"
+          />
+        </label>
+      )}
 
       {hasMaterial && (
         <div className="flex items-center justify-between">

--- a/src/components/WallSurfacePanel.tsx
+++ b/src/components/WallSurfacePanel.tsx
@@ -101,6 +101,14 @@ export default function WallSurfacePanel() {
     setWallpaper(wall.id, activeSide, { ...wp, scaleFt: newScale });
   };
 
+  // Phase 66 (TILE-02, #105): per-surface tile-size override. Range 0.5-10 ft.
+  // Clamps to safe range to prevent zero/negative values that break texture.repeat.
+  const setTileSize = (value: number) => {
+    if (!wp || wp.kind !== "pattern") return;
+    const clamped = Math.max(0.5, Math.min(10, value));
+    setWallpaper(wall.id, activeSide, { ...wp, scaleFt: clamped });
+  };
+
   // Phase 34 — apply a user-uploaded texture as wallpaper on the active side.
   const handleWallpaperUserTexture = (id: string, tileSizeFt: number) => {
     const material: Wallpaper = {
@@ -244,17 +252,35 @@ export default function WallSurfacePanel() {
           }}
         />
         {wp?.kind === "pattern" && (
-          <label className="flex items-center gap-2 mt-1 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={(wp.scaleFt ?? 0) > 0}
-              onChange={toggleTile}
-              className="w-3 h-3 accent-accent rounded-none"
-            />
-            <span className="font-mono text-[11px] text-text-dim tracking-wider">
-              TILE PATTERN {(wp.scaleFt ?? 0) > 0 ? `(${wp.scaleFt}ft)` : "(stretch)"}
-            </span>
-          </label>
+          <div className="mt-1 space-y-1.5">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={(wp.scaleFt ?? 0) > 0}
+                onChange={toggleTile}
+                className="w-3 h-3 accent-accent rounded-none"
+              />
+              <span className="font-mono text-[11px] text-text-dim tracking-wider">
+                TILE PATTERN {(wp.scaleFt ?? 0) > 0 ? `(${wp.scaleFt}ft)` : "(stretch)"}
+              </span>
+            </label>
+            {/* Phase 66 (TILE-02, #105): per-surface tile-size input. Visible only when tiling is on. */}
+            {(wp.scaleFt ?? 0) > 0 && (
+              <label className="block">
+                <span className="font-mono text-[9px] text-text-dim block">TILE SIZE (ft)</span>
+                <input
+                  type="number"
+                  step="0.5"
+                  min="0.5"
+                  max="10"
+                  value={wp.scaleFt}
+                  onChange={(e) => setTileSize(parseFloat(e.target.value) || 2)}
+                  data-testid="wallpaper-tile-size"
+                  className="w-full font-mono text-[10px] bg-obsidian-high text-accent-light border border-outline-variant/30 px-2 py-1 rounded-sm"
+                />
+              </label>
+            )}
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
Last v1.16 phase. Pure UI surface (Phase 42 shipped the data fields; this is the missing UI tier).

Wallpaper: added TILE SIZE (ft) input alongside existing TILE PATTERN toggle. Visible when tiling is on. Clamps [0.5, 10].
Ceiling: added TILE SIZE (ft) input. Visible when a user-uploaded texture is applied. Same clamp.
Floor: SCALE input was already shipped (Phase 42, FloorMaterialPicker:149) — no change.

NO new schema / actions / snapshot bump. Pure UI on top of existing fields.

vitest: 4 failed / 121 passed (baseline unchanged). TS clean.

After merge: /gsd:audit-milestone v1.16 → /gsd:complete-milestone v1.16.

Closes #105
Spec: .planning/phases/66-tile-02-per-surface-tile-size-ui/66-01-SUMMARY.md