### PR TITLE
Phase 70: Library 3-tab rebuild — Materials / Products / Assemblies

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -18,7 +18,7 @@
 
 ### Library Rebuild (LIB-REBUILD)
 
-- [ ] **LIB-REBUILD-01**: Sidebar library shows a 3-way toggle at the top — Materials / Products / Assemblies — switching tabs swaps the visible content cleanly
+- [x] **LIB-REBUILD-01**: Sidebar library shows a 3-way toggle at the top — Materials / Products / Assemblies — switching tabs swaps the visible content cleanly
 - [ ] **LIB-REBUILD-02**: Materials tab shows category sub-tabs (Flooring / Wall coverings / Countertops / Paint) and filters the Phase 67 material library by category
 - [ ] **LIB-REBUILD-03**: Products tab shows category sub-tabs (Furniture / Plumbing fixtures / Appliances / Lighting / Curtains & blinds / Decor); existing products land in the right category or "Uncategorized"
 - [ ] **LIB-REBUILD-04**: Assemblies tab shows a clear empty-state placeholder — not broken UI

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.19
 milestone_name: Material Linking & Library Rebuild
 status: Defining requirements
-last_updated: "2026-05-08T18:40:21.488Z"
+last_updated: "2026-05-08T19:43:52.346Z"
 last_activity: 2026-05-08 — Milestone v1.19 started
 progress:
   total_phases: 16
-  completed_phases: 9
-  total_plans: 37
-  completed_plans: 34
+  completed_phases: 10
+  total_plans: 38
+  completed_plans: 35
 ---
 
 # Project State
@@ -42,6 +42,7 @@ Last activity: 2026-05-08 — Milestone v1.19 started
 - **D-A8 (carry-over):** Phase 69 (MAT-LINK-01) + Phase 70 (LIB-REBUILD-01) deferred from v1.17 to v1.19 to ship in v1.18 Pascal chrome.
 - **[Phase 71-76 decisions preserved]** — see v1.18 SUMMARY/VERIFICATION docs for v1.18 chrome decisions.
 - [Phase 69]: Snapshot v6→v7 is trivial passthrough; GLTF finish deferred to v1.20; MaterialPicker customElementFace surface type reused for product finish
+- [Phase 70]: Default library tab is Materials (not Products) — puts newest feature front and center
 
 ## Performance Metrics
 

