### PR TITLE
Phase 75-01: Migrate AddProductModal, RoomSettings, MaterialPicker to Phase 72 primitives

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.18
 milestone_name: Pascal Visual Parity
 status: completed
-last_updated: "2026-05-08T01:38:30.245Z"
+last_updated: "2026-05-08T03:43:59.407Z"
 last_activity: 2026-05-08
 progress:
   total_phases: 6
-  completed_phases: 3
-  total_plans: 21
-  completed_plans: 18
+  completed_phases: 5
+  total_plans: 27
+  completed_plans: 24
 ---
 
 # Project State
@@ -23,10 +23,10 @@ See: .planning/PROJECT.md (updated 2026-05-07 — v1.17 partial-shipped 67+68; v
 
 ## Current Position
 
-Phase: 74 (Toolbar Rework) — NEXT
+Phase: 76 (Modals + Welcome + Final) — NEXT
 Milestone: v1.18 Pascal Visual Parity
-Phases: 6 (71, 72, 73, 74, 75, 76) — 3 complete (71, 72, 73)
-Status: Phase 73 complete — ready for Phase 74
+Phases: 6 (71, 72, 73, 74, 75, 76) — 5 complete (71, 72, 73, 74, 75)
+Status: Phase 75 complete — ready for Phase 76
 Last activity: 2026-05-08
 
 ## Decisions

--- a/.planning/phases/75-properties-library-restyle-properties-library-restyle/75-01-SUMMARY.md
+++ b/.planning/phases/75-properties-library-restyle-properties-library-restyle/75-01-SUMMARY.md
@@ -1,0 +1,8 @@
+# Plan 75-01 Summary
+Status: complete
+Tasks: 3/3
+Files: AddProductModal.tsx, RoomSettings.tsx, MaterialPicker.tsx
+Key changes:
+- AddProductModal: Dialog primitive wrapping, Input/Switch for form fields
+- RoomSettings: Input primitive for 3 number inputs
+- MaterialPicker: ring-2 ring-ring active state, hover:bg-accent/10, Input for tile-size

--- a/.planning/phases/75-properties-library-restyle-properties-library-restyle/75-02-SUMMARY.md
+++ b/.planning/phases/75-properties-library-restyle-properties-library-restyle/75-02-SUMMARY.md
@@ -1,0 +1,21 @@
+# Phase 75 Plan 02: ProductLibrary + WallSurfacePanel Primitive Migration Summary
+
+Status: complete
+Tasks: 2/2
+Files: ProductLibrary.tsx, WallSurfacePanel.tsx
+
+Key changes:
+- ProductLibrary: CategoryTabs replaced by Tabs/TabsList/TabsTrigger from @/components/ui; search uses Input primitive; GLTF badge (data-testid="gltf-badge") untouched
+- WallSurfacePanel: both checkboxes (wainscoting, crown molding) replaced with Switch primitive; crown molding number input replaced with Input primitive; color inputs left native
+
+## Commits
+- 042a135: feat(75-02): ProductLibrary — Tabs primitive replaces CategoryTabs; Input search
+- 7b3984e: feat(75-02): WallSurfacePanel — Switch + Input migration
+
+## Deviations from Plan
+None — plan executed exactly as written.
+
+## Self-Check: PASSED
+- src/components/ProductLibrary.tsx: exists, uses TabsList, Input, gltf-badge preserved
+- src/components/WallSurfacePanel.tsx: exists, uses Switch (x2), Input (x1), no raw checkboxes
+- TypeScript: zero real errors (only pre-existing baseUrl deprecation warning)

--- a/.planning/phases/75-properties-library-restyle-properties-library-restyle/75-03-SUMMARY.md
+++ b/.planning/phases/75-properties-library-restyle-properties-library-restyle/75-03-SUMMARY.md
@@ -1,0 +1,90 @@
+---
+phase: 75-properties-library-restyle
+plan: "03"
+subsystem: PropertiesPanel
+tags: [input-migration, design-system, primitives]
+dependency_graph:
+  requires: []
+  provides: [PropertiesPanel-Input-migration]
+  affects: [PropertiesPanel.tsx, PropertiesPanel.OpeningSection.tsx, PropertiesPanel.StairSection.tsx]
+tech_stack:
+  added: []
+  patterns: [Input primitive via forwardRef, h-7 text-xs compact variant]
+key_files:
+  created: []
+  modified:
+    - src/components/PropertiesPanel.tsx
+    - src/components/PropertiesPanel.OpeningSection.tsx
+    - src/components/PropertiesPanel.StairSection.tsx
+decisions:
+  - "Used className='h-7 text-xs' on all compact inputs to preserve tight PropertiesPanel layout"
+  - "Input primitive forwardRef supports inputRef used by LabelOverrideInput with no changes needed"
+  - "OpeningSection NumericRow bg-accent preserved via className='bg-accent' passthrough"
+metrics:
+  duration: ~8min
+  completed: "2026-05-07"
+  tasks_completed: 3
+  files_modified: 3
+---
+
+# Phase 75 Plan 03: PropertiesPanel Input Migration Summary
+
+Migrated all raw `<input type="text|number">` elements in the PropertiesPanel family to the `Input` primitive. This is the largest migration file in Phase 75 (992 lines) but all changes were mechanical substitutions.
+
+## Tasks Completed
+
+### Task 1: PropertiesPanel.tsx
+- Added `import { Input } from "@/components/ui/Input"` to existing imports
+- Replaced 4 raw input sites:
+  1. Product dimension grid inputs (3x `<input type="number">` in `.map()`) — `className="h-7 text-xs px-1.5"`
+  2. `LabelOverrideInput` text input (uses `inputRef` via forwardRef) — `className="h-7 text-xs"`
+  3. `CeilingDimInput` text input — `className="w-20 h-7 text-xs text-right"`
+  4. `EditableRow` dynamic type input (text or number based on `parser` prop) — `className="w-20 h-7 text-xs text-right"`
+- All `data-testid` attributes preserved verbatim
+- The `inputRef` (forwardRef) pattern works identically with Input primitive
+
+### Task 2: PropertiesPanel.OpeningSection.tsx + PropertiesPanel.StairSection.tsx
+- **OpeningSection**: Added `Input` import; replaced `NumericRow`'s `<input type="number">` with `<Input>` — `className="w-16 h-7 text-xs text-right bg-accent"` (preserves accent background)
+- **StairSection**: Added `Input` import; replaced 2 raw inputs:
+  1. Stair label `<input type="text">` — `className="h-7 text-xs"`
+  2. `NumberRow`'s `<input type="number">` — `className="flex-1 h-7 text-xs"`
+- All `htmlFor`/`id` pairings preserved (e.g., `stair-label-${stair.id}`, `stair-input-${ariaLabel}`)
+- `data-testid` on opening depth input preserved verbatim
+
+### Task 3: Full Phase Grep Audit
+
+Grep across all 8 Phase 75 target files:
+```
+CLEAN - no raw inputs remain
+```
+
+Legacy CSS check (glass-panel, accent-glow, etc.):
+```
+CLEAN - no legacy CSS
+```
+
+TypeScript check:
+- Zero errors in migrated files
+- Pre-existing: `tsconfig.json(17,5): error TS5101: Option 'baseUrl' is deprecated` — not new, not in scope
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None.
+
+## Commits
+
+- `8c3436a` — feat(75-03): PropertiesPanel — migrate all text/number inputs to Input primitive
+- `6d47d58` — feat(75-03): PropertiesPanel sub-components — Input migration for opening + stair dims
+
+## Self-Check: PASSED
+
+- [x] PropertiesPanel.tsx modified (8c3436a)
+- [x] PropertiesPanel.OpeningSection.tsx modified (6d47d58)
+- [x] PropertiesPanel.StairSection.tsx modified (6d47d58)
+- [x] Zero raw text/number inputs in all three files
+- [x] Zero TypeScript errors in migrated files
+- [x] All data-testid preserved

--- a/src/components/AddProductModal.tsx
+++ b/src/components/AddProductModal.tsx
@@ -1,9 +1,20 @@
 import { useState, useRef } from "react";
-import { X, Upload } from "lucide-react";
+import { X } from "lucide-react";
 import { uid } from "@/lib/geometry";
 import type { Product } from "@/types/product";
 import { PRODUCT_CATEGORIES } from "@/types/product";
 import { saveGltfWithDedup } from "@/lib/gltfStore";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui";
+import { Button } from "@/components/ui";
+import { Input } from "@/components/ui";
+import { Switch } from "@/components/ui";
+import { Upload } from "lucide-react";
 
 interface Props {
   onAdd: (product: Product) => void;
@@ -73,29 +84,13 @@ export default function AddProductModal({ onAdd, onClose }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-background/80 backdrop-blur-sm"
-        onClick={onClose}
-      />
+    <Dialog open={true} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="w-[600px] max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>ADD PRODUCT</DialogTitle>
+        </DialogHeader>
 
-      {/* Modal */}
-      <div className="relative w-[600px] bg-popover/90 backdrop-blur-xl border border-border/50 rounded-smooth-md shadow-2xl">
-        {/* Header */}
-        <div className="flex items-center justify-between p-5 pb-4">
-          <h2 className="font-sans text-sm text-foreground tracking-widest">
-            ADD PRODUCT
-          </h2>
-          <button
-            onClick={onClose}
-            className="text-muted-foreground/60 hover:text-foreground transition-colors"
-          >
-            <X size={18} />
-          </button>
-        </div>
-
-        <form onSubmit={handleSubmit} className="px-5 pb-5 space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
           <div className="flex gap-5">
             {/* Left: image upload */}
             <div className="w-48 shrink-0">
@@ -151,12 +146,11 @@ export default function AddProductModal({ onAdd, onClose }: Props) {
                 <span className="font-sans text-[9px] text-muted-foreground/60 tracking-wider">
                   PRODUCT NAME
                 </span>
-                <input
+                <Input
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="E.G. 'EAMES CHAIR L.01'"
-                  className="w-full px-3 py-2 text-xs"
                   required
                 />
               </label>
@@ -168,7 +162,7 @@ export default function AddProductModal({ onAdd, onClose }: Props) {
                 <select
                   value={category}
                   onChange={(e) => setCategory(e.target.value)}
-                  className="w-full px-3 py-2 text-xs"
+                  className="h-9 w-full rounded-smooth-md border border-border bg-background px-3 py-1 text-sm font-sans text-foreground"
                 >
                   {PRODUCT_CATEGORIES.map((c) => (
                     <option key={c} value={c}>
@@ -183,53 +177,47 @@ export default function AddProductModal({ onAdd, onClose }: Props) {
                   <span className="font-sans text-[9px] text-muted-foreground/60 tracking-wider block">
                     DIMENSIONS (W / D / H)
                   </span>
-                  <label className="flex items-center gap-1.5 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={skipDims}
-                      onChange={(e) => setSkipDims(e.target.checked)}
-                      className="w-3 h-3 accent-accent"
-                    />
-                    <span className="font-sans text-[8px] text-muted-foreground/60 tracking-wider">
-                      Skip dimensions
-                    </span>
-                  </label>
+                  <Switch
+                    checked={skipDims}
+                    onCheckedChange={setSkipDims}
+                    label="Skip dimensions"
+                  />
                 </div>
                 <div className={`grid grid-cols-3 gap-2 ${skipDims ? "opacity-40 pointer-events-none" : ""}`}>
                   <div className="relative">
-                    <input
+                    <Input
                       type="number"
                       min={0.25}
                       step={0.25}
                       value={width}
                       onChange={(e) => setWidth(+e.target.value)}
-                      className="w-full px-3 py-2 text-xs pr-8"
+                      className="pr-8"
                     />
                     <span className="absolute right-2 top-1/2 -translate-y-1/2 font-sans text-[8px] text-muted-foreground/60">
                       FT
                     </span>
                   </div>
                   <div className="relative">
-                    <input
+                    <Input
                       type="number"
                       min={0.25}
                       step={0.25}
                       value={depth}
                       onChange={(e) => setDepth(+e.target.value)}
-                      className="w-full px-3 py-2 text-xs pr-8"
+                      className="pr-8"
                     />
                     <span className="absolute right-2 top-1/2 -translate-y-1/2 font-sans text-[8px] text-muted-foreground/60">
                       FT
                     </span>
                   </div>
                   <div className="relative">
-                    <input
+                    <Input
                       type="number"
                       min={0.25}
                       step={0.25}
                       value={height}
                       onChange={(e) => setHeight(+e.target.value)}
-                      className="w-full px-3 py-2 text-xs pr-8"
+                      className="pr-8"
                     />
                     <span className="absolute right-2 top-1/2 -translate-y-1/2 font-sans text-[8px] text-muted-foreground/60">
                       FT
@@ -242,12 +230,11 @@ export default function AddProductModal({ onAdd, onClose }: Props) {
                 <span className="font-sans text-[9px] text-muted-foreground/60 tracking-wider">
                   MATERIAL FINISH
                 </span>
-                <input
+                <Input
                   type="text"
                   value={material}
                   onChange={(e) => setMaterial(e.target.value)}
                   placeholder="E.G. BRUSHED STEEL"
-                  className="w-full px-3 py-2 text-xs"
                 />
               </label>
 
@@ -257,13 +244,14 @@ export default function AddProductModal({ onAdd, onClose }: Props) {
                   3D MODEL (OPTIONAL)
                 </span>
                 <div className="flex items-center gap-2">
-                  <button
+                  <Button
+                    variant="outline"
+                    size="sm"
                     type="button"
                     onClick={() => gltfRef.current?.click()}
-                    className="font-sans text-[9px] px-3 py-1.5 border border-border/60 rounded-smooth-md text-muted-foreground/80 hover:text-foreground hover:border-accent/40 transition-colors"
                   >
                     {gltfFile ? gltfFile.name.toUpperCase() : "CHOOSE .GLTF / .GLB"}
-                  </button>
+                  </Button>
                   {gltfFile && (
                     <button
                       type="button"
@@ -296,25 +284,16 @@ export default function AddProductModal({ onAdd, onClose }: Props) {
             </div>
           </div>
 
-          {/* Footer */}
-          <div className="flex justify-end gap-3 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="font-sans text-[10px] tracking-widest px-4 py-2 text-muted-foreground/80 hover:text-foreground transition-colors"
-            >
+          <DialogFooter>
+            <Button variant="ghost" type="button" onClick={onClose}>
               CANCEL
-            </button>
-            <button
-              type="submit"
-              disabled={!name}
-              className="font-sans text-[10px] tracking-widest px-5 py-2 bg-accent text-white rounded-smooth-md hover:opacity-90 active:scale-95 disabled:opacity-30 transition-all shadow-[0_0_15px_rgba(124,91,240,0.2)]"
-            >
+            </Button>
+            <Button type="submit" disabled={!name}>
               Add to registry
-            </button>
-          </div>
+            </Button>
+          </DialogFooter>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/MaterialPicker.tsx
+++ b/src/components/MaterialPicker.tsx
@@ -21,6 +21,7 @@ import { useMaterials } from "@/hooks/useMaterials";
 import { materialsForSurface } from "@/data/surfaceMaterials";
 import { MaterialCard } from "@/components/MaterialCard";
 import type { SurfaceTarget } from "@/lib/surfaceMaterial";
+import { Input } from "@/components/ui";
 
 export type MaterialPickerSurface =
   | "wallSide"
@@ -126,8 +127,8 @@ export function MaterialPicker({
               }}
               className={
                 m.id === value
-                  ? "ring-1 ring-accent rounded-md"
-                  : "rounded-md"
+                  ? "ring-2 ring-ring rounded-md cursor-pointer hover:bg-accent/10 transition-colors"
+                  : "rounded-md cursor-pointer hover:bg-accent/10 transition-colors"
               }
             >
               <MaterialCard material={m} onClick={() => apply(m.id)} />
@@ -142,11 +143,11 @@ export function MaterialPicker({
             Tile size (override)
           </label>
           <div className="flex gap-2 items-center">
-            <input
+            <Input
               type="number"
               step="0.1"
               min="0.05"
-              className="font-sans text-[--font-size-sm] bg-popover p-1 rounded-smooth-md w-20"
+              className="w-20"
               placeholder={selected.tileSizeFt.toString()}
               value={tileSizeOverride ?? ""}
               onChange={(e) => {

--- a/src/components/ProductLibrary.tsx
+++ b/src/components/ProductLibrary.tsx
@@ -4,8 +4,9 @@ import type { Product } from "@/types/product";
 import { PRODUCT_CATEGORIES } from "@/types/product";
 import { useUIStore } from "@/stores/uiStore";
 import { setPendingProduct } from "@/canvas/tools/productTool";
-import { LibraryCard, CategoryTabs } from "@/components/library";
+import { LibraryCard } from "@/components/library";
 import type { CategoryTab } from "@/components/library";
+import { Tabs, TabsList, TabsTrigger, Input } from "@/components/ui";
 import { getCachedGltfThumbnail } from "@/three/gltfThumbnailGenerator";
 import { MaterialsSection } from "./MaterialsSection";
 
@@ -105,18 +106,27 @@ export function ProductLibrary({
 
       {/* Filters */}
       <div className="px-6 pb-3 shrink-0 space-y-3">
-        <input
+        <Input
           type="text"
           placeholder="SEARCH ASSETS..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-64 px-3 py-1.5 text-xs"
+          className="w-64"
         />
-        <CategoryTabs
-          tabs={tabList}
-          activeId={activeCategory}
-          onChange={setActiveCategory}
-        />
+        <Tabs value={activeCategory} onValueChange={setActiveCategory}>
+          <TabsList className="flex-wrap gap-1">
+            {tabList.map((tab) => (
+              <TabsTrigger key={tab.id} value={tab.id}>
+                {tab.label}
+                {tab.count > 0 && (
+                  <span className="ml-1 font-mono text-[9px] text-muted-foreground/60">
+                    {tab.count}
+                  </span>
+                )}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
       </div>
 
       {/* Product Grid */}

--- a/src/components/PropertiesPanel.OpeningSection.tsx
+++ b/src/components/PropertiesPanel.OpeningSection.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 import type { WallSegment, Opening } from "@/types/cad";
 import { clampNicheDepth } from "@/types/cad";
 import { useCADStore } from "@/stores/cadStore";
+import { Input } from "@/components/ui/Input";
 
 interface Props {
   wall: WallSegment;
@@ -147,7 +148,7 @@ function NumericRow({
         {label}
       </span>
       <div className="flex items-center gap-1">
-        <input
+        <Input
           type="number"
           step="0.1"
           data-testid={dataTestId}
@@ -177,7 +178,7 @@ function NumericRow({
               (e.target as HTMLInputElement).blur();
             }
           }}
-          className="w-16 font-sans text-[11px] bg-accent text-foreground border border-border/60 px-1 py-0.5 rounded-smooth-md text-right"
+          className="w-16 h-7 text-xs text-right bg-accent"
         />
         <span className="font-sans text-[10px] text-muted-foreground/60">{unit}</span>
       </div>

--- a/src/components/PropertiesPanel.StairSection.tsx
+++ b/src/components/PropertiesPanel.StairSection.tsx
@@ -24,6 +24,7 @@ import { useEffect, useRef, useState } from "react";
 import { useCADStore } from "@/stores/cadStore";
 import type { Stair } from "@/types/cad";
 import { DEFAULT_STAIR_WIDTH_FT } from "@/types/cad";
+import { Input } from "@/components/ui/Input";
 
 interface StairSectionProps {
   stair: Stair;
@@ -237,7 +238,7 @@ export function StairSection({ stair, roomId }: StairSectionProps) {
           >
             Label
           </label>
-          <input
+          <Input
             id={`stair-label-${stair.id}`}
             type="text"
             value={labelDraft}
@@ -262,7 +263,7 @@ export function StairSection({ stair, roomId }: StairSectionProps) {
                 labelOverride: v.trim() === "" ? undefined : v.slice(0, LABEL_MAX),
               });
             }}
-            className="px-2 py-1 font-sans text-sm text-foreground bg-background border border-border/60 rounded-smooth-md"
+            className="h-7 text-xs"
           />
         </div>
       </div>
@@ -304,7 +305,7 @@ function NumberRow({
         {label}
       </label>
       <div className="flex items-center gap-1">
-        <input
+        <Input
           id={`stair-input-${ariaLabel}`}
           type="number"
           aria-label={ariaLabel}
@@ -325,7 +326,7 @@ function NumberRow({
             }
             onCommit();
           }}
-          className="flex-1 px-2 py-1 font-sans text-sm text-foreground bg-background border border-border/60 rounded-smooth-md"
+          className="flex-1 h-7 text-xs"
         />
         {suffix && (
           <span className="font-sans text-sm text-muted-foreground/60">{suffix}</span>

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -22,6 +22,7 @@ import WallSurfacePanel from "./WallSurfacePanel";
 import { MaterialPicker } from "./MaterialPicker";
 import { PanelSection } from "@/components/ui/PanelSection";
 import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 import { Camera, CameraOff } from "lucide-react";
 import { OpeningsSection } from "@/components/PropertiesPanel.OpeningSection";
 
@@ -480,7 +481,7 @@ export default function PropertiesPanel({ productLibrary, viewMode }: Props) {
                 </span>
                 <div className="grid grid-cols-3 gap-1">
                   {(["width", "depth", "height"] as const).map((axis) => (
-                    <input
+                    <Input
                       key={axis}
                       type="number"
                       step={0.25}
@@ -491,7 +492,7 @@ export default function PropertiesPanel({ productLibrary, viewMode }: Props) {
                         const v = parseFloat(e.target.value);
                         if (v > 0) updateProduct(libProduct.id, { [axis]: v });
                       }}
-                      className="w-full px-1.5 py-1 text-[11px] font-sans bg-background border border-border/60"
+                      className="h-7 text-xs px-1.5"
                     />
                   ))}
                 </div>
@@ -752,7 +753,7 @@ function LabelOverrideInput({
       <label className="font-sans text-[11px] text-muted-foreground/60 tracking-wider">
         LABEL_OVERRIDE
       </label>
-      <input
+      <Input
         ref={inputRef}
         type="text"
         value={draft}
@@ -774,7 +775,7 @@ function LabelOverrideInput({
           }
         }}
         onBlur={commit}
-        className="px-2 py-1 font-sans text-[11px] text-foreground bg-background border border-border/60 rounded-smooth-md"
+        className="h-7 text-xs"
       />
     </div>
   );
@@ -843,7 +844,7 @@ function CeilingDimInput({
       >
         {label}
       </label>
-      <input
+      <Input
         id={`ceiling-dim-${axis}-${ceiling.id}`}
         type="text"
         aria-label={label}
@@ -864,7 +865,7 @@ function CeilingDimInput({
           }
         }}
         onBlur={commit}
-        className="w-20 px-1 py-0.5 text-right font-sans text-[11px] text-foreground bg-background border border-ring rounded-smooth-md outline-none"
+        className="w-20 h-7 text-xs text-right"
       />
     </div>
   );
@@ -929,7 +930,7 @@ function EditableRow({
     return (
       <div className="flex justify-between items-center">
         <span className="font-sans text-[11px] text-muted-foreground/60 tracking-wider">{label}</span>
-        <input
+        <Input
           autoFocus
           type={parser ? "text" : "number"}
           step={step}
@@ -941,7 +942,7 @@ function EditableRow({
             if (e.key === "Enter") commit();
             if (e.key === "Escape") setEditing(false);
           }}
-          className="w-20 px-1 py-0.5 text-right font-sans text-[11px] text-foreground bg-background border border-ring rounded-smooth-md outline-none"
+          className="w-20 h-7 text-xs text-right"
         />
       </div>
     );

--- a/src/components/RoomSettings.tsx
+++ b/src/components/RoomSettings.tsx
@@ -4,6 +4,7 @@ import {
   useActiveRoomDoc,
 } from "@/stores/cadStore";
 import { MaterialPicker } from "./MaterialPicker";
+import { Input } from "@/components/ui";
 
 export default function RoomSettings() {
   const room = useActiveRoom() ?? { width: 20, length: 16, wallHeight: 8 };
@@ -19,39 +20,39 @@ export default function RoomSettings() {
       <div className="grid grid-cols-2 gap-2">
         <label className="space-y-1">
           <span className="font-sans text-[9px] text-muted-foreground/60 tracking-wider">Width (ft)</span>
-          <input
+          <Input
             type="number"
             min={4}
             max={200}
             step={0.5}
             value={room.width}
             onChange={(e) => setRoom({ width: Math.max(4, +e.target.value) })}
-            className="w-full px-2 py-1.5 text-xs text-foreground"
+            className="w-full"
           />
         </label>
         <label className="space-y-1">
           <span className="font-sans text-[9px] text-muted-foreground/60 tracking-wider">Length (ft)</span>
-          <input
+          <Input
             type="number"
             min={4}
             max={200}
             step={0.5}
             value={room.length}
             onChange={(e) => setRoom({ length: Math.max(4, +e.target.value) })}
-            className="w-full px-2 py-1.5 text-xs text-foreground"
+            className="w-full"
           />
         </label>
       </div>
       <label className="space-y-1 block">
         <span className="font-sans text-[9px] text-muted-foreground/60 tracking-wider">Height (ft)</span>
-        <input
+        <Input
           type="number"
           min={6}
           max={20}
           step={0.5}
           value={room.wallHeight}
           onChange={(e) => setRoom({ wallHeight: Math.max(6, +e.target.value) })}
-          className="w-full px-2 py-1.5 text-xs text-foreground"
+          className="w-full"
         />
       </label>
 

--- a/src/components/WallSurfacePanel.tsx
+++ b/src/components/WallSurfacePanel.tsx
@@ -7,6 +7,7 @@ import { useWainscotStyleStore } from "@/stores/wainscotStyleStore";
 import { FRAME_PRESETS } from "@/types/framedArt";
 import { STYLE_META } from "@/types/wainscotStyle";
 import { MaterialPicker } from "./MaterialPicker";
+import { Input, Switch } from "@/components/ui";
 
 /** Appears in PropertiesPanel when exactly one wall is selected. */
 export default function WallSurfacePanel() {
@@ -154,24 +155,20 @@ export default function WallSurfacePanel() {
 
       {/* Wainscoting — pick from library (Phase 16) */}
       <div>
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={wains?.enabled ?? false}
-            onChange={(e) =>
-              toggleWainscoting(
-                wall.id,
-                activeSide,
-                e.target.checked,
-                wains?.heightFt,
-                wains?.color,
-                wains?.styleItemId
-              )
-            }
-            className="w-3 h-3 accent-accent rounded-none"
-          />
-          <span className="font-sans text-[11px] text-muted-foreground/80 tracking-wider">Wainscoting</span>
-        </label>
+        <Switch
+          checked={wains?.enabled ?? false}
+          onCheckedChange={(checked) =>
+            toggleWainscoting(
+              wall.id,
+              activeSide,
+              checked,
+              wains?.heightFt,
+              wains?.color,
+              wains?.styleItemId
+            )
+          }
+          label="Wainscoting"
+        />
         {wains?.enabled && (
           <div className="ml-5 mt-1 space-y-1">
             {wainscotStyles.length === 0 ? (
@@ -209,29 +206,25 @@ export default function WallSurfacePanel() {
 
       {/* Crown molding */}
       <div>
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={crown?.enabled ?? false}
-            onChange={(e) =>
-              toggleCrownMolding(wall.id, activeSide, e.target.checked, crown?.heightFt, crown?.color)
-            }
-            className="w-3 h-3 accent-accent rounded-none"
-          />
-          <span className="font-sans text-[11px] text-muted-foreground/80 tracking-wider">CROWN MOLDING</span>
-        </label>
+        <Switch
+          checked={crown?.enabled ?? false}
+          onCheckedChange={(checked) =>
+            toggleCrownMolding(wall.id, activeSide, checked, crown?.heightFt, crown?.color)
+          }
+          label="CROWN MOLDING"
+        />
         {crown?.enabled && (
           <div className="ml-5 mt-1 flex items-center gap-2">
-            <input
+            <Input
               type="number"
-              step="0.08"
-              min="0.17"
-              max="1"
+              step={0.08}
+              min={0.17}
+              max={1}
               value={crown.heightFt}
               onChange={(e) =>
                 toggleCrownMolding(wall.id, activeSide, true, parseFloat(e.target.value) || 0.33, crown.color)
               }
-              className="w-16 font-sans text-[11px] bg-accent text-foreground border border-border/60 px-1 py-0.5 rounded-smooth-md"
+              className="w-16"
             />
             <span className="font-sans text-[8px] text-muted-foreground/60">FT</span>
             <input


### PR DESCRIPTION
## Summary

- **AddProductModal**: Replaced manual overlay/backdrop/X-button with Dialog primitive. Migrated all text/number inputs to Input primitive, checkbox to Switch, action buttons to Button.
- **RoomSettings**: Replaced 3 raw number inputs (width, length, height) with the Input primitive.
- **MaterialPicker**: Updated selected card to ring-2 ring-ring, added hover:bg-accent/10 on all material cards, migrated tile-size input to Input primitive.

## Test plan

- [ ] Open the Add Product modal — no manual backdrop or X button; Esc and backdrop click close it
- [ ] Room Settings panel shows styled Input fields for Width, Length, Height
- [ ] Material picker: hover a card to see the accent tint; selected card shows correct ring highlight
- [ ] Tile size override input in MaterialPicker is styled consistently with other inputs
- [ ] TypeScript compiles with zero errors

Spec: .planning/phases/75-properties-library-restyle-properties-library-restyle/75-01-PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)