### PR TITLE
fix(77-01): fix v1.18 carry-over test failures — TooltipProvider + Switch role

### DIFF
--- a/.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-01-PLAN.md
+++ b/.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-01-PLAN.md
@@ -1,0 +1,257 @@
+---
+phase: 76-modals-welcomescreen-final-modals-welcome-final
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/index.css
+  - src/components/WelcomeScreen.tsx
+  - src/components/ProjectManager.tsx
+autonomous: true
+requirements:
+  - MODALS-WELCOME-FINAL-01
+  - MODALS-WELCOME-FINAL-02
+
+must_haves:
+  truths:
+    - "WelcomeScreen renders with a cream/light background (oklch(0.998 0 0)) even when the editor is in dark mode"
+    - "ProjectManager renders with the same light-mode tokens — no dark surface colors visible"
+    - "All legacy tokens (bg-cad-accent, bg-gray-100, text-gray-600, border-cad-accent, bg-blue-50, bg-red-50) are gone from ProjectManager"
+    - "Save button in ProjectManager uses bg-primary text-primary-foreground"
+  artifacts:
+    - path: "src/index.css"
+      provides: ".light CSS class that re-declares all light token values — overrides .dark ancestor"
+      contains: ".light {"
+    - path: "src/components/WelcomeScreen.tsx"
+      provides: "Root div has className including 'light'"
+    - path: "src/components/ProjectManager.tsx"
+      provides: "Pascal token classes only — zero gray-*, blue-*, cad-accent occurrences"
+  key_links:
+    - from: "src/index.css .light class"
+      to: "src/components/WelcomeScreen.tsx root div"
+      via: "className=\"light ...\""
+      pattern: "className.*light"
+    - from: "src/index.css .light class"
+      to: "src/components/ProjectManager.tsx root div"
+      via: "className=\"light ...\""
+      pattern: "className.*light"
+---
+
+<objective>
+Add a `.light` force-light CSS class to index.css and apply it to WelcomeScreen and ProjectManager so they always render in light mode, regardless of the user's dark/system theme setting. Restyle ProjectManager's legacy tokens to Pascal semantic tokens.
+
+Purpose: Per D-A4, editor surfaces stay dark; WelcomeScreen + ProjectManager adopt light mode (Pascal pattern). WelcomeScreen already uses semantic tokens — it just needs the `.light` wrapper. ProjectManager still has hardcoded gray/blue/red Tailwind utilities that must become semantic tokens.
+
+Output: Two light-mode surfaces; one new CSS class; zero legacy gray/cad-accent/blue tokens in ProjectManager.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+</context>
+
+<interfaces>
+<!-- Token values from src/index.css :root (light mode defaults) -->
+<!-- .light class must redeclare identical values so it overrides .dark on <html> -->
+:root {
+  --background: oklch(0.998 0 0);        /* cream-white */
+  --foreground: oklch(0.145 0 0);        /* near-black */
+  --card: oklch(0.998 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(0.998 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+}
+
+<!-- Token mapping for ProjectManager legacy → Pascal -->
+bg-cad-accent        → bg-primary
+text-white           → text-primary-foreground
+hover:bg-blue-700    → hover:bg-primary/90
+bg-gray-100          → bg-muted
+text-gray-600        → text-muted-foreground
+hover:bg-gray-200    → hover:bg-muted/80
+border-cad-accent    → border-ring
+bg-blue-50           → bg-accent/10
+border-gray-100      → border-border
+hover:border-gray-200 → hover:border-border/60
+text-gray-700        → text-foreground
+text-gray-400        → text-muted-foreground
+bg-red-50            → bg-destructive/10
+text-red-500         → text-destructive
+hover:bg-red-100     → hover:bg-destructive/20
+</interfaces>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add .light CSS class to index.css</name>
+  <files>src/index.css</files>
+  <read_first>src/index.css</read_first>
+  <action>
+Read src/index.css to find the .dark block (lines 30-49). Immediately after the closing brace of .dark {}, add a new .light {} block that redeclares all 16 token variables with the same values as :root (light defaults). This lets any element with className="light" override a .dark ancestor on <html>.
+
+Add this block after the `.dark { }` block:
+
+```css
+/* Force-light wrapper — used by WelcomeScreen + ProjectManager.
+   Overrides .dark on <html> so these surfaces always render in light mode. */
+.light {
+  --background: oklch(0.998 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(0.998 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(0.998 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+}
+```
+
+Do NOT touch the :root block, .dark block, @theme block, or any other CSS in the file.
+  </action>
+  <verify>
+    <automated>grep -n "\.light {" /Users/micahbank/room-cad-renderer/.claude/worktrees/friendly-merkle-8005fb/src/index.css</automated>
+  </verify>
+  <acceptance_criteria>
+    - `.light {` block exists in src/index.css after the `.dark {}` block
+    - The block contains all 16 `--variable: oklch(...)` declarations matching :root values
+    - No other CSS in the file was modified (grep ".dark {" still returns the same line number)
+  </acceptance_criteria>
+  <done>src/index.css contains .light {} class with all 16 light token values</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Apply .light wrapper to WelcomeScreen</name>
+  <files>src/components/WelcomeScreen.tsx</files>
+  <read_first>src/components/WelcomeScreen.tsx</read_first>
+  <action>
+Read src/components/WelcomeScreen.tsx. The root div at line 55 is:
+```tsx
+<div className="h-full flex flex-col bg-background">
+```
+
+Change it to:
+```tsx
+<div className="light h-full flex flex-col bg-background">
+```
+
+That is the only change needed. WelcomeScreen already uses all semantic tokens (bg-background, text-foreground, text-muted-foreground, bg-card, border-border, etc.) — the .light wrapper will cause those tokens to resolve to light values even when html.dark is active.
+
+Do NOT modify any other line in the file.
+  </action>
+  <verify>
+    <automated>grep -n "className=\"light" /Users/micahbank/room-cad-renderer/.claude/worktrees/friendly-merkle-8005fb/src/components/WelcomeScreen.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - Line 55 root div className starts with "light "
+    - No other lines in WelcomeScreen.tsx were changed
+    - grep for "bg-obsidian\|text-text-\|cad-accent\|gray-" returns zero results in this file
+  </acceptance_criteria>
+  <done>WelcomeScreen root div has className="light h-full flex flex-col bg-background"</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Restyle ProjectManager with Pascal tokens + .light wrapper</name>
+  <files>src/components/ProjectManager.tsx</files>
+  <read_first>src/components/ProjectManager.tsx</read_first>
+  <action>
+Read src/components/ProjectManager.tsx. The component currently has no wrapping div — it returns `<div className="space-y-3">`. Wrap the return in a `<div className="light">` shell, OR simply add "light" to the existing outer div's className. The existing outer div is `<div className="space-y-3">` — change it to `<div className="light space-y-3">`.
+
+Then replace all legacy Tailwind tokens with Pascal equivalents:
+
+1. Save button (line 84):
+   FROM: `className="flex-1 py-1.5 rounded bg-cad-accent text-white text-xs font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"`
+   TO:   `className="flex-1 py-1.5 rounded bg-primary text-primary-foreground text-xs font-semibold hover:bg-primary/90 disabled:opacity-50 transition-colors"`
+
+2. New button (line 90):
+   FROM: `className="px-3 py-1.5 rounded bg-gray-100 text-gray-600 text-xs font-medium hover:bg-gray-200 transition-colors"`
+   TO:   `className="px-3 py-1.5 rounded bg-muted text-muted-foreground text-xs font-medium hover:bg-muted/80 transition-colors"`
+
+3. Project row — active state (line 102-103):
+   FROM: `"border-cad-accent bg-blue-50"` (the active branch of the ternary)
+   TO:   `"border-ring bg-accent/10"`
+
+4. Project row — inactive state (line 103):
+   FROM: `"border-gray-100 hover:border-gray-200"`
+   TO:   `"border-border hover:border-border/60"`
+
+5. Project name (line 108):
+   FROM: `className="font-medium text-gray-700 truncate"`
+   TO:   `className="font-sans font-medium text-foreground truncate"`
+
+6. Project date (line 111):
+   FROM: `className="text-[10px] text-gray-400"`
+   TO:   `className="font-sans text-[10px] text-muted-foreground"`
+
+7. Load button (line 117):
+   FROM: `className="px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 hover:bg-gray-200 text-[10px]"`
+   TO:   `className="px-1.5 py-0.5 rounded bg-muted text-muted-foreground hover:bg-muted/80 text-[10px]"`
+
+8. Delete button (line 121):
+   FROM: `className="px-1.5 py-0.5 rounded bg-red-50 text-red-500 hover:bg-red-100 text-[10px]"`
+   TO:   `className="px-1.5 py-0.5 rounded bg-destructive/10 text-destructive hover:bg-destructive/20 text-[10px]"`
+
+Do NOT change any logic, imports, or non-className lines.
+  </action>
+  <verify>
+    <automated>grep -n "cad-accent\|bg-gray\|text-gray\|bg-blue\|bg-red\|text-red\|text-white\|hover:bg-blue-700" /Users/micahbank/room-cad-renderer/.claude/worktrees/friendly-merkle-8005fb/src/components/ProjectManager.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - grep for "cad-accent|bg-gray|text-gray|bg-blue|bg-red|text-red|text-white|hover:bg-blue-700" returns zero matches in ProjectManager.tsx
+    - Outer div className contains "light"
+    - Save button uses bg-primary text-primary-foreground
+    - Delete button uses bg-destructive/10 text-destructive
+    - File compiles without TypeScript errors (npx tsc --noEmit returns 0 for this file's imports)
+  </acceptance_criteria>
+  <done>ProjectManager.tsx uses only Pascal semantic tokens; root div has "light" class; zero legacy gray/cad-accent/blue tokens remain</done>
+</task>
+
+</tasks>
+
+<verification>
+After all three tasks:
+1. `grep -n "\.light {" src/index.css` — finds the block
+2. `grep "className=\"light" src/components/WelcomeScreen.tsx` — finds root div
+3. `grep "cad-accent\|bg-gray\|text-gray\|bg-blue\|bg-red\|text-white" src/components/ProjectManager.tsx` — returns nothing
+4. `npm run build` — exits 0 (TypeScript + Vite bundling clean)
+</verification>
+
+<success_criteria>
+- .light CSS class exists in index.css with all 16 light-mode token values
+- WelcomeScreen root div has className="light h-full flex flex-col bg-background"
+- ProjectManager root div has className="light space-y-3"
+- ProjectManager contains zero legacy gray-*/cad-accent/blue-*/red-* Tailwind classes
+- Build passes clean
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-01-SUMMARY.md`
+</output>

--- a/.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-02-PLAN.md
+++ b/.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-02-PLAN.md
@@ -1,0 +1,293 @@
+---
+phase: 76-modals-welcomescreen-final-modals-welcome-final
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/HelpModal.tsx
+  - src/components/ProductForm.tsx
+autonomous: true
+requirements:
+  - MODALS-WELCOME-FINAL-03
+  - MODALS-WELCOME-FINAL-04
+
+must_haves:
+  truths:
+    - "HelpModal opens and closes using the Dialog primitive — no manual fixed/inset-0 overlay pattern remains"
+    - "HelpModal preserves all existing functionality: section nav, search, anchor scroll, keyboard shortcuts, tour reset"
+    - "ProductForm inputs use border-border and focus:border-ring — zero cad-accent/gray-* legacy tokens"
+    - "ProductForm submit button uses bg-primary text-primary-foreground"
+  artifacts:
+    - path: "src/components/HelpModal.tsx"
+      provides: "Dialog-primitive-based help modal; imports Dialog from @/components/ui"
+      contains: "import { Dialog"
+    - path: "src/components/ProductForm.tsx"
+      provides: "Form with Pascal semantic token classes only"
+      exports: ["default ProductForm"]
+  key_links:
+    - from: "src/components/HelpModal.tsx"
+      to: "src/components/ui/Dialog.tsx"
+      via: "import { Dialog, DialogContent } from '@/components/ui'"
+      pattern: "from \"@/components/ui\""
+---
+
+<objective>
+Migrate HelpModal from its manual overlay/fixed-div pattern to the Dialog primitive. Sweep ProductForm's legacy gray-*/cad-accent tokens to Pascal equivalents.
+
+Purpose: HelpModal is the last major component using the old manual overlay pattern (fixed inset-0, role="dialog", manual backdrop). All other dialogs migrated in Phase 72. ProductForm has hardcoded gray-200/gray-100/cad-accent classes that must become semantic tokens for light-mode correctness.
+
+Output: HelpModal uses Dialog + DialogContent from @/components/ui; ProductForm uses only Pascal tokens.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+</context>
+
+<interfaces>
+<!-- Dialog primitive API from src/components/ui/Dialog.tsx -->
+export const Dialog = DialogPrimitive.Root;         // controlled: open + onOpenChange
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogClose = DialogPrimitive.Close;
+export const DialogContent = React.forwardRef<...>; // renders Portal + Overlay + motion.div panel
+export const DialogTitle = React.forwardRef<...>;
+export const DialogHeader = function({ className, ...props });
+export const DialogFooter = function({ className, ...props });
+
+// DialogContent renders its own Portal + backdrop automatically.
+// max-w-lg by default; override with className="max-w-[900px]"
+// The panel is bg-card rounded-smooth-lg border border-border p-6 by default.
+// To customize panel internals (remove default padding for the multi-column layout),
+// pass className="p-0 max-w-[900px] h-[640px] max-h-[90vh] overflow-hidden"
+
+// HelpModal DOES NOT use DialogTrigger — it's controlled by useUIStore.showHelp.
+// Pattern: <Dialog open={showHelp} onOpenChange={(open) => { if (!open) closeHelp(); }}>
+
+<!-- ProductForm token mapping -->
+border-gray-200           → border-border
+focus:border-cad-accent   → focus:border-ring
+text-gray-400             → text-muted-foreground
+file:bg-gray-100          → file:bg-muted
+file:text-gray-600        → file:text-muted-foreground
+hover:file:bg-gray-200    → hover:file:bg-muted/80
+border-gray-200 (img)     → border-border
+bg-cad-accent             → bg-primary
+text-white                → text-primary-foreground
+hover:bg-blue-700         → hover:bg-primary/90
+</interfaces>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Migrate HelpModal to Dialog primitive</name>
+  <files>src/components/HelpModal.tsx</files>
+  <read_first>src/components/HelpModal.tsx, src/components/ui/Dialog.tsx</read_first>
+  <action>
+Read src/components/HelpModal.tsx (170 lines). The current structure:
+- Early return `if (!showHelp) return null;`
+- Outer: `<div className="fixed inset-0 z-50 flex items-center justify-center">`
+- Backdrop: `<div className="absolute inset-0 bg-background/80 backdrop-blur-sm" onClick={closeHelp} />`
+- Panel: `<div className="relative w-[900px] h-[640px] ... bg-popover border border-border/60 rounded-smooth-md shadow-2xl flex flex-col overflow-hidden" role="dialog" ...>`
+- Header with h2 + close button (X icon)
+- Body: left nav + content pane
+- Footer: REPLAY TOUR button + ESC TO CLOSE label
+
+Replace the entire JSX return (everything after `if (!showHelp) return null;`) with the Dialog primitive pattern. Keep all logic, state, refs, and event handlers intact — only the JSX structure changes.
+
+Add to imports at top of file:
+```tsx
+import { Dialog, DialogContent } from "@/components/ui";
+```
+
+Remove the `import { X, RotateCcw } from "lucide-react";` — keep RotateCcw (used in footer), but X is no longer needed because DialogContent does not auto-render a close button (the component is simpler than AddRoomDialog; the modal has its own close button in the header). Actually keep the X import — we will keep the close button in the header, but it's now inside the DialogContent panel (same as before).
+
+New JSX structure:
+
+```tsx
+// Remove: if (!showHelp) return null;   ← Dialog's open prop handles visibility
+
+return (
+  <Dialog open={showHelp} onOpenChange={(open) => { if (!open) closeHelp(); }}>
+    <DialogContent
+      className="p-0 w-[900px] max-w-[95vw] h-[640px] max-h-[90vh] flex flex-col overflow-hidden"
+      aria-label="Help and documentation"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-3 border-b border-border/50 shrink-0">
+        <h2 className="font-sans text-sm text-foreground tracking-widest uppercase">
+          Help &amp; Documentation
+        </h2>
+        <button
+          onClick={closeHelp}
+          title="Close (Esc)"
+          className="text-muted-foreground/60 hover:text-foreground transition-colors"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left nav */}
+        <nav className="w-56 bg-card border-r border-border/50 py-4 shrink-0 overflow-y-auto">
+          <HelpSearch
+            query={query}
+            onQueryChange={setQuery}
+            onSelect={(entry) => {
+              setHelpSection(entry.section);
+              if (entry.anchor) setPendingAnchor(entry.anchor);
+              setQuery("");
+            }}
+          />
+          <h3 className="font-sans text-[9px] text-muted-foreground/60 tracking-widest uppercase px-4 mb-2">
+            Topics
+          </h3>
+          <ul>
+            {HELP_SECTIONS.map((s) => (
+              <li key={s.id}>
+                <HelpNavButton
+                  section={s.id}
+                  label={s.label}
+                  icon={s.icon}
+                  active={activeSection === s.id}
+                  onClick={() => setHelpSection(s.id)}
+                />
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        {/* Content */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <div
+            ref={contentRef}
+            className="flex-1 overflow-y-auto px-8 py-6 bg-popover"
+          >
+            <HelpSectionContent section={activeSection} />
+          </div>
+          {/* Footer */}
+          <div className="flex items-center justify-between px-6 py-2 border-t border-border/50 bg-card shrink-0">
+            <button
+              onClick={() => {
+                resetTour();
+                closeHelp();
+                setTimeout(() => startTour(), 50);
+              }}
+              className="font-sans text-[10px] tracking-widest text-muted-foreground/80 hover:text-foreground transition-colors flex items-center gap-1"
+            >
+              <RotateCcw size={14} /> {/* D-15: substitute for material-symbols 'replay' */}
+              REPLAY TOUR
+            </button>
+            <span className="font-sans text-[9px] text-muted-foreground/60 tracking-widest">
+              ESC TO CLOSE
+            </span>
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+);
+```
+
+Key changes from the old pattern:
+1. Remove `if (!showHelp) return null;` — Dialog's `open` prop controls visibility
+2. Remove the outer `fixed inset-0 z-50 flex items-center justify-center` div
+3. Remove the manual backdrop div — DialogContent renders its own backdrop
+4. Remove `role="dialog"` — Radix handles ARIA
+5. Wrap everything in `<Dialog open={showHelp} onOpenChange={...}><DialogContent ...>`
+6. DialogContent gets `p-0` to override the default p-6 padding (the modal manages its own internal layout)
+7. All existing interior content (header, nav, content pane, footer) stays identical
+
+The two useEffect hooks (scroll on section change, clear search on close) remain untouched.
+  </action>
+  <verify>
+    <automated>grep -n "fixed inset-0\|absolute inset-0\|role=\"dialog\"" /Users/micahbank/room-cad-renderer/.claude/worktrees/friendly-merkle-8005fb/src/components/HelpModal.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - grep for "fixed inset-0|absolute inset-0|role=\"dialog\"" returns zero matches in HelpModal.tsx
+    - grep for "import { Dialog" returns a match in HelpModal.tsx
+    - grep for "<Dialog open={showHelp}" returns a match in HelpModal.tsx
+    - HELP_SECTIONS, HelpSectionContent, HelpSearch, HelpNavButton, useOnboardingStore imports are all preserved
+    - Both useEffect hooks (scroll + clear search) are preserved
+    - File has no TypeScript errors (verified by build step)
+  </acceptance_criteria>
+  <done>HelpModal uses Dialog + DialogContent from @/components/ui; no manual overlay pattern remains; all existing functionality preserved</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Token sweep on ProductForm</name>
+  <files>src/components/ProductForm.tsx</files>
+  <read_first>src/components/ProductForm.tsx</read_first>
+  <action>
+Read src/components/ProductForm.tsx (152 lines). Replace all legacy Tailwind tokens with Pascal equivalents. Only change className strings — no logic, imports, or JSX structure changes.
+
+Replacements (apply all occurrences):
+
+1. All input borders:
+   FROM: `border border-gray-200`
+   TO:   `border border-border`
+
+2. All input focus rings:
+   FROM: `focus:border-cad-accent`
+   TO:   `focus:border-ring`
+
+3. Dimension label spans (W ft, D ft, H ft):
+   FROM: `text-[10px] text-gray-400`
+   TO:   `text-[10px] text-muted-foreground`
+
+4. File input styling:
+   FROM: `file:bg-gray-100 file:text-gray-600 hover:file:bg-gray-200`
+   TO:   `file:bg-muted file:text-muted-foreground hover:file:bg-muted/80`
+
+5. Preview image border:
+   FROM: `border border-gray-200`
+   TO:   `border border-border`
+   (same as #1 — check the `<img>` tag specifically)
+
+6. Submit button:
+   FROM: `bg-cad-accent text-white ... hover:bg-blue-700`
+   TO:   `bg-primary text-primary-foreground ... hover:bg-primary/90`
+
+After changes, verify no gray-*/cad-accent/blue-* remain.
+  </action>
+  <verify>
+    <automated>grep -n "cad-accent\|bg-gray\|text-gray\|border-gray\|file:bg-gray\|file:text-gray\|bg-blue\|text-white\|hover:bg-blue" /Users/micahbank/room-cad-renderer/.claude/worktrees/friendly-merkle-8005fb/src/components/ProductForm.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - grep for "cad-accent|bg-gray|text-gray|border-gray|file:bg-gray|file:text-gray|bg-blue|text-white|hover:bg-blue" returns zero matches
+    - All input elements use `border-border` and `focus:border-ring`
+    - Submit button uses `bg-primary text-primary-foreground hover:bg-primary/90`
+    - Dimension labels use `text-muted-foreground`
+    - File input uses `file:bg-muted file:text-muted-foreground hover:file:bg-muted/80`
+    - No logic or JSX structure was changed
+  </acceptance_criteria>
+  <done>ProductForm uses only Pascal semantic tokens; zero legacy gray-*/cad-accent classes remain</done>
+</task>
+
+</tasks>
+
+<verification>
+After both tasks:
+1. `grep -n "fixed inset-0\|absolute inset-0\|role=\"dialog\"" src/components/HelpModal.tsx` — returns nothing
+2. `grep "import { Dialog" src/components/HelpModal.tsx` — returns match
+3. `grep "cad-accent\|bg-gray\|text-gray\|border-gray\|bg-blue\|text-white" src/components/ProductForm.tsx` — returns nothing
+4. `npm run build` — exits 0
+</verification>
+
+<success_criteria>
+- HelpModal renders via Dialog + DialogContent primitive; no manual fixed overlay
+- All existing HelpModal features preserved (section nav, search, anchor scroll, tour reset, keyboard shortcuts)
+- ProductForm has zero gray-*/cad-accent/blue-* classes; all inputs use Pascal tokens
+- TypeScript build passes clean
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-02-SUMMARY.md`
+</output>

--- a/.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-03-PLAN.md
+++ b/.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-03-PLAN.md
@@ -1,0 +1,152 @@
+---
+phase: 76-modals-welcomescreen-final-modals-welcome-final
+plan: 03
+type: execute
+wave: 2
+depends_on:
+  - 76-01
+  - 76-02
+files_modified: []
+autonomous: true
+requirements:
+  - MODALS-WELCOME-FINAL-05
+
+must_haves:
+  truths:
+    - "grep for obsidian-/text-text-/accent-glow/cad-grid-bg/glass-panel/material-symbols-outlined across src/ returns zero matches"
+    - "The 4 carry-over vitest tests (snapshotMigration, pickerMyTexturesIntegration, WallMesh.cutaway, contextMenuActionCounts) all pass"
+    - "npm run build exits 0 with zero TypeScript errors"
+  artifacts:
+    - path: "src/"
+      provides: "Entire src directory free of legacy token strings"
+      contains: "(verified by grep — no artifact to create)"
+  key_links:
+    - from: "Plan 76-01 changes"
+      to: "grep audit"
+      via: "zero obsidian-* in src/"
+      pattern: "obsidian-"
+    - from: "Plan 76-02 changes"
+      to: "vitest run"
+      via: "4 carry-over tests pass"
+      pattern: "snapshotMigration|pickerMyTexturesIntegration|WallMesh.cutaway|contextMenuActionCounts"
+---
+
+<objective>
+Run the final grep audit and vitest carry-over test confirmation for Phase 76. This plan produces no code changes — it only verifies the state of src/ after Plans 01 and 02 have executed.
+
+Purpose: Success criterion 4 (zero legacy token references) and success criterion 5 (4 carry-over tests passing) must be confirmed as a formal gate before the phase can be marked complete.
+
+Output: A pass/fail determination on each audit item; SUMMARY.md documenting the results.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-01-SUMMARY.md
+@.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-02-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Final grep audit — zero legacy token references in src/</name>
+  <files></files>
+  <read_first></read_first>
+  <action>
+Run each grep command below from the project root. Each MUST return zero matches. If any command returns output, the plan fails — identify the file(s) and report them in the SUMMARY.md as carry-over items (do not attempt fixes in this plan).
+
+```bash
+# Audit 1: Obsidian palette classes
+grep -r "obsidian-" src/ --include="*.tsx" --include="*.ts" --include="*.css"
+
+# Audit 2: Old text token classes
+grep -r "text-text-" src/ --include="*.tsx" --include="*.ts" --include="*.css"
+
+# Audit 3: Removed custom CSS classes
+grep -r "accent-glow\|cad-grid-bg\|glass-panel" src/ --include="*.tsx" --include="*.ts" --include="*.css"
+
+# Audit 4: Material Symbols web font (dropped per D-A5)
+grep -r "material-symbols-outlined" src/ --include="*.tsx" --include="*.ts" --include="*.css"
+
+# Bonus audit (not in formal success criteria but useful — catches remaining gray-*/cad-accent in any file)
+grep -r "bg-cad-accent\|border-cad-accent\|text-cad-accent" src/ --include="*.tsx" --include="*.ts"
+```
+
+Record the output of each command (empty = pass, any lines = fail) in the SUMMARY.md.
+  </action>
+  <verify>
+    <automated>grep -r "obsidian-\|text-text-\|accent-glow\|cad-grid-bg\|glass-panel\|material-symbols-outlined" /Users/micahbank/room-cad-renderer/.claude/worktrees/friendly-merkle-8005fb/src/ --include="*.tsx" --include="*.ts" --include="*.css" | wc -l</automated>
+  </verify>
+  <acceptance_criteria>
+    - All 4 audit greps return zero matches
+    - The bonus cad-accent audit also returns zero matches
+    - If any grep returns matches: list them in SUMMARY.md as "carry-over items" and note the file paths
+  </acceptance_criteria>
+  <done>grep audit complete; zero legacy token references in src/ (or carry-over items documented)</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Confirm carry-over vitest tests pass + run full build</name>
+  <files></files>
+  <read_first></read_first>
+  <action>
+Run the 4 carry-over tests individually to confirm they pass. Then run a full TypeScript build.
+
+```bash
+# Carry-over test 1 — snapshot migration version assertion
+npx vitest run tests/snapshotMigration.test.ts --reporter=verbose
+
+# Carry-over test 2 — picker/MyTextures tab integration
+npx vitest run tests/pickerMyTexturesIntegration.test.tsx --reporter=verbose
+
+# Carry-over test 3 — WallMesh cutaway
+npx vitest run tests/WallMesh.cutaway.test.tsx --reporter=verbose
+
+# Carry-over test 4 — context menu action counts (test pollution fix)
+npx vitest run tests/lib/contextMenuActionCounts.test.ts --reporter=verbose
+
+# TypeScript build check
+npm run build
+```
+
+For each test: record PASS or FAIL in the SUMMARY.md. If any test FAILS, document the failure output. Do NOT attempt to fix failing tests in this plan — report them as carry-over items.
+
+Expected: all 4 PASS (per pre-planning research). Build: exits 0.
+  </action>
+  <verify>
+    <automated>npx vitest run tests/snapshotMigration.test.ts tests/pickerMyTexturesIntegration.test.tsx tests/WallMesh.cutaway.test.tsx tests/lib/contextMenuActionCounts.test.ts --reporter=verbose 2>&1 | tail -20</automated>
+  </verify>
+  <acceptance_criteria>
+    - All 4 vitest test files report "passed" (not "failed")
+    - npm run build exits with code 0
+    - SUMMARY.md documents the pass/fail result for each test
+    - If any test fails: output is captured in SUMMARY.md as a carry-over item
+  </acceptance_criteria>
+  <done>All 4 carry-over tests confirmed passing; build clean; phase audit complete</done>
+</task>
+
+</tasks>
+
+<verification>
+Both tasks are audit-only. Verification IS the task output:
+- 0 lines from the legacy token grep
+- 4/4 vitest tests PASS
+- npm run build exits 0
+</verification>
+
+<success_criteria>
+- grep audit: zero matches for obsidian-/text-text-/accent-glow/cad-grid-bg/glass-panel/material-symbols-outlined in src/
+- Carry-over tests: snapshotMigration + pickerMyTexturesIntegration + WallMesh.cutaway + contextMenuActionCounts all PASS
+- TypeScript + Vite build: exits 0
+- Phase 76 SUMMARY.md documents all audit results
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/76-modals-welcomescreen-final-modals-welcome-final/76-03-SUMMARY.md`
+</output>


### PR DESCRIPTION
## Summary

- Wraps every `render(<App />)` call in `<TooltipProvider>` across 5 test files (GH #163) — fixes Radix Tooltip throwing without a provider ancestor
- Fixes `getByRole("checkbox")` → `getByRole("switch")` in AddProductModal tests (GH #164) — Switch primitive uses `role="switch"` not `role="checkbox"`
- Fixes `container.querySelector` → `document.body.querySelector` for Dialog portal DOM (auto-fix: portals render outside the RTL container)

**Result:** 926 tests passing. Only the 2 pre-existing failures (SaveIndicator, SidebarProductPicker) remain.

Closes #163
Closes #164

Spec: .planning/phases/77-test-suite-cleanup-test-cleanup-01-v1-19-active/77-01-PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)