--- a/.planning/phases/70-library-rebuild-lib-rebuild-01-v1-19-active/70-01-PLAN.md
+++ b/.planning/phases/70-library-rebuild-lib-rebuild-01-v1-19-active/70-01-PLAN.md
@@ -1,0 +1,290 @@
+---
+phase: 70-library-rebuild-lib-rebuild-01-v1-19-active
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/types/material.ts
+  - src/components/UploadMaterialModal.tsx
+  - src/components/ProductLibrary.tsx
+  - src/components/MaterialsSection.tsx
+autonomous: true
+requirements:
+  - LIB-REBUILD-01
+must_haves:
+  truths:
+    - "Sidebar shows a 3-way Materials / Products / Assemblies toggle at the top"
+    - "Switching tabs swaps visible content without layout shift or broken UI"
+    - "Materials tab shows Flooring / Wall coverings / Countertops / Paint sub-tabs and filters materials by category"
+    - "Products tab shows existing category sub-tabs; products without a matching category appear under 'Uncategorized'"
+    - "Assemblies tab shows a readable placeholder — not empty, not broken"
+    - "Upload Material button is only visible in the Materials tab; Add Product button is only visible in the Products tab"
+    - "Existing product place flow (setPendingProduct → setTool('product')) continues to work"
+    - "Existing UploadMaterialModal open/close flow continues to work"
+  artifacts:
+    - path: "src/types/material.ts"
+      provides: "Material.category optional field + MATERIAL_CATEGORIES constant"
+      contains: "MATERIAL_CATEGORIES"
+    - path: "src/components/ProductLibrary.tsx"
+      provides: "3-tab library shell"
+      exports: ["ProductLibrary"]
+    - path: "src/components/UploadMaterialModal.tsx"
+      provides: "Category selector in upload form"
+      contains: "MATERIAL_CATEGORIES"
+  key_links:
+    - from: "src/components/ProductLibrary.tsx"
+      to: "src/components/MaterialsSection.tsx"
+      via: "activeLibraryTab === 'materials' conditional render"
+    - from: "src/components/MaterialsSection.tsx"
+      to: "useMaterials()"
+      via: "materials filtered by activeMaterialCategory"
+    - from: "src/components/UploadMaterialModal.tsx"
+      to: "src/types/material.ts"
+      via: "MATERIAL_CATEGORIES import + category field on submit"
+---
+
+<objective>
+Reorganize the sidebar library into a top-level 3-way toggle: Materials / Products / Assemblies. Each tab owns its category sub-tabs and its upload/add action button.
+
+Purpose: Jessica can navigate materials, products, and assemblies as distinct collections without hunting through a single collapsed panel. The Materials tab introduces category filtering for Phase 67 materials.
+
+Output: Updated ProductLibrary.tsx with 3-tab shell, MaterialsSection.tsx with category sub-tabs, UploadMaterialModal.tsx with category selector, and a new MATERIAL_CATEGORIES constant in material.ts.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+
+<interfaces>
+<!-- Key contracts the executor needs. No codebase exploration required. -->
+
+From src/types/material.ts (current — add category field):
+```typescript
+export interface Material {
+  id: string;
+  name: string;
+  colorMapId: string;
+  roughnessMapId?: string;
+  reflectionMapId?: string;
+  brand?: string;
+  sku?: string;
+  cost?: number;
+  leadTime?: string;
+  tileSizeFt?: number;
+  colorHex?: string;
+  // ADD: category?: string
+}
+```
+
+From src/types/product.ts (existing — do NOT change):
+```typescript
+export const PRODUCT_CATEGORIES = [
+  "Seating", "Tables", "Storage", "Beds", "Lighting",
+  "Rugs", "Decor", "Appliances", "Other"
+] as const;
+```
+
+From src/components/ProductLibrary.tsx (current props — do NOT change signature):
+```typescript
+interface Props {
+  products: Product[];
+  onAdd: (product: Product) => void;
+  onRemove: (productId: string) => void;
+  onOpenAddModal: () => void;
+}
+```
+
+From src/components/MaterialsSection.tsx (current — used internally by ProductLibrary):
+```typescript
+// Self-contained: calls useMaterials(), renders MaterialCard grid
+// and controls UploadMaterialModal open state.
+// Phase 70: add activeMaterialCategory state + category sub-tabs filter.
+```
+
+MATERIAL_CATEGORIES (to add — Flooring / Wall coverings / Countertops / Paint):
+```typescript
+export const MATERIAL_CATEGORIES = [
+  "Flooring",
+  "Wall coverings",
+  "Countertops",
+  "Paint",
+] as const;
+export type MaterialCategory = (typeof MATERIAL_CATEGORIES)[number];
+```
+
+Products tab sub-tabs: use existing PRODUCT_CATEGORIES values verbatim.
+Products whose category is not in PRODUCT_CATEGORIES show under "Uncategorized".
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add category field to Material type and UploadMaterialModal</name>
+  <files>src/types/material.ts, src/components/UploadMaterialModal.tsx</files>
+  <action>
+**src/types/material.ts**
+- Add `category?: string` to the `Material` interface.
+- Add and export `MATERIAL_CATEGORIES` constant (tuple):
+  ```typescript
+  export const MATERIAL_CATEGORIES = [
+    "Flooring",
+    "Wall coverings",
+    "Countertops",
+    "Paint",
+  ] as const;
+  export type MaterialCategory = (typeof MATERIAL_CATEGORIES)[number];
+  ```
+
+**src/components/UploadMaterialModal.tsx**
+- Import `MATERIAL_CATEGORIES` from `@/types/material`.
+- Add a `category` field to the form state (initial value: `""` meaning unset).
+- In the form body, add a `<select>` (or shadcn `Select`) between the name field and the first texture upload row. Label: "Category (optional)". Options: a blank option ("No category") + one option per `MATERIAL_CATEGORIES` entry.
+- On save, include `category: formState.category || undefined` in the Material object passed to the create/update handler. This is an additive change — existing save logic is otherwise untouched.
+- No migration needed; previously-saved Materials have `category: undefined` and will appear only in "All" sub-tab.
+  </action>
+  <verify>
+    <automated>grep -n "MATERIAL_CATEGORIES" /Users/micahbank/room-cad-renderer/src/types/material.ts && grep -n "category" /Users/micahbank/room-cad-renderer/src/components/UploadMaterialModal.tsx</automated>
+  </verify>
+  <done>
+    - `MATERIAL_CATEGORIES` exported from `src/types/material.ts`
+    - `Material.category?: string` present
+    - UploadMaterialModal form renders a category selector; submitting sets `category` on the Material object
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add category sub-tab filtering to MaterialsSection</name>
+  <files>src/components/MaterialsSection.tsx</files>
+  <action>
+Add category sub-tab filtering inside `MaterialsSection` (keep it self-contained):
+
+1. Add `activeMaterialCategory` state: `"All" | MaterialCategory`, default `"All"`.
+2. Import `MATERIAL_CATEGORIES` from `@/types/material`.
+3. Render a `<Tabs>` row above the MaterialCard grid. TabsTriggers: "All" + one per `MATERIAL_CATEGORIES` entry (4 items = 5 triggers total). Use the same `Tabs` primitive from `@/components/ui` that ProductLibrary already imports.
+4. Filter the `materials` array from `useMaterials()`:
+   - `"All"` → show everything
+   - Any category value → `materials.filter(m => m.category === activeMaterialCategory)`
+5. The "Upload Material" button and `UploadMaterialModal` remain exactly as they are — do NOT move them out of MaterialsSection in this task (ProductLibrary.tsx will surface the button contextually in Task 3).
+6. Apply `font-sans text-sm` to tab triggers. Use `rounded-smooth-md` on the `TabsList`. Semantic tokens only (`bg-muted`, `text-foreground`, `text-muted-foreground`).
+  </action>
+  <verify>
+    <automated>grep -n "activeMaterialCategory\|MATERIAL_CATEGORIES\|All" /Users/micahbank/room-cad-renderer/src/components/MaterialsSection.tsx | head -20</automated>
+  </verify>
+  <done>
+    - MaterialsSection renders 5 sub-tab triggers (All + 4 categories)
+    - Selecting a category tab filters the MaterialCard grid
+    - "All" shows every material regardless of category
+    - UploadMaterialModal open/close still works
+  </done>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 3: Refactor ProductLibrary into 3-tab shell</name>
+  <files>src/components/ProductLibrary.tsx</files>
+  <action>
+Full in-place refactor of `ProductLibrary.tsx`. Props signature is UNCHANGED.
+
+**State to add:**
+```typescript
+const [activeLibraryTab, setActiveLibraryTab] = useState<
+  "materials" | "products" | "assemblies"
+>("materials");
+```
+
+**New layout structure (top to bottom):**
+
+1. **Top-level tab toggle** — a `<Tabs>` component with three `<TabsTrigger>` values: `"materials"`, `"products"`, `"assemblies"`. Labels: "Materials", "Products", "Assemblies". Use `font-sans text-sm font-medium`. Apply `rounded-smooth-md` on `TabsList`. This replaces the old "PRODUCT REGISTRY" header.
+
+2. **Conditional content** (render exactly one panel based on `activeLibraryTab`):
+
+   **materials panel** (`activeLibraryTab === "materials"`):
+   - Render `<MaterialsSection />` (already has its own upload button and category sub-tabs after Task 2).
+   - Do NOT render a separate "Upload Material" button here — MaterialsSection owns it.
+
+   **products panel** (`activeLibraryTab === "products"`):
+   - Keep the existing search `<Input>` and existing product category `<Tabs>` (the current category tabs already in ProductLibrary).
+   - Add an "Uncategorized" tab: products whose `category` is not in `PRODUCT_CATEGORIES` land here. Products with no category at all also land here.
+   - Keep the existing `<LibraryCard>` product grid.
+   - Render the "Add Product" button (calls `onOpenAddModal`) in this panel's header area — same styling as the old button.
+
+   **assemblies panel** (`activeLibraryTab === "assemblies"`):
+   - Render an empty-state block:
+     ```tsx
+     <div className="flex flex-col items-center justify-center py-12 gap-3 text-muted-foreground">
+       <Layers className="w-8 h-8 opacity-40" />
+       <p className="font-sans text-sm text-center leading-snug">
+         Coming soon — pre-built combos like<br />kitchen cabinetry and bathroom sets
+       </p>
+     </div>
+     ```
+   - Import `Layers` from `lucide-react` (D-A5).
+
+3. **Remove** the old "Phase 67" `<MaterialsSection />` that was rendered unconditionally above the products grid. It is now only rendered inside the materials panel.
+
+4. **Remove** the old divider between MaterialsSection and products grid.
+
+**Constraints:**
+- `onOpenAddModal` prop must still call the Add Product modal — do NOT wire it to anything in the materials flow.
+- `onAdd` / `onRemove` props pass through to the products panel unchanged.
+- GLTF place flow (`setPendingProduct`, `setTool("product")`) lives in LibraryCard — do not touch it.
+- Semantic tokens only. No `bg-obsidian-*` or raw hex values.
+  </action>
+  <verify>
+    <automated>grep -n "activeLibraryTab\|assemblies\|Coming soon\|Layers" /Users/micahbank/room-cad-renderer/src/components/ProductLibrary.tsx | head -20</automated>
+  </verify>
+  <done>
+    - ProductLibrary renders a 3-trigger tab toggle at the top
+    - Switching to Materials shows MaterialsSection with category sub-tabs
+    - Switching to Products shows search + category tabs + product grid + "Add Product" button
+    - Switching to Assemblies shows the placeholder with Layers icon
+    - Props interface (products, onAdd, onRemove, onOpenAddModal) unchanged
+    - No TypeScript errors (`npm run build` exits 0)
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+After all tasks complete, run these checks:
+
+```bash
+# TypeScript build — must exit 0
+cd /Users/micahbank/room-cad-renderer && npm run build 2>&1 | tail -20
+
+# MATERIAL_CATEGORIES exported
+grep -n "export.*MATERIAL_CATEGORIES" src/types/material.ts
+
+# 3-tab toggle present
+grep -n "activeLibraryTab\|assemblies\|Coming soon" src/components/ProductLibrary.tsx | head -10
+
+# Category sub-tabs in MaterialsSection
+grep -n "activeMaterialCategory" src/components/MaterialsSection.tsx | head -5
+
+# Props signature unchanged (onOpenAddModal must still exist)
+grep -n "onOpenAddModal" src/components/ProductLibrary.tsx
+
+# No material-symbols imports introduced (D-A5)
+grep -rn "material-symbols" src/components/ProductLibrary.tsx src/components/MaterialsSection.tsx
+```
+</verification>
+
+<success_criteria>
+- `npm run build` exits 0 with no TypeScript errors
+- Sidebar library top area shows "Materials / Products / Assemblies" tabs
+- Clicking Materials → MaterialsSection visible with "All / Flooring / Wall coverings / Countertops / Paint" sub-tabs
+- Clicking Products → existing product grid visible with "Add Product" button; Materials panel hidden
+- Clicking Assemblies → placeholder text with Layers icon; no JS errors in console
+- UploadMaterialModal category dropdown appears and saves `category` field on Material
+- `onOpenAddModal` prop still opens the Add Product dialog (verified by clicking "Add Product" in Products tab)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/70-library-rebuild-lib-rebuild-01-v1-19-active/70-01-SUMMARY.md`
+</output>

--- a/.planning/phases/70-library-rebuild-lib-rebuild-01-v1-19-active/70-01-SUMMARY.md
+++ b/.planning/phases/70-library-rebuild-lib-rebuild-01-v1-19-active/70-01-SUMMARY.md
@@ -1,0 +1,100 @@
+---
+phase: 70-library-rebuild-lib-rebuild-01-v1-19-active
+plan: "01"
+subsystem: library-ui
+tags: [library, materials, products, assemblies, tabs, ui]
+dependency_graph:
+  requires: [Phase 67 materialStore, Phase 68 UploadMaterialModal, Phase 72 Tabs primitive]
+  provides: [3-tab library shell, Material.category field, MATERIAL_CATEGORIES constant, category sub-tabs in MaterialsSection]
+  affects: [ProductLibrary, MaterialsSection, UploadMaterialModal, materialStore, useMaterials]
+tech_stack:
+  added: []
+  patterns: [Tabs primitive for 3-level navigation, category filter state in component, Rule 1 test fixes]
+key_files:
+  created: []
+  modified:
+    - src/types/material.ts
+    - src/lib/materialStore.ts
+    - src/hooks/useMaterials.ts
+    - src/components/UploadMaterialModal.tsx
+    - src/components/MaterialsSection.tsx
+    - src/components/ProductLibrary.tsx
+    - tests/components/ProductLibrary.gltf.test.tsx
+    - tests/phase33/phase33LibraryMigration.test.tsx
+decisions:
+  - "Default tab is Materials (not Products) — puts the newest feature front and center"
+  - "MaterialsSection owns its upload button; ProductLibrary does not duplicate it"
+  - "Uncategorized tab added to Products tab to handle products without a PRODUCT_CATEGORIES match"
+  - "SaveMaterialInput.category flows through materialStore to persist in IDB"
+metrics:
+  duration: "~25 minutes"
+  completed: "2026-05-08"
+  tasks_completed: 3
+  files_modified: 8
+---
+
+# Phase 70 Plan 01: Library 3-Tab Rebuild Summary
+
+**One-liner:** 3-way Materials/Products/Assemblies Tabs toggle replacing the single-panel PRODUCT REGISTRY, with MATERIAL_CATEGORIES sub-tab filtering and category persistence in UploadMaterialModal.
+
+## What Was Built
+
+The sidebar library now has a top-level 3-tab toggle: **Materials**, **Products**, **Assemblies**.
+
+- **Materials tab** (default): renders `MaterialsSection` with its own 5 sub-tab row (All + Flooring, Wall coverings, Countertops, Paint). Clicking a category tab filters the `MaterialCard` grid. The Upload Material button and `UploadMaterialModal` remain owned by `MaterialsSection`.
+- **Products tab**: search input + existing category `Tabs` (with a new Uncategorized tab for products outside `PRODUCT_CATEGORIES`) + `LibraryCard` product grid + Add Product button. All existing `onAdd`/`onRemove`/`onOpenAddModal` props unchanged. GLTF place flow (`setPendingProduct` + `setTool("product")`) preserved.
+- **Assemblies tab**: readable placeholder with `Layers` (lucide-react) icon and coming-soon copy. No errors, no blank state.
+
+**Data model additions:**
+- `Material.category?: string` added to the interface
+- `MATERIAL_CATEGORIES` constant + `MaterialCategory` type exported from `src/types/material.ts`
+- `SaveMaterialInput.category?` added to materialStore; written to IDB in `saveMaterialWithDedup`
+- `updateMaterialMetadata` and `useMaterials.update()` type extended to include `category`
+- `UploadMaterialModal` renders a `<select>` for category (optional, between Name and Tile Size)
+
+## Commits
+
+| Hash | Description |
+|------|-------------|
+| `69e2d1a` | feat(70-01): add Material.category field and MATERIAL_CATEGORIES constant |
+| `5f27345` | feat(70-01): add category sub-tab filtering to MaterialsSection |
+| `1bb2b0c` | feat(70-01): refactor ProductLibrary into 3-tab Materials/Products/Assemblies shell |
+| `a7d5ae2` | fix(70-01): update ProductLibrary tests to navigate to Products tab first |
+
+## Verification
+
+- `npm run build` exits 0 — no TypeScript errors
+- Test suite: 2 pre-existing failures only (SaveIndicator, SidebarProductPicker); all other 944 tests pass
+- PR: https://github.com/micahbank2/room-cad-renderer/pull/167 (Closes #24)
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 2 - Missing field] Add category to materialStore write path**
+- **Found during:** Task 1
+- **Issue:** `SaveMaterialInput` and `updateMaterialMetadata` did not include a `category` field — passing `category` from the modal would have caused a TypeScript error and the field would not be persisted.
+- **Fix:** Added `category?` to `SaveMaterialInput`, included it in the `Material` record created by `saveMaterialWithDedup`, and added it to the `Pick<>` type in both `updateMaterialMetadata` and `useMaterials.update()`.
+- **Files modified:** `src/lib/materialStore.ts`, `src/hooks/useMaterials.ts`
+- **Commit:** `69e2d1a`
+
+**2. [Rule 1 - Bug] ProductLibrary tests broke when default tab changed to Materials**
+- **Found during:** Task 3 (post-build test run)
+- **Issue:** 7 tests rendered `ProductLibrary` and queried `[data-testid="library-card"]` directly. With the default tab now "materials", the products panel is not mounted, so no cards are found.
+- **Fix:** Added `fireEvent.click(screen.getByRole("tab", { name: "Products" }))` before each card query in `ProductLibrary.gltf.test.tsx` (6 tests) and `phase33LibraryMigration.test.tsx` (1 test).
+- **Files modified:** `tests/components/ProductLibrary.gltf.test.tsx`, `tests/phase33/phase33LibraryMigration.test.tsx`
+- **Commit:** `a7d5ae2`
+
+## Known Stubs
+
+None — the Assemblies tab placeholder is intentional per the plan ("Assemblies tab shows a readable placeholder — not empty, not broken") and is not blocking the plan's goal.
+
+## Self-Check: PASSED
+
+- `src/types/material.ts` — FOUND (MATERIAL_CATEGORIES exported)
+- `src/components/ProductLibrary.tsx` — FOUND (activeLibraryTab, assemblies, Coming soon, Layers)
+- `src/components/MaterialsSection.tsx` — FOUND (activeMaterialCategory)
+- `src/components/UploadMaterialModal.tsx` — FOUND (category state + select)
+- Commits `69e2d1a`, `5f27345`, `1bb2b0c`, `a7d5ae2` — all present in git log
+- `npm run build` — exits 0
+- Test suite — 2 pre-existing failures only

--- a/src/components/MaterialsSection.tsx
+++ b/src/components/MaterialsSection.tsx
@@ -10,6 +10,7 @@
  * Surface:
  *   - Heading row: chevron (open/close) + "MATERIALS" + count badge +
  *     "+ UPLOAD_MATERIAL" CTA on the right.
+ *   - Phase 70: category sub-tabs (All + 4 categories) above the MaterialCard grid.
  *   - Body: grid of MaterialCard. Empty state copy when none exist.
  *   - Hosts UploadMaterialModal in create + edit modes via internal state.
  *
@@ -24,13 +25,20 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import { useMaterials } from "@/hooks/useMaterials";
 import { MaterialCard } from "./MaterialCard";
 import { UploadMaterialModal } from "./UploadMaterialModal";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui";
 import type { Material } from "@/types/material";
+import { MATERIAL_CATEGORIES } from "@/types/material";
+import type { MaterialCategory } from "@/types/material";
+
+type ActiveTab = "All" | MaterialCategory;
 
 export function MaterialsSection(): JSX.Element {
   const { materials } = useMaterials();
   const [expanded, setExpanded] = useState(true);
   const [uploadOpen, setUploadOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<Material | null>(null);
+  const [activeMaterialCategory, setActiveMaterialCategory] =
+    useState<ActiveTab>("All");
 
   const handleMore = (mat: Material) => {
     // Phase 67: ⋮ click directly opens edit modal. Phase 70 will introduce
@@ -39,6 +47,11 @@ export function MaterialsSection(): JSX.Element {
     // a delete-dialog primitive this phase.
     setEditTarget(mat);
   };
+
+  const filteredMaterials =
+    activeMaterialCategory === "All"
+      ? materials
+      : materials.filter((m) => m.category === activeMaterialCategory);
 
   return (
     <div className="flex flex-col gap-2 px-6 pb-2">
@@ -74,13 +87,32 @@ export function MaterialsSection(): JSX.Element {
       {/* Body */}
       {expanded && (
         <div className="flex flex-col gap-2">
-          {materials.length === 0 ? (
-            <p className="font-body text-sm text-muted-foreground px-2 py-4">
-              No materials yet — upload one to get started.
+          {/* Category sub-tabs (All + 4 MATERIAL_CATEGORIES) */}
+          <Tabs
+            value={activeMaterialCategory}
+            onValueChange={(v) => setActiveMaterialCategory(v as ActiveTab)}
+          >
+            <TabsList className="rounded-smooth-md flex-wrap gap-1">
+              <TabsTrigger value="All" className="font-sans text-sm">
+                All
+              </TabsTrigger>
+              {MATERIAL_CATEGORIES.map((cat) => (
+                <TabsTrigger key={cat} value={cat} className="font-sans text-sm">
+                  {cat}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+
+          {filteredMaterials.length === 0 ? (
+            <p className="font-sans text-sm text-muted-foreground px-2 py-4">
+              {materials.length === 0
+                ? "No materials yet — upload one to get started."
+                : "No materials in this category."}
             </p>
           ) : (
             <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {materials.map((mat) => (
+              {filteredMaterials.map((mat) => (
                 <MaterialCard
                   key={mat.id}
                   material={mat}

--- a/src/components/ProductLibrary.tsx
+++ b/src/components/ProductLibrary.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box, Package } from "lucide-react";
+import { Box, Layers, Package } from "lucide-react";
 import type { Product } from "@/types/product";
 import { PRODUCT_CATEGORIES } from "@/types/product";
 import { useUIStore } from "@/stores/uiStore";
@@ -22,6 +22,12 @@ export function ProductLibrary({
   onRemove,
   onOpenAddModal,
 }: Props) {
+  // Top-level 3-tab toggle state
+  const [activeLibraryTab, setActiveLibraryTab] = useState<
+    "materials" | "products" | "assemblies"
+  >("materials");
+
+  // Products tab state
   const [activeCategory, setActiveCategory] = useState("all");
   const [search, setSearch] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -47,14 +53,26 @@ export function ProductLibrary({
     return undefined;
   }
 
+  // Products in PRODUCT_CATEGORIES filter directly; rest land in "Uncategorized"
+  const KNOWN_CATEGORIES_LOWER = new Set(
+    PRODUCT_CATEGORIES.map((c) => c.toLowerCase()),
+  );
+
   const filtered = products.filter((p) => {
+    const catLower = p.category?.toLowerCase() ?? "";
     const matchesCategory =
       activeCategory === "all" ||
-      p.category.toLowerCase() === activeCategory.toLowerCase();
+      (activeCategory === "uncategorized" && !KNOWN_CATEGORIES_LOWER.has(catLower)) ||
+      catLower === activeCategory.toLowerCase();
     const matchesSearch =
       !search || p.name.toLowerCase().includes(search.toLowerCase());
     return matchesCategory && matchesSearch;
   });
+
+  // Count uncategorized products
+  const uncategorizedCount = products.filter(
+    (p) => !KNOWN_CATEGORIES_LOWER.has(p.category?.toLowerCase() ?? ""),
+  ).length;
 
   const tabList: CategoryTab[] = [
     { id: "all", label: "All", count: products.length },
@@ -62,9 +80,10 @@ export function ProductLibrary({
       id: cat.toLowerCase(),
       label: cat,
       count: products.filter(
-        (p) => p.category.toLowerCase() === cat.toLowerCase(),
+        (p) => p.category?.toLowerCase() === cat.toLowerCase(),
       ).length,
     })),
+    { id: "uncategorized", label: "Uncategorized", count: uncategorizedCount },
   ];
 
   function handlePlace(productId: string) {
@@ -75,100 +94,138 @@ export function ProductLibrary({
 
   return (
     <div className="flex-1 flex flex-col h-full overflow-hidden">
-      {/* Header */}
-      <div className="p-6 pb-4 shrink-0">
-        <div className="flex items-start justify-between mb-1">
-          <div>
-            <span className="font-sans text-[10px] text-muted-foreground/60 tracking-widest block mb-1">
-              YOUR LIBRARY
-            </span>
-            <h1 className="font-sans font-bold text-2xl text-foreground tracking-tight">
-              PRODUCT REGISTRY
-            </h1>
-          </div>
-          <button
-            onClick={onOpenAddModal}
-            className="font-sans text-[10px] tracking-widest px-4 py-2 bg-primary text-primary-foreground rounded-smooth-md hover:opacity-90 active:scale-95 transition-all shadow-[0_0_15px_rgba(124,91,240,0.2)]"
-          >
-            + ADD PRODUCT
-          </button>
-        </div>
-        <span className="font-sans text-sm text-foreground">
-          {filtered.length} ITEMS
-        </span>
-      </div>
-
-      {/* Phase 67 — Materials section (collapsible) above the products grid.
-          Phase 70 will lift this into a top-level Materials/Assemblies/Products
-          toggle; for now it's a sub-section of ProductLibrary per D-06. */}
-      <MaterialsSection />
-      <div className="border-t border-border/50 my-2 mx-6" />
-
-      {/* Filters */}
-      <div className="px-6 pb-3 shrink-0 space-y-3">
-        <Input
-          type="text"
-          placeholder="SEARCH ASSETS..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-64"
-        />
-        <Tabs value={activeCategory} onValueChange={setActiveCategory}>
-          <TabsList className="flex-wrap gap-1">
-            {tabList.map((tab) => (
-              <TabsTrigger key={tab.id} value={tab.id}>
-                {tab.label}
-                {tab.count > 0 && (
-                  <span className="ml-1 font-mono text-[9px] text-muted-foreground/60">
-                    {tab.count}
-                  </span>
-                )}
-              </TabsTrigger>
-            ))}
+      {/* Top-level 3-way tab toggle (replaces the old PRODUCT REGISTRY header) */}
+      <div className="px-6 pt-6 pb-3 shrink-0">
+        <Tabs
+          value={activeLibraryTab}
+          onValueChange={(v) =>
+            setActiveLibraryTab(v as "materials" | "products" | "assemblies")
+          }
+        >
+          <TabsList className="rounded-smooth-md w-full">
+            <TabsTrigger
+              value="materials"
+              className="font-sans text-sm font-medium flex-1"
+            >
+              Materials
+            </TabsTrigger>
+            <TabsTrigger
+              value="products"
+              className="font-sans text-sm font-medium flex-1"
+            >
+              Products
+            </TabsTrigger>
+            <TabsTrigger
+              value="assemblies"
+              className="font-sans text-sm font-medium flex-1"
+            >
+              Assemblies
+            </TabsTrigger>
           </TabsList>
         </Tabs>
       </div>
 
-      {/* Product Grid */}
-      <div className="flex-1 overflow-y-auto px-6 pb-6">
-        {filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full">
-            <Package size={36} className="text-muted-foreground/60 mb-3" /> {/* D-15: substitute for material-symbols 'inventory_2' */}
-            <span className="font-sans text-[10px] text-muted-foreground/60 tracking-widest">
-              NO ITEMS FOUND
-            </span>
-            <button
-              onClick={onOpenAddModal}
-              className="mt-3 font-sans text-[10px] tracking-widest px-4 py-1.5 text-foreground border border-ring rounded-smooth-md hover:bg-accent/10 transition-colors"
-            >
-              + ADD PRODUCT
-            </button>
+      {/* Materials panel */}
+      {activeLibraryTab === "materials" && (
+        <div className="flex-1 overflow-y-auto">
+          {/* MaterialsSection owns its upload button and category sub-tabs */}
+          <MaterialsSection />
+        </div>
+      )}
+
+      {/* Products panel */}
+      {activeLibraryTab === "products" && (
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {/* Products header with Add Product button */}
+          <div className="px-6 pb-3 shrink-0">
+            <div className="flex items-center justify-between mb-3">
+              <span className="font-sans text-sm text-foreground">
+                {filtered.length} items
+              </span>
+              <button
+                onClick={onOpenAddModal}
+                className="font-sans text-[10px] tracking-widest px-4 py-2 bg-primary text-primary-foreground rounded-smooth-md hover:opacity-90 active:scale-95 transition-all shadow-[0_0_15px_rgba(124,91,240,0.2)]"
+              >
+                + ADD PRODUCT
+              </button>
+            </div>
+            <Input
+              type="text"
+              placeholder="SEARCH ASSETS..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full mb-3"
+            />
+            <Tabs value={activeCategory} onValueChange={setActiveCategory}>
+              <TabsList className="flex-wrap gap-1">
+                {tabList.map((tab) => (
+                  <TabsTrigger key={tab.id} value={tab.id}>
+                    {tab.label}
+                    {tab.count > 0 && (
+                      <span className="ml-1 font-mono text-[9px] text-muted-foreground/60">
+                        {tab.count}
+                      </span>
+                    )}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
           </div>
-        ) : (
-          <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-            {filtered.map((p) => (
-              <LibraryCard
-                key={p.id}
-                thumbnail={resolveThumbnail(p)}
-                label={p.name}
-                selected={selectedId === p.id}
-                onClick={() => handlePlace(p.id)}
-                onRemove={() => onRemove(p.id)}
-                variant="grid"
-                badge={
-                  p.gltfId ? (
-                    <Box
-                      size={12}
-                      className="text-muted-foreground/80"
-                      data-testid="gltf-badge"
-                    />
-                  ) : undefined
-                }
-              />
-            ))}
+
+          {/* Product Grid */}
+          <div className="flex-1 overflow-y-auto px-6 pb-6">
+            {filtered.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full">
+                <Package size={36} className="text-muted-foreground/60 mb-3" /> {/* D-15: substitute for material-symbols 'inventory_2' */}
+                <span className="font-sans text-[10px] text-muted-foreground/60 tracking-widest">
+                  NO ITEMS FOUND
+                </span>
+                <button
+                  onClick={onOpenAddModal}
+                  className="mt-3 font-sans text-[10px] tracking-widest px-4 py-1.5 text-foreground border border-ring rounded-smooth-md hover:bg-accent/10 transition-colors"
+                >
+                  + ADD PRODUCT
+                </button>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                {filtered.map((p) => (
+                  <LibraryCard
+                    key={p.id}
+                    thumbnail={resolveThumbnail(p)}
+                    label={p.name}
+                    selected={selectedId === p.id}
+                    onClick={() => handlePlace(p.id)}
+                    onRemove={() => onRemove(p.id)}
+                    variant="grid"
+                    badge={
+                      p.gltfId ? (
+                        <Box
+                          size={12}
+                          className="text-muted-foreground/80"
+                          data-testid="gltf-badge"
+                        />
+                      ) : undefined
+                    }
+                  />
+                ))}
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </div>
+      )}
+
+      {/* Assemblies panel — placeholder */}
+      {activeLibraryTab === "assemblies" && (
+        <div className="flex-1 overflow-y-auto px-6">
+          <div className="flex flex-col items-center justify-center py-12 gap-3 text-muted-foreground">
+            <Layers className="w-8 h-8 opacity-40" />
+            <p className="font-sans text-sm text-center leading-snug">
+              Coming soon — pre-built combos like<br />kitchen cabinetry and bathroom sets
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/UploadMaterialModal.tsx
+++ b/src/components/UploadMaterialModal.tsx
@@ -34,6 +34,7 @@ import {
   ProcessTextureError,
 } from "@/lib/processTextureFile";
 import type { Material } from "@/types/material";
+import { MATERIAL_CATEGORIES } from "@/types/material";
 
 // ---- Locked copy (UI-SPEC §1 Material Copywriting Contract — D-07/D-08/D-39) --
 const COPY = {
@@ -114,6 +115,7 @@ export function UploadMaterialModal(
   const [sku, setSku] = useState(() => existing?.sku ?? "");
   const [cost, setCost] = useState(() => existing?.cost ?? "");
   const [leadTime, setLeadTime] = useState(() => existing?.leadTime ?? "");
+  const [category, setCategory] = useState(() => existing?.category ?? "");
 
   const [colorMap, setColorMap] = useState<ProcessedMap | null>(null);
   const [roughnessMap, setRoughnessMap] = useState<ProcessedMap | null>(null);
@@ -140,6 +142,7 @@ export function UploadMaterialModal(
     setSku(existing?.sku ?? "");
     setCost(existing?.cost ?? "");
     setLeadTime(existing?.leadTime ?? "");
+    setCategory(existing?.category ?? "");
     setNameError(null);
     setTileSizeError(null);
     setColorError(null);
@@ -286,6 +289,7 @@ export function UploadMaterialModal(
           sku: sku.trim() || undefined,
           cost: cost.trim() || undefined,
           leadTime: leadTime.trim() || undefined,
+          category: category.trim() || undefined,
           colorFile: colorMap.file,
           roughnessFile: roughnessMap?.file,
           reflectionFile: reflectionMap?.file,
@@ -307,6 +311,7 @@ export function UploadMaterialModal(
           sku: sku.trim() || undefined,
           cost: cost.trim() || undefined,
           leadTime: leadTime.trim() || undefined,
+          category: category.trim() || undefined,
         });
         toastSuccess(COPY.toastSaved);
         onSaved?.(existing.id);
@@ -326,6 +331,7 @@ export function UploadMaterialModal(
     sku,
     cost,
     leadTime,
+    category,
     save,
     update,
     onSaved,
@@ -430,6 +436,32 @@ export function UploadMaterialModal(
             {nameError && (
               <p className="font-sans text-sm text-error">{nameError}</p>
             )}
+          </div>
+
+          {/* CATEGORY (optional) */}
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="mat-category"
+              className="font-sans text-sm font-medium uppercase tracking-wide text-muted-foreground/80"
+            >
+              CATEGORY
+              <span className="ml-2 font-sans text-sm text-muted-foreground/60 tracking-widest normal-case">
+                optional
+              </span>
+            </label>
+            <select
+              id="mat-category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="bg-card border border-border/50 rounded-smooth-md px-2 py-1 text-sm font-sans text-foreground w-full"
+            >
+              <option value="">No category</option>
+              {MATERIAL_CATEGORIES.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat}
+                </option>
+              ))}
+            </select>
           </div>
 
           {/* TILE_SIZE */}

--- a/src/hooks/useMaterials.ts
+++ b/src/hooks/useMaterials.ts
@@ -40,7 +40,7 @@ export interface UseMaterialsResult {
   update: (
     id: string,
     changes: Partial<
-      Pick<Material, "name" | "tileSizeFt" | "brand" | "sku" | "cost" | "leadTime">
+      Pick<Material, "name" | "tileSizeFt" | "brand" | "sku" | "cost" | "leadTime" | "category">
     >,
   ) => Promise<void>;
   /** Hard-delete a Material entry. UserTexture refs are NOT cascade-deleted

--- a/src/lib/materialStore.ts
+++ b/src/lib/materialStore.ts
@@ -42,6 +42,8 @@ export interface SaveMaterialInput {
   sku?: string;
   cost?: string;
   leadTime?: string;
+  /** Phase 70: optional category for library sub-tab filtering. */
+  category?: string;
   colorFile: File;
   roughnessFile?: File;
   reflectionFile?: File;
@@ -112,6 +114,7 @@ export async function saveMaterialWithDedup(
     sku: input.sku?.trim() || undefined,
     cost: input.cost?.trim() || undefined,
     leadTime: input.leadTime?.trim() || undefined,
+    category: input.category?.trim() || undefined,
     createdAt: Date.now(),
   };
   await set(id, mat, materialIdbStore);
@@ -205,7 +208,7 @@ export async function deleteMaterial(id: string): Promise<void> {
 export async function updateMaterialMetadata(
   id: string,
   changes: Partial<
-    Pick<Material, "name" | "tileSizeFt" | "brand" | "sku" | "cost" | "leadTime">
+    Pick<Material, "name" | "tileSizeFt" | "brand" | "sku" | "cost" | "leadTime" | "category">
   >,
 ): Promise<void> {
   const existing = await getMaterial(id);

--- a/src/types/material.ts
+++ b/src/types/material.ts
@@ -89,4 +89,19 @@ export interface Material {
 
   /** Upload timestamp (Date.now()). Drives listMaterials sort order. */
   createdAt: number;
+
+  /**
+   * Phase 70 LIB-REBUILD-01 — optional category for library sub-tab filtering.
+   * Previously-saved Materials without a category appear under "All" only.
+   */
+  category?: string;
 }
+
+export const MATERIAL_CATEGORIES = [
+  "Flooring",
+  "Wall coverings",
+  "Countertops",
+  "Paint",
+] as const;
+
+export type MaterialCategory = (typeof MATERIAL_CATEGORIES)[number];

--- a/tests/components/ProductLibrary.gltf.test.tsx
+++ b/tests/components/ProductLibrary.gltf.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Product } from "@/types/product";
 
@@ -45,6 +45,12 @@ function makeProduct(overrides: Partial<Product> = {}): Product {
   };
 }
 
+/** Phase 70: ProductLibrary now defaults to the Materials tab.
+ *  Click the Products tab to make LibraryCards visible. */
+function switchToProductsTab() {
+  fireEvent.click(screen.getByRole("tab", { name: "Products" }));
+}
+
 beforeEach(() => {
   mockedGetCached.mockReset();
 });
@@ -63,6 +69,7 @@ describe("ProductLibrary × GLTF (Phase 58)", () => {
         onOpenAddModal={() => {}}
       />,
     );
+    switchToProductsTab();
     const card = screen.getByTestId("library-card");
     expect(within(card).getByTestId("library-card-badge")).toBeInTheDocument();
   });
@@ -76,6 +83,7 @@ describe("ProductLibrary × GLTF (Phase 58)", () => {
         onOpenAddModal={() => {}}
       />,
     );
+    switchToProductsTab();
     const card = screen.getByTestId("library-card");
     expect(
       within(card).queryByTestId("library-card-badge"),
@@ -96,6 +104,7 @@ describe("ProductLibrary × GLTF (Phase 58)", () => {
         onOpenAddModal={() => {}}
       />,
     );
+    switchToProductsTab();
     const card = screen.getByTestId("library-card");
     const img = card.querySelector("img");
     expect(img?.getAttribute("src")).toBe("data:image/png;base64,XXX");
@@ -112,6 +121,7 @@ describe("ProductLibrary × GLTF (Phase 58)", () => {
         onOpenAddModal={() => {}}
       />,
     );
+    switchToProductsTab();
     expect(mockedGetCached).toHaveBeenCalledWith(
       "gltf_abc",
       expect.any(Function),
@@ -130,6 +140,7 @@ describe("ProductLibrary × GLTF (Phase 58)", () => {
         onOpenAddModal={() => {}}
       />,
     );
+    switchToProductsTab();
     const card = screen.getByTestId("library-card");
     expect(card.querySelector("img")).toBeNull();
   });
@@ -144,6 +155,7 @@ describe("ProductLibrary × GLTF (Phase 58)", () => {
         onOpenAddModal={() => {}}
       />,
     );
+    switchToProductsTab();
     const card = screen.getByTestId("library-card");
     expect(card.querySelector("img")).toBeNull();
   });

--- a/tests/phase33/phase33LibraryMigration.test.tsx
+++ b/tests/phase33/phase33LibraryMigration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 import { ProductLibrary } from "@/components/ProductLibrary";
 import CustomElementsPanel from "@/components/CustomElementsPanel";
 import { useCADStore } from "@/stores/cadStore";
@@ -77,6 +77,8 @@ describe("Library migration — render count regression (GH #89 blocker fix)", (
         onOpenAddModal={() => {}}
       />,
     );
+    // Phase 70: ProductLibrary defaults to Materials tab — click Products to see cards.
+    fireEvent.click(screen.getByRole("tab", { name: "Products" }));
     const cards = container.querySelectorAll('[data-testid="library-card"]');
     // Default activeCategory is "all" → all 5 products rendered.
     expect(cards.length).toBe(SEED_PRODUCTS.length);


### PR DESCRIPTION
## Summary

- Reorganizes the sidebar library into a top-level 3-way tab toggle: **Materials**, **Products**, **Assemblies**
- Materials tab shows MaterialsSection with 5 sub-tabs (All + Flooring, Wall coverings, Countertops, Paint) — filters the material grid by category
- Products tab shows the existing search + category tabs + product grid + Add Product button; adds an Uncategorized tab for products outside PRODUCT_CATEGORIES
- Assemblies tab shows a readable placeholder with a Layers icon and coming-soon copy
- Adds `Material.category?: string` field + `MATERIAL_CATEGORIES` constant to `src/types/material.ts`
- Adds category selector to UploadMaterialModal (optional, between Name and Tile Size fields)
- All existing props unchanged (`products`, `onAdd`, `onRemove`, `onOpenAddModal`); GLTF place flow preserved

## Files Changed

- `src/types/material.ts` — `category?` field + `MATERIAL_CATEGORIES` + `MaterialCategory` type
- `src/lib/materialStore.ts` — `SaveMaterialInput.category?` + write-through to IDB record + `updateMaterialMetadata` picks up `category`
- `src/hooks/useMaterials.ts` — `update()` signature extended to include `category`
- `src/components/UploadMaterialModal.tsx` — category `<select>` in form body; persists on save/edit
- `src/components/MaterialsSection.tsx` — 5 sub-tab triggers (All + 4 categories); filters MaterialCard grid
- `src/components/ProductLibrary.tsx` — full 3-tab shell refactor; default tab is Materials
- `tests/components/ProductLibrary.gltf.test.tsx` — click Products tab before querying LibraryCards
- `tests/phase33/phase33LibraryMigration.test.tsx` — same tab navigation fix

## Test Results

- Build: `npm run build` exits 0, no TypeScript errors
- Tests: 2 pre-existing failures only (SaveIndicator, SidebarProductPicker) — all other 944 pass

Closes #24
Spec: .planning/phases/70-library-rebuild-lib-rebuild-01-v1-19-active/70-01-PLAN.md