### PR TITLE
Phase 80 audit cleanup: remove dead/duplicate sidebar + topbar sections

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,10 +1,5 @@
 import { PanelSection } from "@/components/ui";
 import type { Product } from "@/types/product";
-import {
-  useActiveRoom,
-  useActiveWalls,
-  useActivePlacedProducts,
-} from "@/stores/cadStore";
 import { useUIStore } from "@/stores/uiStore";
 import RoomSettings from "./RoomSettings";
 import SidebarProductPicker from "./SidebarProductPicker";
@@ -19,13 +14,6 @@ interface Props {
 
 
 export default function Sidebar({ productLibrary }: Props) {
-  const room = useActiveRoom() ?? { width: 20, length: 16, wallHeight: 8 };
-  const walls = useActiveWalls();
-  const placedProducts = useActivePlacedProducts();
-  const wallCount = Object.keys(walls).length;
-  const productCount = Object.keys(placedProducts).length;
-  const showGrid = useUIStore((s) => s.showGrid);
-  const toggleGrid = useUIStore((s) => s.toggleGrid);
   const gridSnap = useUIStore((s) => s.gridSnap);
   const setGridSnap = useUIStore((s) => s.setGridSnap);
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
@@ -51,39 +39,10 @@ export default function Sidebar({ productLibrary }: Props) {
           <RoomSettings />
         </PanelSection>
 
-        <PanelSection id="sidebar-system-stats" label="System stats" defaultOpen={false}>
-          <div className="space-y-1.5">
-            <div className="flex justify-between">
-              <span className="font-sans text-[10px] text-muted-foreground/80">Area</span>
-              <span className="font-sans text-[10px] text-foreground">
-                {(room.width * room.length).toFixed(0)} SQ FT
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="font-sans text-[10px] text-muted-foreground/80">Walls</span>
-              <span className="font-sans text-[10px] text-foreground">{wallCount}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="font-sans text-[10px] text-muted-foreground/80">Products</span>
-              <span className="font-sans text-[10px] text-foreground">{productCount}</span>
-            </div>
-          </div>
-        </PanelSection>
-
-        <PanelSection id="sidebar-layers" label="Layers" defaultOpen={false}>
-          <div className="space-y-1.5">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={showGrid}
-                onChange={toggleGrid}
-                className="w-3 h-3 accent-accent rounded-none"
-              />
-              <span className="font-sans text-[10px] text-muted-foreground/80">Grid</span>
-            </label>
-          </div>
-        </PanelSection>
-
+        {/* Phase 80 audit removals (dead code / duplicates):
+            - "System stats" panel — debug chrome with no audience
+            - "Layers" panel — single Show Grid checkbox already in FloatingToolbar
+            Snap stays here until Phase 83 wires it into the FloatingToolbar utility group. */}
 
         <PanelSection id="sidebar-snap" label="Snap" defaultOpen={false}>
           <select

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -16,11 +16,7 @@ import {
   Map as MapIcon,
   Box,
   CornerDownRight,
-  BookOpen,
   HelpCircle,
-  Settings,
-  Undo2,
-  Redo2,
   AlertCircle,
   Loader2,
   CloudCheck,
@@ -87,11 +83,7 @@ export function ToolbarSaveStatus(): JSX.Element {
   );
 }
 
-export function TopBar({ viewMode, onViewChange }: TopBarProps): JSX.Element {
-  const undo = useCADStore((s) => s.undo);
-  const redo = useCADStore((s) => s.redo);
-  const pastLen = useCADStore((s) => s.past.length);
-  const futureLen = useCADStore((s) => s.future.length);
+export function TopBar({ viewMode }: TopBarProps): JSX.Element {
   const cameraMode = useUIStore((s) => s.cameraMode);
   const activePreset = useUIStore((s) => s.activePreset);
   const requestPreset = useUIStore((s) => s.requestPreset);
@@ -133,42 +125,7 @@ export function TopBar({ viewMode, onViewChange }: TopBarProps): JSX.Element {
         {/* Save status */}
         <ToolbarSaveStatus />
 
-        <div className="w-px h-5 bg-border/50 mx-1" />
-
-        {/* Undo / Redo (D-11) */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              onClick={undo}
-              disabled={pastLen === 0}
-              aria-label="Undo"
-              variant="ghost"
-              size="icon-sm"
-            >
-              <Undo2 size={16} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            Undo <kbd>Ctrl+Z</kbd>
-          </TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              onClick={redo}
-              disabled={futureLen === 0}
-              aria-label="Redo"
-              variant="ghost"
-              size="icon-sm"
-            >
-              <Redo2 size={16} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            Redo <kbd>Ctrl+Shift+Z</kbd>
-          </TooltipContent>
-        </Tooltip>
+        {/* Phase 80 audit removal: Undo/Redo duplicated in FloatingToolbar — single canonical home. */}
 
         <div className="w-px h-5 bg-border/50 mx-1" />
 
@@ -231,24 +188,9 @@ export function TopBar({ viewMode, onViewChange }: TopBarProps): JSX.Element {
           <TooltipContent side="bottom">Export 3D view as PNG</TooltipContent>
         </Tooltip>
 
-        <div className="w-px h-5 bg-border/50 mx-1" />
+        {/* Phase 80 audit removal: Library button duplicated in FloatingToolbar view-mode group — single canonical home. */}
 
-        {/* Library button */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              onClick={() => onViewChange("library")}
-              variant="ghost"
-              size="icon-sm"
-              data-testid="view-mode-library"
-              aria-label="Product library"
-              active={viewMode === "library"}
-            >
-              <BookOpen size={16} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Product library</TooltipContent>
-        </Tooltip>
+        <div className="w-px h-5 bg-border/50 mx-1" />
 
         {/* Help */}
         <Tooltip>
@@ -266,10 +208,8 @@ export function TopBar({ viewMode, onViewChange }: TopBarProps): JSX.Element {
           <TooltipContent side="bottom">Help &amp; shortcuts</TooltipContent>
         </Tooltip>
 
-        {/* Settings */}
-        <Button variant="ghost" size="icon-sm" aria-label="Settings">
-          <Settings size={16} />
-        </Button>
+        {/* Phase 80 audit removal: Settings button had no onClick handler — dead.
+            Re-introduce when the theme/settings drawer ships (tracked in v1.21 backlog). */}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary

Acts on 4 of the 5 "Remove" decisions from the [v1.21 Phase 80 sidebar audit](.planning/milestones/v1.21-SIDEBAR-AUDIT.md). All surgical dead-code removals — no design decisions, no behavior changes for any working feature.

## Removed

| Surface | What | Why |
|---------|------|-----|
| Left sidebar | "System stats" panel (Area / Walls / Products counters) | Debug chrome, no audience |
| Left sidebar | "Layers" panel (one "Show Grid" checkbox) | Duplicate of FloatingToolbar grid button |
| TopBar | Undo / Redo icon buttons | Duplicate of FloatingToolbar Undo/Redo (canonical home) |
| TopBar | Library icon button | Duplicate of FloatingToolbar view-mode group (Library button restored in PR #168) |
| TopBar | Settings gear icon | Had no `onClick` handler — dead button. Re-introduce when theme/settings drawer ships. |

## Kept (with rationale)

| Audit said | We did | Why |
|------------|--------|-----|
| Snap panel → Move to FloatingToolbar | Kept in sidebar | Moving without surfacing in FloatingToolbar first would lose the snap control. Phase 83 (floating toolbar redesign) will do the move properly. |

## Test plan

- [x] 992 vitest tests pass (0 regressions vs main)
- [ ] Manual smoke: load app → no missing controls vs pre-merge baseline → Undo/Redo still work (via FloatingToolbar) → Library button still works (via FloatingToolbar) → Grid toggle still works (via FloatingToolbar)

Refs `.planning/milestones/v1.21-SIDEBAR-AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)