### PR TITLE
Phase 73: Sidebar Restyle — tree spine geometry + contextual right panel

### DIFF
--- a/e2e/measurements.spec.ts
+++ b/e2e/measurements.spec.ts
@@ -100,13 +100,12 @@ test("E4: place + edit annotation via driver — text round-trips", async ({ pag
 });
 
 test("E5: PropertiesPanel renders AREA: 100 SQ FT for 10×10 closed-loop room", async ({ page }) => {
-  // Empty selection state; PropertiesPanel Room-properties branch should
-  // render the AREA row.
+  // State-level check — area calculation is correct regardless of UI mount state.
   const area = await page.evaluate(() => window.__getRoomArea?.("room_main") ?? 0);
   expect(area).toBe(100);
-  // PropertiesPanel UI assertion — find AREA row in DOM.
-  await expect(page.getByText("AREA")).toBeVisible();
-  await expect(page.getByText(/100 SQ FT/)).toBeVisible();
+  // Note: Phase 73 made PropertiesPanel contextual (mounts only when selectedIds.length > 0).
+  // The DOM-level "AREA" / "100 SQ FT" assertion was removed because the panel no longer
+  // renders with empty selection — the room area is tested via __getRoomArea above.
 });
 
 test("E6: room-area overlay renders at canvas centroid (state-level — overlay text exists)", async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,7 @@
 import { useState, useEffect, useMemo, lazy, Suspense } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { springTransition } from "@/lib/motion";
 import type { ToolType } from "@/types/cad";
 import { useTheme } from "@/hooks/useTheme";
 import { registerThemeSetter } from "@/test-utils/themeDrivers";
@@ -53,6 +56,8 @@ export default function App() {
   const setTool = useUIStore((s) => s.setTool);
   const showSidebar = useUIStore((s) => s.showSidebar);
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
+  const selectedIds = useUIStore((s) => s.selectedIds);
+  const reduced = useReducedMotion();
   const activeWalls = useActiveWalls();
   const wallCount = Object.keys(activeWalls).length;
   // Phase 31 Plan 03 Rule 2: comment in auto-detect effect says "walls or
@@ -252,10 +257,25 @@ export default function App() {
             {isCanvas && <RoomTabs onAddClick={() => setShowAddRoomDialog(true)} />}
             <div className="flex flex-1 overflow-hidden">
             {(viewMode === "2d" || viewMode === "split") && (
-              <div className={`${viewMode === "split" ? "w-1/2" : "flex-1"} h-full relative`}>
-                <FabricCanvas productLibrary={productLibrary} />
-                <ToolPalette />
-                <PropertiesPanel productLibrary={productLibrary} viewMode={viewMode} />
+              <div className={`${viewMode === "split" ? "w-1/2" : "flex-1"} h-full relative flex`}>
+                <div className="flex-1 h-full relative">
+                  <FabricCanvas productLibrary={productLibrary} />
+                  <ToolPalette />
+                </div>
+                <AnimatePresence>
+                  {selectedIds.length > 0 && (
+                    <motion.div
+                      key="properties-panel"
+                      className="w-72 h-full shrink-0 overflow-y-auto bg-card border-l border-border"
+                      initial={{ x: 288, opacity: 0 }}
+                      animate={{ x: 0, opacity: 1 }}
+                      exit={{ x: 288, opacity: 0 }}
+                      transition={springTransition(reduced)}
+                    >
+                      <PropertiesPanel productLibrary={productLibrary} viewMode={viewMode} />
+                    </motion.div>
+                  )}
+                </AnimatePresence>
               </div>
             )}
             {viewMode === "split" && (
@@ -274,9 +294,20 @@ export default function App() {
                 >
                   <ThreeViewport productLibrary={productLibrary} />
                 </Suspense>
-                {viewMode === "3d" && (
-                  <PropertiesPanel productLibrary={productLibrary} viewMode={viewMode} />
-                )}
+                <AnimatePresence>
+                  {viewMode === "3d" && selectedIds.length > 0 && (
+                    <motion.div
+                      key="properties-panel-3d"
+                      className="w-72 h-full shrink-0 overflow-y-auto bg-card border-l border-border"
+                      initial={{ x: 288, opacity: 0 }}
+                      animate={{ x: 0, opacity: 1 }}
+                      exit={{ x: 288, opacity: 0 }}
+                      transition={springTransition(reduced)}
+                    >
+                      <PropertiesPanel productLibrary={productLibrary} viewMode={viewMode} />
+                    </motion.div>
+                  )}
+                </AnimatePresence>
               </div>
             )}
             </div>

--- a/src/components/RoomsTreePanel/TreeRow.tsx
+++ b/src/components/RoomsTreePanel/TreeRow.tsx
@@ -26,12 +26,6 @@ interface TreeRowProps {
   onDoubleClickRow?: (node: TreeNode) => void;
 }
 
-const INDENT: Record<0 | 1 | 2, string> = {
-  0: "pl-2",
-  1: "pl-4",
-  2: "pl-6",
-};
-
 export function TreeRow(props: TreeRowProps) {
   const {
     node,
@@ -66,12 +60,12 @@ export function TreeRow(props: TreeRowProps) {
   // Row container classes — h-6 (24px) per UI-SPEC § Row height contract
   // ---------------------------------------------------------------------------
   const rowBase = [
-    "group flex items-center h-6 pr-2 rounded-smooth-md cursor-pointer",
-    INDENT[depth],
-    "hover:bg-accent",
+    "group relative flex items-center h-6 pr-2 pl-8 rounded-smooth-md cursor-pointer",
+    "hover:bg-accent/30",
     "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent",
   ];
-  if (selected) rowBase.push("bg-secondary border-l-2 border-accent");
+  if (selected) rowBase.push("bg-accent/20 text-accent-foreground");
+  if (isActiveRoom) rowBase.push("bg-accent text-accent-foreground");
   if (parentOnlyHidden) rowBase.push("opacity-50");
   const rowClass = rowBase.join(" ");
 
@@ -129,12 +123,17 @@ export function TreeRow(props: TreeRowProps) {
           if (isGroup) return;
           props.onClickRow(node);
         }}
+
         onDoubleClick={() => {
           // Phase 48 D-02: groups ignored (matches single-click NO-OP semantics).
           if (isGroup) return;
           props.onDoubleClickRow?.(node);
         }}
       >
+        {/* D-01: Pascal spine — 1px vertical line at left:21px */}
+        <div className="absolute top-0 bottom-0 left-[21px] w-px bg-border/50 pointer-events-none" />
+        {/* D-02: Pascal branch — horizontal tick from left:21px spanning 11px */}
+        <div className="absolute top-1/2 left-[21px] h-px w-[11px] bg-border/50 pointer-events-none" />
         {/* Chevron — ROOM ROWS ONLY per UI-SPEC § Per-Row Anatomy */}
         {isRoom ? (
           <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { PanelSection } from "@/components/ui";
 import type { Product } from "@/types/product";
 import {
   useActiveRoom,
@@ -17,33 +17,6 @@ interface Props {
   productLibrary: Product[];
 }
 
-function CollapsibleSection({
-  label,
-  defaultOpen = true,
-  children,
-}: {
-  label: string;
-  defaultOpen?: boolean;
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div>
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center justify-between mb-2 py-1"
-      >
-        <h3 className="font-sans text-base font-medium text-muted-foreground">
-          {label}
-        </h3>
-        <span className="font-sans text-sm text-muted-foreground/60">
-          {open ? "\u2212" : "+"}
-        </span>
-      </button>
-      {open && children}
-    </div>
-  );
-}
 
 export default function Sidebar({ productLibrary }: Props) {
   const room = useActiveRoom() ?? { width: 20, length: 16, wallHeight: 8 };
@@ -74,11 +47,11 @@ export default function Sidebar({ productLibrary }: Props) {
       {/* Scrollable content */}
       <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
         <RoomsTreePanel productLibrary={productLibrary} />
-        <CollapsibleSection label="Room config">
+        <PanelSection id="sidebar-room-config" label="Room config">
           <RoomSettings />
-        </CollapsibleSection>
+        </PanelSection>
 
-        <CollapsibleSection label="System stats" defaultOpen={false}>
+        <PanelSection id="sidebar-system-stats" label="System stats" defaultOpen={false}>
           <div className="space-y-1.5">
             <div className="flex justify-between">
               <span className="font-sans text-[10px] text-muted-foreground/80">Area</span>
@@ -95,9 +68,9 @@ export default function Sidebar({ productLibrary }: Props) {
               <span className="font-sans text-[10px] text-foreground">{productCount}</span>
             </div>
           </div>
-        </CollapsibleSection>
+        </PanelSection>
 
-        <CollapsibleSection label="Layers" defaultOpen={false}>
+        <PanelSection id="sidebar-layers" label="Layers" defaultOpen={false}>
           <div className="space-y-1.5">
             <label className="flex items-center gap-2 cursor-pointer">
               <input
@@ -109,10 +82,10 @@ export default function Sidebar({ productLibrary }: Props) {
               <span className="font-sans text-[10px] text-muted-foreground/80">Grid</span>
             </label>
           </div>
-        </CollapsibleSection>
+        </PanelSection>
 
 
-        <CollapsibleSection label="Snap" defaultOpen={false}>
+        <PanelSection id="sidebar-snap" label="Snap" defaultOpen={false}>
           <select
             value={gridSnap}
             onChange={(e) => setGridSnap(+e.target.value)}
@@ -123,7 +96,7 @@ export default function Sidebar({ productLibrary }: Props) {
             <option value={0.5}>6 inch</option>
             <option value={1}>1 foot</option>
           </select>
-        </CollapsibleSection>
+        </PanelSection>
 
         {/* Custom Elements (Phase 14) — has its own internal header */}
         <CustomElementsPanel />
@@ -134,9 +107,9 @@ export default function Sidebar({ productLibrary }: Props) {
         {/* Wainscoting Style Library (Phase 16) — has its own internal header */}
         <WainscotLibrary />
 
-        <CollapsibleSection label="Product library">
+        <PanelSection id="sidebar-product-library" label="Product library">
           <SidebarProductPicker />
-        </CollapsibleSection>
+        </PanelSection>
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- **TreeRow.tsx** — Pascal spine-and-branches geometry: 1px vertical spine at `left-[21px]`, 11px horizontal branch ticks; uniform `pl-8` replaces depth-based INDENT; `hover:bg-accent/30` / `bg-accent/20` selected / `bg-accent` active room
- **Sidebar.tsx** — Local `CollapsibleSection` removed; all 5 sections migrated to `PanelSection` primitive (Phase 72) with `id="sidebar-*"` localStorage keys
- **App.tsx** — PropertiesPanel now mounts only when `selectedIds.length > 0`; wrapped in `AnimatePresence` + `motion.div` that spring-slides in from x:288; reduced-motion safe via `springTransition(reduced)`

## Test plan
- [ ] 44/44 phase33 + phase46 tests pass
- [ ] TypeScript compiles clean (no errors, only TS5101 deprecation noise)
- [ ] Rooms tree shows faint spine + branch lines
- [ ] Hover/active/selected row colors match design tokens
- [ ] Selecting an object → right panel slides in; deselecting → panel collapses
- [ ] Phase 46 double-click focus and Phase 47 eye-icon behavior unchanged

Closes #157
Spec: .planning/phases/73-sidebar-restyle-sidebar-restyle/

🤖 Generated with [Claude Code](https://claude.com/claude-code)