### PR TITLE
Phase 87: Theme toggle + Settings popover

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -447,6 +447,14 @@
 **Plans:** 3/3 plans complete
 **UI hint:** yes
 
+## Polish Phases
+
+Standalone phases that ship outside any v1.xx milestone — small, focused, one-off improvements.
+
+- 🚧 **Phase 87 — Theme Toggle + Settings Popover** (in progress) — branch `gsd/phase-87-theme-toggle`. Gear button in TopBar → popover with Light / Dark / System segmented control wired to existing `useTheme()` hook. Removes the three `.light` force-wrappers from WelcomeScreen / ProjectManager / HelpPage shipped in Phase 76. See [.planning/phases/87-theme-toggle-settings/87-CONTEXT.md](phases/87-theme-toggle-settings/87-CONTEXT.md).
+
+---
+
 ## Progress
 
 | Phase | Plans Complete | Status | Completed |
@@ -506,6 +514,7 @@
 | 84. Contextual Sidebar Visibility (IA-08) | 1/1 | Complete    | 2026-05-15 |
 | 85. Parametric Product Controls (PARAM-01) | 3/3 | Complete    | 2026-05-15 |
 | 86. Columns & Pillars (COL-01) | 3/3 | Complete    | 2026-05-15 |
+| 87. Theme Toggle + Settings Popover (polish) | 0/1 | In Progress | — |
 
 ## Backlog
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -514,7 +514,7 @@ Standalone phases that ship outside any v1.xx milestone — small, focused, one-
 | 84. Contextual Sidebar Visibility (IA-08) | 1/1 | Complete    | 2026-05-15 |
 | 85. Parametric Product Controls (PARAM-01) | 3/3 | Complete    | 2026-05-15 |
 | 86. Columns & Pillars (COL-01) | 3/3 | Complete    | 2026-05-15 |
-| 87. Theme Toggle + Settings Popover (polish) | 0/1 | In Progress | — |
+| 87. Theme Toggle + Settings Popover (polish) | 1/1 | Complete   | 2026-05-15 |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v1.19
 milestone_name: Material Linking & Library Rebuild
 status: completed
-stopped_at: Completed 86-03-PLAN.md (Wave 3 — ColumnInspector + Tree + Toolbar) — v1.20 milestone COMPLETE
-last_updated: "2026-05-15T15:15:20.198Z"
+stopped_at: Completed 87-01-PLAN.md — theme toggle + Settings popover shipped (standalone polish phase)
+last_updated: "2026-05-15T16:09:00.000Z"
 last_activity: 2026-05-15
 progress:
-  total_phases: 20
-  completed_phases: 13
-  total_plans: 48
-  completed_plans: 45
+  total_phases: 21
+  completed_phases: 14
+  total_plans: 49
+  completed_plans: 46
 ---
 
 # Project State
@@ -24,13 +24,13 @@ See: .planning/PROJECT.md (updated 2026-05-08 — v1.19 Material Linking & Libra
 
 ## Current Position
 
-Phase: 999.1
-Plan: Not started
-Milestone: v1.20 Surface Depth & Architectural Expansion — COMPLETE (Phases 78, 79, 80, 86 all shipped). Next milestone TBD.
-Phases: 81 complete; 82 complete; 83 complete; 84 complete; 85 complete; 86 complete (all 3 waves)
-Status: Phase 86 Plan 03 COMPLETE — ColumnInspector with Dimensions/Material/Rotation tabs + RightInspector dispatch + Columns group in Rooms tree (buildRoomTree + RoomsTreePanel + savedCameraSet + focusOnColumn) + FloatingToolbar Cuboid Column button. 1107 vitest passing (+12 new) + 4 e2e GREEN (2 placement + 2 lifecycle). Jessica can place / select / edit / rename / camera-save / focus / delete a column entirely through the visible UI. v1.20 milestone closed.
+Phase: 87 (standalone polish — no active milestone)
+Plan: Complete
+Milestone: v1.20 Surface Depth & Architectural Expansion — COMPLETE. Phase 87 ships as standalone polish phase per D-01.
+Phases: 81 complete; 82 complete; 83 complete; 84 complete; 85 complete; 86 complete; 87 complete (1 plan)
+Status: Phase 87 Plan 01 COMPLETE — Settings gear button + SettingsPopover (Light/Dark/System SegmentedControl) wired to useTheme(); removed .light force-wrappers from WelcomeScreen + ProjectManager + HelpPage (D-04). 6 unit tests + 3 e2e tests GREEN. 1113 vitest passing (+6 new). All 5 THEME requirements traced. Jessica can flip themes from the gear button; choice persists across reload; HelpPage/Welcome/ProjectManager now inherit the .dark cascade.
 Last activity: 2026-05-15
-Stopped at: Completed 86-03-PLAN.md (Wave 3 — ColumnInspector + Tree + Toolbar) — v1.20 milestone COMPLETE
+Stopped at: Completed 87-01-PLAN.md — theme toggle + Settings popover shipped (standalone polish phase)
 
 ## Decisions
 
@@ -68,6 +68,7 @@ Stopped at: Completed 86-03-PLAN.md (Wave 3 — ColumnInspector + Tree + Toolbar
 - [Phase 86]: Phase 86-02: Column hit-test inserted BEFORE wall in selectTool — D-01 Pitfall 4 (column wins when cursor in both); rotated AABB via cos/sin into local frame
 - [Phase 86]: Phase 86-02: Column drag uses Phase 31 transaction pattern (empty updateColumn at drag-start + moveColumnNoHistory mid-stroke); no fast-path (cheap redraw)
 - [Phase 86]: Phase 86-03: ColumnInspector with Dimensions/Material/Rotation tabs (D-08) mounts via RightInspector keyed on column.id; Reset-to-wall-height button (D-03) single-history-push verified by 12-case vitest suite; Columns group emitted in Rooms tree mirror of Phase 60 Stairs pattern; FloatingToolbar Cuboid Column button reads room.wallHeight at click time and bridges via setPendingColumn → setTool('column'); no C keyboard shortcut (collides with Ceiling — D-07 deferral)
+- [Phase 87]: Plan 87-01 (THEME-01..05): standalone polish phase. SettingsPopover component (~70 lines, src/components/SettingsPopover.tsx) extracted as its own file (vs research's inline-in-TopBar recommendation) to anticipate future settings rows. D-03 honored — popover stays open after segment click (deliberately different from Phase 83 Snap auto-close, because theme is a "try it" choice). D-04 — three .light force-wrappers removed (WelcomeScreen:55, ProjectManager:69, HelpPage:83); .light CSS class definition preserved as reserved utility. 6 unit + 3 e2e tests; 1113/1113 vitest passing.
 
 ## Performance Metrics
 
@@ -98,6 +99,7 @@ Stopped at: Completed 86-03-PLAN.md (Wave 3 — ColumnInspector + Tree + Toolbar
 | Phase 85 P03 | 6min | 3 tasks | 1 files |
 | Phase 86 P01 | ~18min | 4 tasks | 9 files |
 | Phase 86 P02 | 22 | 3 tasks | 11 files |
+| Phase 87 P01 | ~8min | 4 tasks | 7 files |
 
 ## v1.20 Roadmap
 
@@ -128,4 +130,4 @@ Stopped at: Completed 86-03-PLAN.md (Wave 3 — ColumnInspector + Tree + Toolbar
 
 ## Next Step
 
-v1.21 Sidebar IA & Contextual Surfaces milestone is COMPLETE. Open Phase 84 PR (closes #177) once branch lands. Next milestone candidates: continue v1.20 (Phases 78 P02-P04 remaining PBR maps, Phase 80 parametric controls) or move to v1.22 scope.
+Phase 87 (theme toggle + Settings popover) COMPLETE as standalone polish phase. Ready to open PR (closes the v1.21 / v1.22 theme-toggle backlog item, no GH issue tracks it directly per CONTEXT.md). Next milestone candidates: visual polish for dark mode on Welcome/Help/ProjectManager surfaces (if UAT surfaces contrast issues), or move to next v1.22 scope.

--- a/.planning/phases/87-theme-toggle-settings/87-01-PLAN.md
+++ b/.planning/phases/87-theme-toggle-settings/87-01-PLAN.md
@@ -1,0 +1,422 @@
+---
+phase: 87-theme-toggle-settings
+plan: 01
+plan_id: 87-01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/TopBar.tsx
+  - src/components/SettingsPopover.tsx
+  - src/components/WelcomeScreen.tsx
+  - src/components/ProjectManager.tsx
+  - src/components/HelpPage.tsx
+  - src/components/__tests__/SettingsPopover.test.tsx
+  - tests/e2e/specs/theme-toggle.spec.ts
+autonomous: true
+task_count: 4
+gap_closure: false
+requirements:
+  - THEME-01
+  - THEME-02
+  - THEME-03
+  - THEME-04
+  - THEME-05
+
+must_haves:
+  truths:
+    - "Jessica sees a gear icon button in the top bar's right slot, next to the Help button"
+    - "Clicking the gear opens a popover with a 'Theme' label and a 3-option segmented control: Light / Dark / System"
+    - "The active segment matches Jessica's stored theme choice on first paint"
+    - "Clicking Light removes the .dark class from <html>; clicking Dark adds it; clicking System defers to OS preference"
+    - "The popover stays open after selecting an option (closes only on outside click or Escape per D-03)"
+    - "Reloading the page preserves the chosen theme — first paint never flashes the wrong mode"
+    - "WelcomeScreen, ProjectManager, and HelpPage render in the user's chosen theme (no .light force-wrapper)"
+  artifacts:
+    - path: "src/components/SettingsPopover.tsx"
+      provides: "SettingsPopover component — Popover content with Theme section + SegmentedControl"
+      min_lines: 30
+    - path: "src/components/TopBar.tsx"
+      provides: "Gear button + Popover trigger wired to SettingsPopover"
+      contains: "data-testid=\"topbar-settings-button\""
+    - path: "src/components/__tests__/SettingsPopover.test.tsx"
+      provides: "Unit/integration coverage for THEME-01 / THEME-02 / THEME-03"
+      contains: "describe"
+    - path: "tests/e2e/specs/theme-toggle.spec.ts"
+      provides: "E2E coverage for THEME-03 (toggle + persist) and THEME-05 (no-flash reload)"
+      contains: "test"
+  key_links:
+    - from: "src/components/TopBar.tsx"
+      to: "src/components/SettingsPopover.tsx"
+      via: "import + render inside <Popover> trigger pair"
+      pattern: "SettingsPopover"
+    - from: "src/components/SettingsPopover.tsx"
+      to: "src/hooks/useTheme.ts"
+      via: "useTheme() destructure { theme, setTheme }"
+      pattern: "useTheme\\("
+    - from: "src/components/SettingsPopover.tsx"
+      to: "src/components/ui/SegmentedControl.tsx"
+      via: "import + render with options=[Light, Dark, System]"
+      pattern: "SegmentedControl"
+    - from: "src/components/WelcomeScreen.tsx"
+      to: ".dark / .light cascade on <html>"
+      via: "absence of 'light' className on root div"
+      pattern: "className=\"h-full flex flex-col bg-background\""
+---
+
+<objective>
+Add a Settings gear button + Theme popover to TopBar that lets Jessica flip the app between Light / Dark / System, and remove the three `.light` force-wrappers shipped in Phase 76 so her choice actually applies across every surface.
+
+Purpose: All theme infrastructure exists from Phase 71 (`useTheme`, boot bridge, test driver). The only missing piece is the UI affordance. Phase 76 force-locked WelcomeScreen / ProjectManager / HelpPage to light mode as a stopgap; this phase unlocks them.
+
+Output: One new component (`SettingsPopover.tsx`), one edited TopBar (re-introduces the gear button removed in Phase 80 audit), three one-line className changes, and full RED→GREEN test coverage including a Playwright e2e for theme persistence across reload.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@CLAUDE.md
+@.planning/phases/87-theme-toggle-settings/87-CONTEXT.md
+@.planning/phases/87-theme-toggle-settings/87-RESEARCH.md
+@src/hooks/useTheme.ts
+@src/components/ui/Popover.tsx
+@src/components/ui/SegmentedControl.tsx
+@src/components/TopBar.tsx
+@src/components/FloatingToolbar.tsx
+@src/components/WelcomeScreen.tsx
+@src/components/ProjectManager.tsx
+@src/components/HelpPage.tsx
+@src/test-utils/themeDrivers.ts
+
+<interfaces>
+<!-- Contracts Jessica's executor needs. Use directly — no codebase scavenger-hunt. -->
+
+From src/hooks/useTheme.ts:
+```typescript
+export type ThemeChoice = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+export function useTheme(): {
+  theme: ThemeChoice;
+  resolved: ResolvedTheme;
+  setTheme: (t: ThemeChoice) => void;
+};
+```
+
+From src/components/ui/SegmentedControl.tsx:
+```typescript
+export interface SegmentedControlOption {
+  value: string;
+  label: string;
+}
+export function SegmentedControl(props: {
+  value: string;
+  onValueChange: (v: string) => void;   // note: string, not ThemeChoice — cast at call site
+  options: SegmentedControlOption[];
+  className?: string;
+}): JSX.Element;
+```
+
+From src/components/ui/Popover.tsx:
+```typescript
+export const Popover: typeof PopoverPrimitive.Root;        // takes open / onOpenChange
+export const PopoverTrigger: typeof PopoverPrimitive.Trigger;  // asChild supported
+export function PopoverContent(props: {
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+  sideOffset?: number;
+  className?: string;
+}): JSX.Element;
+```
+
+From src/components/ui/Button.tsx (already imported in TopBar):
+```typescript
+// variant="ghost" + size="icon-sm" matches the existing Help button styling
+```
+
+Phase 83 popover precedent (FloatingToolbar.tsx lines 447–499 — Snap popover):
+```tsx
+<Popover open={open} onOpenChange={setOpen}>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon-sm" aria-label="..." data-testid="...">
+          <Icon size={16} />
+        </Button>
+      </PopoverTrigger>
+    </TooltipTrigger>
+    <TooltipContent side="bottom">...</TooltipContent>
+  </Tooltip>
+  <PopoverContent side="bottom" align="end" sideOffset={6} className="w-64">
+    {/* body */}
+  </PopoverContent>
+</Popover>
+```
+
+Phase 87 deviates from Snap precedent in ONE place: do NOT call `setOpen(false)` inside the segmented-control onValueChange. Theme popover stays open per D-03.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: RED — failing unit + e2e tests for Settings popover + theme toggle</name>
+  <files>
+    src/components/__tests__/SettingsPopover.test.tsx,
+    tests/e2e/specs/theme-toggle.spec.ts
+  </files>
+  <behavior>
+    Unit (`src/components/__tests__/SettingsPopover.test.tsx`):
+    - Test 1: Mounts `<TopBar viewMode="2d" onViewChange={() => {}} />`. Asserts a button with `data-testid="topbar-settings-button"` exists.
+    - Test 2: Clicking the gear button reveals a popover containing the text "Theme" and three radio buttons labeled "Light", "Dark", "System". (Use `userEvent.click` on the gear, then query within `screen` for the popover by role="dialog" or by `data-testid="settings-popover"`.)
+    - Test 3: On mount with `localStorage["room-cad-theme"] === "dark"`, the "Dark" segment has `aria-checked="true"` and the others do not.
+    - Test 4: Clicking the "Light" radio toggles `document.documentElement.classList` — `dark` class removed. Clicking "Dark" — `dark` class added. Clicking "System" — class follows the mocked `matchMedia("(prefers-color-scheme: dark)")` value.
+    - Test 5 (D-03): After clicking any radio option, the popover remains open (the "Theme" label is still in the DOM).
+
+    E2E (`tests/e2e/specs/theme-toggle.spec.ts`):
+    - Test 1: Load app → click `[data-testid="topbar-settings-button"]` → click button with text "Dark" → assert `<html>` has class `dark`.
+    - Test 2: Reload page → assert `<html>` still has class `dark` on first paint (boot bridge persistence). Then click gear → click "Light" → assert `<html>` no longer has `dark` class. Reload → assert `<html>` does NOT have `dark` class.
+    - Test 3 (THEME-04 visual smoke): Click "Dark" → navigate to Help (open via existing Help button) → screenshot the page (no `toHaveScreenshot` golden — just `expect(page.locator('html')).toHaveClass(/dark/)` to assert HelpPage actually inherits the dark token cascade; no `.light` wrapper stopping it). Then return to editor and same check for project manager/welcome surface as reachable.
+
+    All tests MUST fail on this commit (no gear button, no SettingsPopover component, `.light` wrappers still in place).
+  </behavior>
+  <action>
+    Create the two test files above. Reference the unit-test pattern from `src/components/__tests__/FloatingToolbar.test.tsx` (Snap popover precedent) for popover-open assertions, and `tests/e2e/specs/window-preset.spec.ts` (Phase 79) for Playwright structure.
+
+    For the unit test, mock `window.matchMedia` in `beforeEach` to return `{ matches: false, addEventListener: () => {}, removeEventListener: () => {} }` so System mode is deterministic. Clear `localStorage` between tests.
+
+    For the e2e test, use Playwright's `page.evaluate(() => document.documentElement.classList.contains('dark'))` for class assertions. Use `await page.reload()` between persistence checks. Run against `chromium-dev` project only — no need for cross-browser at this phase.
+
+    Do NOT create the SettingsPopover component or edit TopBar in this task — these tests must be RED. Commit with `test(87-01): add RED unit + e2e for theme settings popover`.
+
+    Reference D-02 (segmented control with Light / Dark / System), D-03 (popover stays open on selection), D-04 (wrappers removed), and THEME-01 through THEME-05 from 87-CONTEXT.md.
+  </action>
+  <verify>
+    <automated>npm run test -- --run src/components/__tests__/SettingsPopover.test.tsx 2>&1 | tail -30</automated>
+  </verify>
+  <done>
+    Both test files committed. `npm run test -- --run src/components/__tests__/SettingsPopover.test.tsx` reports failures (component does not exist / gear button not found). E2E spec exists and is picked up by `npx playwright test --list --grep "theme-toggle"`.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: GREEN — SettingsPopover component + TopBar gear button</name>
+  <files>
+    src/components/SettingsPopover.tsx,
+    src/components/TopBar.tsx
+  </files>
+  <behavior>
+    Test 1–5 from Task 1 must turn GREEN after this task. Specifically:
+    - Gear button with `data-testid="topbar-settings-button"`, `aria-label="Settings"`, lucide `Settings` icon at size 16, rendered as `<Button variant="ghost" size="icon-sm">` to match the adjacent Help button.
+    - Popover opens on gear click, closes on outside click / Escape (Radix defaults).
+    - Popover body contains a section header "Theme" (`font-sans text-xs font-medium text-muted-foreground`) and a SegmentedControl with options `[{value:"light",label:"Light"},{value:"dark",label:"Dark"},{value:"system",label:"System"}]`.
+    - `value={theme}` and `onValueChange={(v) => setTheme(v as ThemeChoice)}` — does NOT call `setOpen(false)` (per D-03).
+    - Popover container has `data-testid="settings-popover"` for e2e querying.
+  </behavior>
+  <action>
+    Create `src/components/SettingsPopover.tsx`:
+
+    ```tsx
+    import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/Popover";
+    import { SegmentedControl } from "@/components/ui/SegmentedControl";
+    import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/Tooltip";
+    import { Button } from "@/components/ui/Button";
+    import { Settings } from "lucide-react";
+    import { useTheme, type ThemeChoice } from "@/hooks/useTheme";
+
+    interface SettingsPopoverProps {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+    }
+
+    const THEME_OPTIONS = [
+      { value: "light", label: "Light" },
+      { value: "dark", label: "Dark" },
+      { value: "system", label: "System" },
+    ];
+
+    export function SettingsPopover({ open, onOpenChange }: SettingsPopoverProps): JSX.Element {
+      const { theme, setTheme } = useTheme();
+      return (
+        <Popover open={open} onOpenChange={onOpenChange}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Settings"
+                  data-testid="topbar-settings-button"
+                >
+                  <Settings size={16} />
+                </Button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Settings</TooltipContent>
+          </Tooltip>
+          <PopoverContent
+            side="bottom"
+            align="end"
+            sideOffset={6}
+            className="w-64"
+            data-testid="settings-popover"
+          >
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <label className="font-sans text-xs font-medium text-muted-foreground">
+                  Theme
+                </label>
+                <SegmentedControl
+                  value={theme}
+                  onValueChange={(v) => setTheme(v as ThemeChoice)}
+                  options={THEME_OPTIONS}
+                />
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      );
+    }
+    ```
+
+    Edit `src/components/TopBar.tsx`:
+    - Add `useState` to React imports (line 1).
+    - Import `SettingsPopover` from `./SettingsPopover` (after the lucide import block, ~line 25).
+    - Inside `TopBar()` near the top, add: `const [settingsOpen, setSettingsOpen] = useState(false);`
+    - At lines 211–212 (currently the Phase 80 audit-removal comment block), REPLACE the comment with: `<SettingsPopover open={settingsOpen} onOpenChange={setSettingsOpen} />`
+
+    Do NOT touch the boot bridge in `index.html` (it's already correct per research § "Boot bridge VERIFIED CORRECT"). Do NOT add a keyboard shortcut for Settings (out of scope per CONTEXT.md). Do NOT call `setSettingsOpen(false)` on theme change (D-03).
+
+    Commit with `feat(87-01): add Settings popover with theme toggle to TopBar`.
+  </action>
+  <verify>
+    <automated>npm run test -- --run src/components/__tests__/SettingsPopover.test.tsx 2>&1 | tail -30</automated>
+  </verify>
+  <done>
+    `SettingsPopover.tsx` created (~50 lines). `TopBar.tsx` shows the gear button at the right slot trailing position. Unit tests from Task 1 all turn GREEN (failures → 0). Dev server boots without TypeScript errors.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Remove .light force-wrappers from WelcomeScreen / ProjectManager / HelpPage</name>
+  <files>
+    src/components/WelcomeScreen.tsx,
+    src/components/ProjectManager.tsx,
+    src/components/HelpPage.tsx
+  </files>
+  <action>
+    Three targeted className edits per D-04:
+
+    1. `src/components/WelcomeScreen.tsx:55`:
+       ```diff
+       - <div className="light h-full flex flex-col bg-background">
+       + <div className="h-full flex flex-col bg-background">
+       ```
+
+    2. `src/components/ProjectManager.tsx:69`:
+       ```diff
+       - <div className="light space-y-3">
+       + <div className="space-y-3">
+       ```
+
+    3. `src/components/HelpPage.tsx:83`:
+       ```diff
+       - <div className="light min-h-screen bg-background text-foreground flex flex-col font-sans">
+       + <div className="min-h-screen bg-background text-foreground flex flex-col font-sans">
+       ```
+
+    Also remove the now-stale comment above line 83 in `HelpPage.tsx` (lines 80–82: "Force light mode for the help page..."). Replace with a single-line comment: `// Phase 87 D-04: respects user theme choice (was force-light prior to Phase 87).`
+
+    Do NOT remove the `.light` CSS class definition from `src/index.css` (D-04 says keep it as a reserved utility). Do NOT change anything inside the three components beyond the root div className — only the force-wrapper class is being dropped, all child markup stays identical.
+
+    Commit with `feat(87-01): remove .light force-wrappers from Welcome/Project/Help (D-04)`.
+  </action>
+  <verify>
+    <automated>grep -n 'className="light ' src/components/WelcomeScreen.tsx src/components/ProjectManager.tsx src/components/HelpPage.tsx; test $? -eq 1 && echo "OK: no .light wrappers remain"</automated>
+  </verify>
+  <done>
+    Grep for `className="light ` across the three files returns zero matches. All three surfaces now inherit the `<html class="dark|...">` cascade. The `.light` class definition in `src/index.css` is untouched.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Full suite green + e2e theme persistence verification</name>
+  <files>
+    (no source changes — verification only)
+  </files>
+  <action>
+    Run the three verification gates in order:
+
+    1. **Unit suite — full sweep:**
+       ```
+       npm run test:quick
+       ```
+       Expect: ~1107 tests pass (baseline from Phase 86), 0 new failures, the 5 new SettingsPopover tests all green. If any new failures, triage before committing — a likely candidate is a test that asserted `.light` was present on Welcome / Project / Help; update the assertion to reflect D-04.
+
+    2. **E2E theme spec:**
+       ```
+       npx playwright test --project=chromium-dev tests/e2e/specs/theme-toggle.spec.ts
+       ```
+       Expect: all three e2e tests pass. The reload-persistence test is the critical one — it validates the index.html boot bridge handles the new toggle path correctly.
+
+    3. **Type check:**
+       ```
+       npm run typecheck
+       ```
+       Expect: clean. `ThemeChoice` cast in SettingsPopover is the only new type-adjacent surface.
+
+    No code edits in this task unless a verification step surfaces an issue. If a test breaks, fix in a new commit (`fix(87-01): ...`) rather than amending Task 2 or 3.
+
+    Optional manual smoke (NOT required for plan to pass, but worth a minute during execution): run `npm run dev`, open localhost, click gear → Dark → look at HelpPage (open via Help button), confirm it actually renders dark. Then Light, confirm WelcomeScreen still renders light (open via Project Manager → New). File any visual bugs as `bug` + `backlog` GH issues per CLAUDE.md global rule — do NOT try to fix dark-mode contrast bugs in this phase (D-04 explicitly defers).
+
+    Commit any test-update fallout with `test(87-01): update Welcome/Project/Help assertions for D-04 wrapper removal` if needed. Otherwise no commit needed — verification only.
+  </action>
+  <verify>
+    <automated>npm run test:quick 2>&1 | tail -10 && npx playwright test --project=chromium-dev tests/e2e/specs/theme-toggle.spec.ts 2>&1 | tail -15</automated>
+  </verify>
+  <done>
+    Full unit suite green (≥1107 passes, 0 failures). E2E `theme-toggle.spec.ts` passes on chromium-dev. `npm run typecheck` clean. Phase 87 is ready for `/gsd:verify-work` → `/gsd:complete-phase`.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+**Phase-level success checks** (executor confirms each before declaring phase complete):
+
+1. **THEME-01** — Click anywhere in app → click gear button at TopBar right slot (next to Help) → Settings popover opens with "Theme" label visible.
+2. **THEME-02** — Popover shows segmented control with three options: Light / Dark / System (in that order, mixed-case labels per D-09).
+3. **THEME-03** — Click Dark → `<html>` gets `dark` class within 1 frame; `localStorage["room-cad-theme"] === "dark"`. Click Light → class removed. Click System → class follows `prefers-color-scheme` media query state.
+4. **THEME-04** — Toggle to Dark → open Help (via Help button) → HelpPage renders in dark mode. Open Welcome surface and ProjectManager → both render in dark mode. No `light` class on any of the three root divs.
+5. **THEME-05** — Set theme to Dark → reload page (Cmd+R) → `<html>` has `dark` class on first paint (no light-mode flash).
+6. **D-03 (popover persistence)** — Click gear → click Light → popover still open. Click Dark → still open. Click outside or press Escape → closes.
+7. **Test suite** — `npm run test:quick` green. `npx playwright test --project=chromium-dev tests/e2e/specs/theme-toggle.spec.ts` green. `npm run typecheck` clean.
+8. **No collateral damage** — Existing TopBar features still work: project name inline edit, save status, camera presets (when in 3D), Export, Help.
+</verification>
+
+<success_criteria>
+- Gear button exists in TopBar right slot with `data-testid="topbar-settings-button"` and lucide `Settings` icon
+- `SettingsPopover` component exists at `src/components/SettingsPopover.tsx`, ~50 lines, uses SegmentedControl primitive
+- All three `.light` force-wrappers removed from WelcomeScreen / ProjectManager / HelpPage
+- Unit + e2e tests cover THEME-01 through THEME-05, all green
+- `npm run test:quick` reports 0 regressions vs Phase 86 baseline
+- No changes to `index.html` boot bridge, `src/hooks/useTheme.ts`, `src/test-utils/themeDrivers.ts`, or `src/index.css` `.light` class definition
+- D-03 honored: popover stays open after theme selection
+</success_criteria>
+
+<rollback>
+Single-commit reverts available per task:
+
+- **Task 4 fallout** — discard test edits via `git checkout -- <test files>`, no production code changes.
+- **Task 3 (wrappers)** — restore via `git revert <task-3 sha>`. Brings back force-light surfaces; not strictly required to roll back unless dark mode reveals critical visual breakage.
+- **Task 2 (component + TopBar)** — `git revert <task-2 sha>`. Removes gear button and SettingsPopover; tests from Task 1 go RED again.
+- **Task 1 (tests)** — `git revert <task-1 sha>` removes the new test files; no source impact.
+
+Full phase rollback: `git revert` all four task commits in reverse order, then `git push`. No data migrations, no localStorage cleanup needed — `useTheme` reads any legacy `"room-cad-theme"` localStorage value cleanly regardless of whether the toggle UI exists.
+</rollback>
+
+<output>
+After completion, create `.planning/phases/87-theme-toggle-settings/87-01-SUMMARY.md` per `$HOME/.claude/get-shit-done/templates/summary.md` template. Include: what shipped (gear + popover + wrapper removal), traceability table (THEME-01..05 → tests → commits), files changed, before/after for `.light` wrappers, and a one-sentence note for visual UAT to confirm dark-mode rendering on the three previously-locked surfaces before closing the phase.
+</output>

--- a/.planning/phases/87-theme-toggle-settings/87-01-SUMMARY.md
+++ b/.planning/phases/87-theme-toggle-settings/87-01-SUMMARY.md
@@ -1,0 +1,165 @@
+---
+phase: 87-theme-toggle-settings
+plan: 01
+subsystem: ui
+tags: [theme, dark-mode, popover, settings, segmented-control, radix, lucide]
+
+requires:
+  - phase: 71-token-foundation
+    provides: "useTheme hook + boot bridge + Pascal token system + .dark class flip"
+  - phase: 76-token-foundation
+    provides: ".light force-wrappers on WelcomeScreen / ProjectManager / HelpPage (now removed)"
+  - phase: 80-toolbar-audit
+    provides: "Empty insertion slot in TopBar right-side where the dead Settings button used to live"
+  - phase: 83-toolbar-snap
+    provides: "Popover-from-toolbar-button pattern (Snap popover precedent)"
+provides:
+  - "SettingsPopover component — gear button + Popover + theme SegmentedControl in TopBar"
+  - "Theme toggle UI wired to useTheme() (Light / Dark / System)"
+  - "Wrapper-free WelcomeScreen / ProjectManager / HelpPage that respect theme cascade"
+affects: [phase-88+, future-settings-rows, design-system-followup]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Settings-popover precedent (D-03: stays open on segment click, unlike Snap which auto-closes)"
+    - "Component-extracted Popover (vs Phase 83 inline FloatingToolbar Snap) — for future settings rows"
+
+key-files:
+  created:
+    - "src/components/SettingsPopover.tsx"
+    - "src/components/__tests__/SettingsPopover.test.tsx"
+    - "tests/e2e/specs/theme-toggle.spec.ts"
+  modified:
+    - "src/components/TopBar.tsx"
+    - "src/components/WelcomeScreen.tsx"
+    - "src/components/ProjectManager.tsx"
+    - "src/components/HelpPage.tsx"
+
+key-decisions:
+  - "D-02: 3-option SegmentedControl (Light / Dark / System) reusing existing primitive, not a custom dropdown or cycling Sun/Moon"
+  - "D-03: popover stays open after segment click — theme is a 'try it' choice, deliberately different from Phase 83 Snap auto-close"
+  - "D-04: removed all three .light force-wrappers (Welcome / Project / Help) in same phase; CSS class definition preserved as reserved utility"
+  - "D-05: theme-only popover body in v1 — no placeholder rows for future settings"
+  - "SettingsPopover extracted to its own file (~70 lines) instead of inline in TopBar — anticipates future settings rows without further refactor"
+
+patterns-established:
+  - "Pascal-token-aware popover with reused SegmentedControl primitive — ready for Units / Default-room rows in future phases"
+  - "useState-driven open/close on parent component, passed via { open, onOpenChange } props — matches Phase 83 Snap pattern"
+
+requirements-completed: [THEME-01, THEME-02, THEME-03, THEME-04, THEME-05]
+
+duration: 8min
+completed: 2026-05-15
+---
+
+# Phase 87 Plan 01: Theme Toggle + Settings Popover Summary
+
+**Gear button in TopBar opens a Settings popover with a Light/Dark/System SegmentedControl wired to useTheme(); removed three .light force-wrappers so Jessica's choice now applies to WelcomeScreen, ProjectManager, and HelpPage.**
+
+## Performance
+
+- **Duration:** ~8 min (atomic execution, all 4 tasks GREEN on first try)
+- **Started:** 2026-05-15T16:00:00Z
+- **Completed:** 2026-05-15T16:08:54Z
+- **Tasks:** 4
+- **Files modified:** 7 (3 created, 4 edited)
+- **Commits:** 4 task commits
+
+## Accomplishments
+
+- Settings gear button (lucide `Settings`, `icon-sm`) re-introduced to TopBar right slot trailing Help button, with `data-testid="topbar-settings-button"`
+- `SettingsPopover` component (~70 lines) — Radix Popover + reused `SegmentedControl` primitive, exposes `data-testid="settings-popover"` for e2e
+- Three-option theme toggle wired to `useTheme()`: Light, Dark, System; active segment reads `theme`, click writes `setTheme(v as ThemeChoice)`
+- D-03 honored — popover stays open across segment clicks so Jessica can compare modes without re-opening (outside click + Escape still close via Radix defaults)
+- All three `.light` force-wrappers removed from WelcomeScreen (line 55), ProjectManager (line 69), HelpPage (line 83); HelpPage's stale "Force light mode" comment replaced with D-04 marker
+- 6 unit tests + 3 e2e tests added — all GREEN; full vitest sweep 1113 passing (up from 1107 baseline)
+
+## Task Commits
+
+1. **Task 1: RED unit + e2e tests** — `99ef73d` (test)
+2. **Task 2: SettingsPopover + TopBar wiring (GREEN)** — `e2be551` (feat)
+3. **Task 3: Remove .light force-wrappers** — `5a0c9f9` (feat)
+4. **Task 4: E2E spec wiring fix (seedRoom + reset removal)** — `e8659d3` (test)
+
+## Files Created/Modified
+
+- `src/components/SettingsPopover.tsx` — Settings popover with theme SegmentedControl; D-03 no-close-on-select
+- `src/components/__tests__/SettingsPopover.test.tsx` — 6 unit tests covering THEME-01/02/03 + D-03
+- `tests/e2e/specs/theme-toggle.spec.ts` — 3 e2e tests covering THEME-03 (toggle), THEME-05 (reload persistence), THEME-04 (HelpPage cascade)
+- `src/components/TopBar.tsx` — adds `useState` import, `SettingsPopover` import, `settingsOpen` state, popover render in right slot
+- `src/components/WelcomeScreen.tsx` — drop `light` from root div className (line 55)
+- `src/components/ProjectManager.tsx` — drop `light` from root div className (line 69)
+- `src/components/HelpPage.tsx` — drop `light` + replace stale force-light comment with D-04 marker (line 80-83)
+
+## Traceability
+
+| Req ID    | Description                                          | Tests                                                                                                     | Commit                                |
+| --------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| THEME-01  | Gear button opens Settings popover                   | unit: "renders a gear button…", "clicking the gear opens a popover…"                                      | `e2be551`                             |
+| THEME-02  | Popover contains 3-option SegmentedControl           | unit: "clicking the gear opens a popover with Theme header + Light/Dark/System segments"                  | `e2be551`                             |
+| THEME-03  | Toggle writes useTheme + flips `.dark` on `<html>`   | unit: "clicking Dark adds .dark…", "clicking System follows matchMedia…"; e2e: "click gear → Dark adds…"  | `e2be551`                             |
+| THEME-04  | WelcomeScreen/ProjectManager/HelpPage respect theme  | e2e: "HelpPage inherits .dark cascade (no .light force-wrapper)"                                          | `5a0c9f9`                             |
+| THEME-05  | Reload preserves choice (no flash)                   | e2e: "choice persists across reload (no flash)"                                                           | `e2be551` (UI) + boot bridge (existing) |
+| D-03      | Popover stays open on segment click                  | unit: "popover stays open after a segment is clicked"                                                     | `e2be551`                             |
+
+## Decisions Made
+
+- Extracted `SettingsPopover` to its own component file even though v1 only has one setting — anticipates Units / Default-room follow-ups without further refactor. The research doc suggested inlining; plan elevated to component extraction; the plan won.
+- Kept the `.light` CSS class definition in `index.css` (line 53) per D-04 — useful as a reserved utility for future "always-light" surfaces (print preview, export thumbnails).
+- The popover open/close state lives on TopBar (`useState(false)`) and is passed as `{ open, onOpenChange }` props to SettingsPopover, matching the Phase 83 Snap pattern.
+
+## Deviations from Plan
+
+**1. [Rule 3 — Blocking] Wrapped unit test render in TooltipProvider**
+
+- **Found during:** Task 1 (RED test run)
+- **Issue:** First test run threw `Tooltip must be used within TooltipProvider` because the test rendered TopBar without the global provider wired in `src/main.tsx`.
+- **Fix:** Added `<TooltipProvider>` wrapper inside the test's `renderTopBar()` helper. Tests then failed for the right reason (gear button doesn't exist yet) — true RED.
+- **Files modified:** `src/components/__tests__/SettingsPopover.test.tsx`
+- **Commit:** `99ef73d`
+
+**2. [Rule 3 — Blocking] E2E spec needed seedRoom + init-script reset removed**
+
+- **Found during:** Task 4 (first e2e run)
+- **Issue:** Page loaded WelcomeScreen (no project hydrated), so `topbar-settings-button` was never in the DOM. Then once seedRoom was added, the reload-persistence test failed because the `addInitScript` reset was clobbering localStorage on every reload.
+- **Fix:** Added `seedRoom(page)` before each test (mounts TopBar by triggering `setHasStarted(true)`); removed the `beforeEach` init-script reset that was defeating the reload-persistence check; re-seed after reload in THEME-05.
+- **Files modified:** `tests/e2e/specs/theme-toggle.spec.ts`
+- **Commit:** `e8659d3`
+
+---
+
+**Total deviations:** 2 auto-fixed (both blocking — pre-existing test infrastructure context I needed to learn)
+**Impact on plan:** None on plan scope or design. Plan executed exactly as written for production code.
+
+## Issues Encountered
+
+- TS deprecation warning on `tsconfig.json:17` (`baseUrl` deprecated, will be removed in TypeScript 7.0). Pre-existing, not introduced by Phase 87. Logged as out-of-scope.
+- 33 unhandled rejections from `swatchThumbnailGenerator` WebGL renderer surfaced in vitest — pre-existing on main, not caused by Phase 87 changes. Verified by running `git stash && npm run test:quick` shows same 33 errors before phase work.
+
+## Self-Check: PASSED
+
+- Files exist: `SettingsPopover.tsx`, `SettingsPopover.test.tsx`, `theme-toggle.spec.ts` — all FOUND
+- Commits exist: `99ef73d`, `e2be551`, `5a0c9f9`, `e8659d3` — all FOUND
+- Tests green: 1113/1113 vitest + 3/3 e2e on chromium-dev
+
+## Manual UAT (recommended, not required to ship)
+
+Open dev server (`npm run dev`), click gear in top bar:
+1. Confirm Theme popover shows Light / Dark / System pill
+2. Click Dark → app flips to dark; click Light → flips to light; click System → follows OS
+3. Reload after each selection → no flash, correct theme on first paint
+4. With Dark active, open Help (HelpCircle icon) → confirm HelpPage actually renders dark (was force-light before)
+5. With Dark active, navigate to Welcome / ProjectManager via Home → confirm both render dark
+
+If any of WelcomeScreen / ProjectManager / HelpPage reveal dark-mode visual bugs (low-contrast text, hardcoded light colors), file as GH issues with `bug` + `backlog` labels per D-04 — those are explicitly out of scope for Phase 87.
+
+## Next Phase Readiness
+
+- Theme toggle is shippable. Phase 87 has no downstream blockers.
+- Future settings rows (Units, Default room, Reduced-motion override) can extend `SettingsPopover` without API change — just add new sections below the Theme block.
+- The three force-light surfaces are now under theme cascade — visual polish for dark mode on Welcome/Project/Help can land in a follow-up phase if UAT surfaces contrast issues.
+
+---
+*Phase: 87-theme-toggle-settings*
+*Completed: 2026-05-15*

--- a/.planning/phases/87-theme-toggle-settings/87-CONTEXT.md
+++ b/.planning/phases/87-theme-toggle-settings/87-CONTEXT.md
@@ -1,0 +1,69 @@
+# Phase 87: Theme Toggle + Settings Popover — Context
+
+**Captured:** 2026-05-15
+**Branch:** `gsd/phase-87-theme-toggle`
+**Status:** Locked — ready for plan
+
+## Vision
+
+Jessica can flip the app between Light, Dark, and System mode from a gear button in the top bar. The three "force-light" wrappers shipped in Phase 76 (WelcomeScreen, ProjectManager, HelpPage) come off so her choice actually sticks across every surface. All theme infrastructure exists from Phase 71 (`useTheme()`, boot bridge, `__driveTheme` test driver) — this phase is purely the missing affordance + wrapper removal.
+
+## Milestone Placement
+
+This is a standalone polish phase. It ships outside any v1.xx milestone — v1.20 and v1.21 closed (2026-05-15) and there is no active v1.22 yet. No new milestone REQUIREMENTS.md file. ROADMAP.md gets the phase listed in the regular `Phases` progress table.
+
+## Decisions (Locked)
+
+### D-01 — Standalone polish phase
+
+Phase 87 is a one-off polish phase that ships independently. No v1.22 milestone is opened for it. ROADMAP.md adds a `## Polish Phases` section (or appends to existing if present) listing Phase 87, and adds a row in the `## Progress` table once shipped. No `milestones/v1.22-REQUIREMENTS.md` file.
+
+### D-02 — Segmented control for theme toggle
+
+Reuse the existing `src/components/ui/SegmentedControl.tsx` primitive. Three options in this order: **Light / Dark / System**. Mixed-case labels per D-09 chrome convention. Active option reads from `useTheme().theme`, click writes via `setTheme(value)`. Cast at the call site: `(v) => setTheme(v as ThemeChoice)` because `SegmentedControl.onValueChange` is typed `(v: string) => void`.
+
+Rejected alternatives: cycling Sun/Moon button (hides System), dropdown menu (extra click), three separate icon buttons (no grouping affordance).
+
+### D-03 — Popover stays open until outside click or Escape
+
+Default Radix Popover dismissal behavior — do NOT call `setOpen(false)` inside the segmented-control `onValueChange` handler. This is intentionally different from the Phase 83 Snap popover (which auto-closes) because theme is a "try it" choice, not "set and forget". Jessica should be able to click Light → Dark → System and feel the difference without re-opening the popover each time. Outside click and Escape still close it via Radix defaults.
+
+### D-04 — Remove all three `.light` force-wrappers
+
+Drop the `light` className from the root div in all three files:
+
+- `src/components/WelcomeScreen.tsx:55` — `<div className="light h-full flex flex-col bg-background">` → drop `light `
+- `src/components/ProjectManager.tsx:69` — `<div className="light space-y-3">` → drop `light `
+- `src/components/HelpPage.tsx:83` — `<div className="light min-h-screen bg-background text-foreground flex flex-col font-sans">` → drop `light `
+
+The `.light` CSS class definition in `src/index.css` (line 53) stays in place — it's harmless as a future utility for always-light surfaces (print preview, export thumbnails) and removing it touches more than this phase needs. Optional cosmetic comment refresh on the class definition can land in the same commit if convenient, but is NOT required for the phase to ship.
+
+If removing wrappers reveals dark-mode visual bugs on WelcomeScreen / ProjectManager / HelpPage (low-contrast text, hardcoded light colors), file as GH issues with `bug` + `backlog` labels and triage as a follow-up phase. Phase 87 is THEME-04 = wrappers gone, not THEME-04 = wrappers gone AND all three surfaces look perfect in dark mode.
+
+### D-05 — Theme-only popover content in v1
+
+The Settings popover renders exactly one section in this phase: header label "Theme" + segmented control. No placeholder rows for future settings ("Units (coming soon)", "Default room size", etc). Future settings extend the popover body without API change. Avoid invitation to ask "when?".
+
+## Out of Scope
+
+Explicitly deferred:
+
+- Visual polish of WelcomeScreen / ProjectManager / HelpPage in dark mode (file as bugs if discovered)
+- Settings beyond Theme (Units, Default Room, Reduced Motion override, Snap default)
+- Tooltip on the gear button mentioning the keyboard shortcut (there is no shortcut for Settings; tooltip just says "Settings")
+- Animation polish beyond what Radix Popover + SegmentedControl give by default
+- Persisting popover open state across reloads (it should always boot closed)
+
+## Linked Issues / Spec
+
+No GitHub issue tracks this directly. The need surfaced from Phase 76 UAT feedback — Jessica noticed Help / Welcome / ProjectManager were stuck in light mode regardless of her preference, and there was no way to set a preference anyway. CONTEXT.md serves as the spec; PLAN.md links back to this file.
+
+## Requirements Summary (for traceability)
+
+| ID | Behavior | Surfaces |
+|----|----------|----------|
+| THEME-01 | Gear button in TopBar right slot opens Settings popover | `TopBar.tsx` |
+| THEME-02 | Popover body contains Theme segmented control (Light / Dark / System) | `TopBar.tsx`, `SegmentedControl` primitive |
+| THEME-03 | Toggle wired to `useTheme().theme` + `setTheme()`, persists via localStorage | `useTheme` hook (existing, no changes) |
+| THEME-04 | WelcomeScreen, ProjectManager, HelpPage respect user theme — drop `.light` force-wrappers | `WelcomeScreen.tsx`, `ProjectManager.tsx`, `HelpPage.tsx` |
+| THEME-05 | First-paint matches stored choice (no flash) | `index.html` boot bridge (existing, no changes) |

--- a/.planning/phases/87-theme-toggle-settings/87-RESEARCH.md
+++ b/.planning/phases/87-theme-toggle-settings/87-RESEARCH.md
@@ -1,0 +1,332 @@
+# Phase 87: Theme Toggle + Settings Popover — Research
+
+**Researched:** 2026-05-15
+**Domain:** Frontend UI — theme switching, settings affordance
+**Confidence:** HIGH
+
+## Summary
+
+All infrastructure exists. Phase 71 (v1.18) shipped `useTheme()` (light/dark/system with localStorage + matchMedia), the boot-bridge script in `index.html` (handles system mode correctly via `prefers-color-scheme`), a test driver (`__driveTheme`), and a `.dark` class flip on `<html>`. Phase 76 added force-`.light` wrappers on three components (WelcomeScreen, ProjectManager, HelpPage) and shipped without the toggle. Phase 80 deleted the dead Settings gear button. Phase 83 established the canonical Popover-anchored-to-toolbar-button pattern (Snap popover in `FloatingToolbar.tsx`).
+
+This phase needs ~four file changes: re-add the gear button in `TopBar`, build `SettingsPopover` body using existing `SegmentedControl`, remove three `.light` wrappers, optional CSS comment update. No new dependencies. No state plumbing — `useTheme()` is self-contained.
+
+**Primary recommendation:** Single plan, ~4 tasks. Use existing `SegmentedControl` for Light/Dark/System. Remove all three `.light` wrappers in the same phase (WelcomeScreen, ProjectManager, HelpPage — the third is not in the brief but exists at `HelpPage.tsx:83`).
+
+## Project Constraints (from CLAUDE.md)
+
+- **D-09 UI labels:** mixed case for chrome — "Theme", "Light", "Dark", "System"
+- **D-33 icons:** lucide-react only — use `Settings` from lucide
+- **D-13 squircle:** Popover already applies `rounded-smooth-lg` via primitive
+- **§7 StrictMode-safe useEffect cleanup:** any new module-level state must use identity-checked cleanup. `useTheme` already follows this; new Popover state is local React state (no concern)
+- **Pascal token system (Phase 71):** use `bg-card`, `text-foreground`, `border-border`, `bg-accent/10` — NO `bg-obsidian-*` or `text-text-*`
+- **No emojis in code**
+
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| THEME-01 | Gear icon button in TopBar right slot opens Settings popover | TopBar.tsx has exact insertion site at line 211 (where dead button comment lives); Popover primitive ready |
+| THEME-02 | Popover body contains Theme segmented control (Light / Dark / System) | `SegmentedControl` exists at `src/components/ui/SegmentedControl.tsx`; iOS-style with motion pill |
+| THEME-03 | Toggle wired to `useTheme().theme` + `setTheme()`, persists via localStorage | `useTheme()` already complete with localStorage + matchMedia |
+| THEME-04 | WelcomeScreen, ProjectManager (and HelpPage) respect user theme — drop `.light` force-wrappers | Wrappers found at WelcomeScreen.tsx:55, ProjectManager.tsx:69, HelpPage.tsx:83 |
+| THEME-05 | First-paint matches stored choice (no flash) | Boot-bridge `<script>` in index.html lines 10–18 already correct |
+
+## Current State
+
+### `useTheme()` hook (`src/hooks/useTheme.ts`, 55 lines)
+Full API surface:
+- **Returns:** `{ theme: "light" | "dark" | "system", resolved: "light" | "dark", setTheme: (t) => void }`
+- **`theme`** — user's stored choice (lazy-read from `localStorage["room-cad-theme"]`, defaults to `"system"`)
+- **`resolved`** — computed: if `theme === "system"`, follows `matchMedia("(prefers-color-scheme: dark)")`; else equals `theme`
+- **`setTheme`** — writes to localStorage (with quota try/catch) + setState
+- Effect applies/removes `<html class="dark">` whenever `resolved` changes
+- Effect subscribes to `matchMedia` change events for live OS-pref updates
+- **Default for new users:** `"system"` (line 23) — no override needed
+
+### Boot bridge (`index.html` lines 10–18) — VERIFIED CORRECT
+```js
+var t = localStorage.getItem('room-cad-theme') || 'system';
+var dark = t === 'dark' || (t === 'system' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+if (dark) document.documentElement.classList.add('dark');
+```
+Handles system mode via `prefers-color-scheme`. No flash on reload. No change needed.
+
+### Dead Settings button site (`src/components/TopBar.tsx` lines 211–212)
+```tsx
+{/* Phase 80 audit removal: Settings button had no onClick handler — dead.
+    Re-introduce when the theme/settings drawer ships (tracked in v1.21 backlog). */}
+```
+Insertion point clearly marked. Gear sits after the Help button (line 196–209) in the right slot. No vertical separator before it (Help is the trailing element today).
+
+### Popover primitive (`src/components/ui/Popover.tsx`, 40 lines)
+- Re-exports `Popover` (Root), `PopoverTrigger`
+- Custom `PopoverContent` — z-50, w-72, `rounded-smooth-lg`, `border-border`, `bg-card`, `p-4`, `shadow-md`, fade+zoom animations, side-aware slide
+- Radix handles Escape + outside-click close automatically
+- Used in `FloatingToolbar.tsx` (Snap popover) — canonical precedent
+
+### SegmentedControl primitive (`src/components/ui/SegmentedControl.tsx`, 72 lines) — PERFECT FIT
+- Props: `value`, `onValueChange`, `options: { value, label }[]`, `className`
+- iOS-style with sliding `motion.div` pill (layoutId animates between segments)
+- Respects `useReducedMotion()`
+- `role="group"` + per-button `role="radio"` + `aria-checked` — a11y correct out of the box
+- `bg-muted/50` track, active segment gets `bg-card` shadow
+
+### `.light` force-wrapper sites (3 total)
+| File | Line | Wrapper |
+|------|------|---------|
+| `src/components/WelcomeScreen.tsx` | 55 | `<div className="light h-full flex flex-col bg-background">` |
+| `src/components/ProjectManager.tsx` | 69 | `<div className="light space-y-3">` |
+| `src/components/HelpPage.tsx` | 83 | `<div className="light min-h-screen bg-background text-foreground flex flex-col font-sans">` |
+
+CSS definition: `src/index.css` line 53 — `.light { ... oklch tokens ... }`. The class itself can stay (in case it's useful as a utility for "always-light" surfaces later), but all three call sites should drop the `light ` prefix.
+
+### Test driver (`src/test-utils/themeDrivers.ts`, 43 lines)
+- `window.__driveTheme(theme)` exposed in test mode only
+- `registerThemeSetter` uses identity-checked cleanup (StrictMode safe per CLAUDE.md §7)
+- Already wired: `main.tsx:49` installs the driver, `App.tsx:50` registers the setter via `useEffect`
+- For Phase 87 e2e: driver writes to `setTheme`, which already updates UI. Driver does NOT need extension unless tests want to assert the gear/popover state — in which case standard Playwright clicks suffice (no driver needed).
+
+## Standard Stack
+
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| `@radix-ui/react-popover` | (installed) | Popover Root + Trigger | Existing primitive, used by Snap popover |
+| `lucide-react` | (installed) | `Settings` gear icon | D-33 — only icon library allowed |
+| `motion/react` | (installed) | SegmentedControl pill animation | Already a SegmentedControl dependency |
+
+No new packages needed.
+
+## Settings Popover Spec (Opinionated)
+
+### Recommended structure
+
+```tsx
+// In TopBar.tsx, replace the Phase 80 audit-removal comment block at lines 211–212
+const [settingsOpen, setSettingsOpen] = useState(false);
+const { theme, setTheme } = useTheme();
+
+// ... in the right slot, after the Help Tooltip:
+<Popover open={settingsOpen} onOpenChange={setSettingsOpen}>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Settings"
+          data-testid="topbar-settings"
+        >
+          <Settings size={16} />
+        </Button>
+      </PopoverTrigger>
+    </TooltipTrigger>
+    <TooltipContent side="bottom">Settings</TooltipContent>
+  </Tooltip>
+  <PopoverContent
+    side="bottom"
+    align="end"
+    sideOffset={6}
+    className="w-64"
+    data-testid="settings-popover"
+  >
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <label className="font-sans text-xs font-medium text-muted-foreground">
+          Theme
+        </label>
+        <SegmentedControl
+          value={theme}
+          onValueChange={(v) => setTheme(v as ThemeChoice)}
+          options={[
+            { value: "light", label: "Light" },
+            { value: "dark", label: "Dark" },
+            { value: "system", label: "System" },
+          ]}
+          data-testid="theme-segmented-control"
+        />
+      </div>
+    </div>
+  </PopoverContent>
+</Popover>
+```
+
+### Why segmented control (not dropdown or cycling icon)
+- **Discoverable** — all three options visible at once; Jessica doesn't need to learn that clicking a sun toggles to a moon
+- **Matches Tailwind docs UX** — pattern she's likely seen
+- **Already built and styled** — zero new component cost
+- **Accessible** — `role="radio"` semantics free
+
+Alternative considered: single Sun/Moon button that cycles. Rejected — three-state cycle is harder to discover, "System" is invisible.
+
+### File location
+Inline in `TopBar.tsx` for v1 (~30 lines). If a second setting lands later (Units, Default room), extract to `src/components/SettingsPopover.tsx`. Premature extraction now would bloat the diff without payoff.
+
+## Architecture Patterns
+
+### Popover-from-toolbar-button pattern (Phase 83 precedent)
+Wrap `Tooltip` around `PopoverTrigger asChild` around `Button`. Tooltip + Popover compose cleanly. Local React state controls open/close. Radix handles Escape, focus trap, outside-click close.
+
+### Theme write path
+User clicks segment → `setTheme(v)` → localStorage write + setState → `useTheme` effect adds/removes `.dark` on `<html>` → Pascal token CSS vars flip → entire UI re-renders new colors. No manual re-render needed.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| 3-way option toggle | Custom radio group | `SegmentedControl` | Already built, animated, a11y-correct |
+| Popover positioning + dismiss | Custom dropdown | `Popover` primitive | Radix handles Escape, focus, outside-click |
+| `prefers-color-scheme` detection | Custom matchMedia logic | `useTheme()` | Already handles system mode + live OS-pref updates |
+| Persist theme across reloads | Custom localStorage code | `useTheme().setTheme()` | Already wraps localStorage with try/catch |
+
+## Common Pitfalls
+
+### Pitfall 1: Removing `.light` reveals dark-mode bugs
+**What goes wrong:** WelcomeScreen, ProjectManager, HelpPage have never been visually tested in dark mode (force-light since Phase 76). Hard-coded light colors or low-contrast text may surface.
+**How to avoid:** Visual check during UAT. Run dev server, toggle to Dark, visit all three surfaces. Look for: invisible text (light-on-light), white containers on dark background, inline `style` overrides.
+**Warning signs:** Buttons or borders that disappear; text that looks washed out.
+
+### Pitfall 2: Popover open state needs explicit close on segment click
+**What goes wrong:** User selects "Dark" — popover stays open with no visual confirmation since the toggle is right there.
+**How to avoid:** Per Phase 83 precedent, the Snap popover closes on selection (line 484: `setSnapPopoverOpen(false)`). For Settings popover, leaving it open is OK — segmented control is visually responsive (pill slides). Recommend KEEPING IT OPEN so Jessica can compare options without re-opening. Snap closes because it's a "set and forget" choice; theme is a "try it" choice.
+
+### Pitfall 3: First paint flash if boot script changes
+**What goes wrong:** Modifying the boot script can cause a flash of unstyled or wrong-themed content.
+**How to avoid:** DO NOT touch `index.html` boot bridge. Already correct.
+
+### Pitfall 4: `<html class="dark light">` conflict
+**What goes wrong:** If `.light` wrapper isn't removed and user picks Dark, the `<html>` has `dark` class but a nested `.light` div overrides tokens via cascade. Some surfaces stay light while others go dark.
+**How to avoid:** Remove all three `.light` wrappers in this phase. This is THEME-04. Not deferrable.
+
+### Pitfall 5: SegmentedControl value type mismatch
+**What goes wrong:** `SegmentedControl.onValueChange` is typed `(v: string) => void`. `setTheme` expects `ThemeChoice`.
+**How to avoid:** Cast at the call site: `onValueChange={(v) => setTheme(v as ThemeChoice)}`. Safe because options array is the only source.
+
+## Code Examples
+
+### TopBar gear button insertion (replaces lines 211–212)
+See "Settings Popover Spec" above. Add `Settings` to lucide imports (line 17–24 of TopBar.tsx). Add `useState` import (line 1).
+
+### Wrapper removal — WelcomeScreen.tsx line 55
+```diff
+- <div className="light h-full flex flex-col bg-background">
++ <div className="h-full flex flex-col bg-background">
+```
+Same shape for ProjectManager.tsx:69 (`light space-y-3` → `space-y-3`) and HelpPage.tsx:83.
+
+### Optional: index.css line 50–51 comment update
+The CSS class definition itself can stay (might be useful later as `.light` utility for always-light surfaces like print preview). Update the comment to reflect new reality:
+```diff
+- /* Force-light wrapper — used by WelcomeScreen + ProjectManager.
+-    Overrides .dark on <html> so these surfaces always render in light mode. */
++ /* Force-light utility — overrides .dark on <html> for always-light surfaces.
++    Phase 87: removed from WelcomeScreen / ProjectManager / HelpPage which now
++    respect the user's theme choice. Reserved for future print/export surfaces. */
+```
+
+## Plan Decomposition
+
+**Recommended: single plan `87-01-theme-toggle-settings`, 4 atomic tasks**
+
+1. **Task A — Settings popover in TopBar** (RED+GREEN)
+   - Re-add gear button + Popover + SegmentedControl wired to `useTheme()`
+   - Add `data-testid`s for e2e: `topbar-settings`, `settings-popover`, `theme-segmented-control`
+   - Unit/integration test: click gear → popover opens; click "Dark" → `<html>` gets `.dark` class; click "Light" → class removed
+2. **Task B — Remove `.light` force-wrappers** (single commit, low risk)
+   - Three string deletions across WelcomeScreen, ProjectManager, HelpPage
+   - Optional: refresh comment on `.light` CSS class
+3. **Task C — E2E test: theme persistence across reload**
+   - Playwright: click gear → Dark → reload page → assert `<html>` has `dark` class on first paint (boot bridge validation)
+4. **Task D — UAT note: visual check on light mode** (manual)
+   - Dev server, toggle Dark + Light + System, visit Welcome / Help / ProjectManager. Flag any contrast/color bugs.
+
+Don't split B into its own plan — the wrappers are 3 line edits, atomic. If dark mode reveals bugs on those screens, surface them in the UAT and triage as carry-over GH issues (THEME-04 ships when wrappers are gone; visual polish is separate).
+
+## Open Questions for Plan Phase
+
+1. **Phase 87 milestone home:** standalone phase, or open new v1.22 milestone? Recommendation: standalone polish phase. No active v1.22 theme; opening one for a one-plan phase is overkill.
+2. **Toggle UX:** Recommended — three-segment control (Light / Dark / System) using existing `SegmentedControl`. See "Why segmented control" above. Confirm with user.
+3. **Future settings placeholder rows:** Recommendation — ship Theme only. Don't add "Units (coming soon)" placeholder. v1 ships smaller; adding placeholders invites the user to ask "when?"
+4. **Drop `.light` wrappers in this phase or defer?** Recommendation — drop now. Three wrappers is small. If dark-mode bugs surface on Welcome/Help/ProjectManager, file as GH issues and ship them as visual polish in a follow-up phase.
+5. **System mode default:** Already implemented — `useTheme` defaults new users to `"system"` (line 23). No change needed. Confirm this is the intended default.
+6. **HelpPage `.light` wrapper:** Not in original brief but exists at `HelpPage.tsx:83`. Recommendation — include in THEME-04. Otherwise Help opens in light mode even when user picks Dark, which is inconsistent.
+
+## Open Questions
+
+1. **Popover close-on-selection behavior**
+   - What we know: Snap popover closes on selection (Phase 83). Other tooling docs (Tailwind) keep theme toggles persistent.
+   - What's unclear: Jessica's preference. Letting the popover stay open while she compares Light/Dark/System feels right.
+   - Recommendation: Keep open. If UAT feedback says otherwise, one-line change.
+
+## Runtime State Inventory
+
+This phase is mostly additive UI; one category needs explicit mention.
+
+| Category | Items Found | Action Required |
+|----------|-------------|-------------------|
+| Stored data | localStorage key `room-cad-theme` already in use since Phase 71. No schema change. Existing values (`"light"` / `"dark"` / `"system"`) valid. | None — existing storage works as-is |
+| Live service config | None — local-first app | None |
+| OS-registered state | `prefers-color-scheme` media query (read-only, OS-managed) | None — already wired in `useTheme` |
+| Secrets/env vars | None | None |
+| Build artifacts | None | None |
+
+## Environment Availability
+
+Pure code/config changes, no external dependencies. **Step 2.6: SKIPPED (no external dependencies identified)**.
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | Vitest (unit/integration) + Playwright (e2e) |
+| Config file | `vitest.config.ts`, `playwright.config.ts` |
+| Quick run command | `npm run test -- --run` (Vitest) or `npm run test:e2e -- --grep "theme"` |
+| Full suite command | `npm run test && npm run test:e2e` |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|--------------|
+| THEME-01 | Gear button in TopBar opens popover | integration | `npm run test -- TopBar.test` | Wave 0 — create `src/components/__tests__/TopBar.test.tsx` |
+| THEME-02 | Popover contains 3-option segmented control | integration | same as above | Wave 0 |
+| THEME-03 | Click "Dark" → `<html class="dark">`; "Light" → class removed; persists localStorage | integration | same | Wave 0 |
+| THEME-04 | WelcomeScreen / ProjectManager / HelpPage have no `.light` class on root | integration | `npm run test -- WelcomeScreen.test ProjectManager.test HelpPage.test` | Wave 0 — likely needs new test files |
+| THEME-05 | Theme persists across reload (first-paint correct) | e2e | `npm run test:e2e -- --grep "theme persistence"` | Wave 0 — new spec |
+
+### Sampling Rate
+- **Per task commit:** `npm run test -- TopBar` (or whatever file is being edited)
+- **Per wave merge:** Full unit suite + scoped e2e: `npm run test && npm run test:e2e -- --grep "theme"`
+- **Phase gate:** Full suite green before `/gsd:verify-work`
+
+### Wave 0 Gaps
+- [ ] `src/components/__tests__/TopBar.test.tsx` — Settings popover test cases (THEME-01..03)
+- [ ] `e2e/theme-persistence.spec.ts` — reload + first-paint test (THEME-05)
+- [ ] Possibly: `src/components/__tests__/WelcomeScreen.test.tsx` — assert `<root>` does NOT have `light` class (or check ProjectManager / HelpPage similarly). May be easier to add an e2e visual smoke or simply rely on the diff being a 3-line removal.
+
+## Sources
+
+### Primary (HIGH confidence)
+- `src/hooks/useTheme.ts` — full API surface read
+- `src/components/ui/Popover.tsx` — primitive shape verified
+- `src/components/ui/SegmentedControl.tsx` — exact match for toggle
+- `src/components/TopBar.tsx` — insertion site identified (line 211)
+- `src/components/FloatingToolbar.tsx` — Phase 83 Popover precedent (lines 447–499)
+- `index.html` — boot bridge correct (lines 10–18)
+- `src/test-utils/themeDrivers.ts` — driver already wired in main.tsx + App.tsx
+- `src/index.css` — `.light` token block (lines 50–80)
+- `./CLAUDE.md` — Phase 71 design system section, D-09 / D-33 / §7 patterns
+
+### Secondary (MEDIUM confidence)
+- None needed — all findings verified in-repo
+
+### Tertiary (LOW confidence)
+- None
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — all primitives already exist in-repo
+- Architecture: HIGH — Phase 83 precedent + Phase 71 hook are exact patterns
+- Pitfalls: HIGH — `.light` wrapper removal risk is concrete and bounded
+
+**Research date:** 2026-05-15
+**Valid until:** 30 days (theme system is stable; no external deps to drift)

--- a/src/components/HelpPage.tsx
+++ b/src/components/HelpPage.tsx
@@ -77,10 +77,8 @@ export default function HelpPage() {
     : SECTIONS;
 
   return (
-    // Force light mode for the help page (same pattern as WelcomeScreen).
-    // This gives a clean, readable SaaS-docs feel regardless of the user's
-    // current app theme.
-    <div className="light min-h-screen bg-background text-foreground flex flex-col font-sans">
+    // Phase 87 D-04: respects user theme choice (was force-light prior to Phase 87).
+    <div className="min-h-screen bg-background text-foreground flex flex-col font-sans">
       {/* ------------------------------------------------------------------ */}
       {/* Top bar                                                             */}
       {/* ------------------------------------------------------------------ */}

--- a/src/components/ProjectManager.tsx
+++ b/src/components/ProjectManager.tsx
@@ -66,7 +66,7 @@ export default function ProjectManager() {
   }
 
   return (
-    <div className="light space-y-3">
+    <div className="space-y-3">
       <h3 className="font-sans text-base font-medium text-muted-foreground">
         Project
       </h3>

--- a/src/components/SettingsPopover.tsx
+++ b/src/components/SettingsPopover.tsx
@@ -1,0 +1,71 @@
+// Phase 87 Plan 01 — Settings popover with theme toggle.
+//
+// Renders a gear button in TopBar that opens a Popover containing a "Theme"
+// SegmentedControl (Light / Dark / System). Per D-03, the popover stays open
+// after a segment click — Radix default close-on-outside-click + Escape still
+// apply.
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/Popover";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/Tooltip";
+import { Button } from "@/components/ui/Button";
+import { Settings } from "lucide-react";
+import { useTheme, type ThemeChoice } from "@/hooks/useTheme";
+
+interface SettingsPopoverProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
+];
+
+export function SettingsPopover({
+  open,
+  onOpenChange,
+}: SettingsPopoverProps): JSX.Element {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Settings"
+              data-testid="topbar-settings-button"
+            >
+              <Settings size={16} />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Settings</TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        sideOffset={6}
+        className="w-64"
+        data-testid="settings-popover"
+      >
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <label className="font-sans text-xs font-medium text-muted-foreground">
+              Theme
+            </label>
+            <SegmentedControl
+              value={theme}
+              onValueChange={(v) => setTheme(v as ThemeChoice)}
+              options={THEME_OPTIONS}
+            />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useUIStore } from "@/stores/uiStore";
 import { useCADStore } from "@/stores/cadStore";
 import { useProjectStore } from "@/stores/projectStore";
@@ -5,6 +6,7 @@ import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { exportRenderedImage } from "@/lib/export";
 import { InlineEditableText } from "@/components/ui/InlineEditableText";
 import { Button } from "@/components/ui/Button";
+import { SettingsPopover } from "@/components/SettingsPopover";
 import { PRESETS, type PresetId } from "@/three/cameraPresets";
 import {
   Tooltip,
@@ -99,6 +101,9 @@ export function TopBar({ viewMode }: TopBarProps): JSX.Element {
   const displayValue = draftName ?? activeName;
 
   const show3DControls = viewMode === "3d" || viewMode === "split";
+
+  // Phase 87 THEME-01 — Settings popover open state.
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   return (
     <header className="fixed top-0 left-0 right-0 z-40 h-10 flex items-center justify-between px-3 bg-background/80 backdrop-blur-sm border-b border-border/30">
@@ -208,8 +213,9 @@ export function TopBar({ viewMode }: TopBarProps): JSX.Element {
           <TooltipContent side="bottom">Help &amp; shortcuts</TooltipContent>
         </Tooltip>
 
-        {/* Phase 80 audit removal: Settings button had no onClick handler — dead.
-            Re-introduce when the theme/settings drawer ships (tracked in v1.21 backlog). */}
+        {/* Phase 87 THEME-01 — Settings popover (theme toggle: Light / Dark / System) */}
+        <SettingsPopover open={settingsOpen} onOpenChange={setSettingsOpen} />
+
       </div>
     </header>
   );

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -52,7 +52,7 @@ export default function WelcomeScreen({ onStart }: Props) {
   };
 
   return (
-    <div className="light h-full flex flex-col bg-background">
+    <div className="h-full flex flex-col bg-background">
       {/* Minimal top bar — just the brand */}
       <header className="h-14 bg-background flex items-center px-6 border border-border/50 border-0 border-b">
         <span className="font-sans font-bold text-foreground text-sm tracking-[0.1em]">

--- a/src/components/__tests__/SettingsPopover.test.tsx
+++ b/src/components/__tests__/SettingsPopover.test.tsx
@@ -1,0 +1,140 @@
+// Phase 87 Plan 01 — RED tests for Settings popover + theme toggle.
+// Verifies THEME-01 / THEME-02 / THEME-03 / D-03 (popover stays open).
+//
+// Asserts:
+//  1. TopBar renders a gear button with data-testid="topbar-settings-button".
+//  2. Clicking the gear opens a popover with "Theme" header + 3 segments.
+//  3. localStorage["room-cad-theme"]="dark" → "Dark" segment aria-checked=true.
+//  4. Click Light → .dark removed from <html>; Click Dark → .dark added;
+//     Click System → class follows mocked matchMedia.
+//  5. D-03 — popover stays open after segment click.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { TopBar } from "@/components/TopBar";
+import { TooltipProvider } from "@/components/ui/Tooltip";
+
+// Provide deterministic matchMedia for System mode (no dark OS pref).
+function mockMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+function renderTopBar() {
+  return render(
+    <TooltipProvider>
+      <TopBar viewMode="2d" onViewChange={() => {}} />
+    </TooltipProvider>,
+  );
+}
+
+describe("SettingsPopover — Phase 87 (THEME-01/02/03, D-03)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    mockMatchMedia(false); // System default to light
+  });
+
+  it("renders a gear button with data-testid=topbar-settings-button in TopBar", () => {
+    renderTopBar();
+    const gear = screen.getByTestId("topbar-settings-button");
+    expect(gear).toBeInTheDocument();
+    expect(gear).toHaveAttribute("aria-label", "Settings");
+  });
+
+  it("clicking the gear opens a popover with Theme header + Light/Dark/System segments", () => {
+    renderTopBar();
+    const gear = screen.getByTestId("topbar-settings-button");
+    fireEvent.click(gear);
+
+    // Popover body should be in the DOM after open
+    expect(screen.getByTestId("settings-popover")).toBeInTheDocument();
+    // Theme section header
+    expect(screen.getByText("Theme")).toBeInTheDocument();
+    // Three radio options
+    const radios = screen.getAllByRole("radio");
+    const labels = radios.map((r) => r.textContent?.trim());
+    expect(labels).toEqual(expect.arrayContaining(["Light", "Dark", "System"]));
+    expect(radios).toHaveLength(3);
+  });
+
+  it("when localStorage room-cad-theme=dark, Dark segment is aria-checked", () => {
+    localStorage.setItem("room-cad-theme", "dark");
+    renderTopBar();
+    fireEvent.click(screen.getByTestId("topbar-settings-button"));
+
+    const radios = screen.getAllByRole("radio");
+    const darkRadio = radios.find((r) => r.textContent?.trim() === "Dark");
+    const lightRadio = radios.find((r) => r.textContent?.trim() === "Light");
+    const systemRadio = radios.find((r) => r.textContent?.trim() === "System");
+
+    expect(darkRadio).toHaveAttribute("aria-checked", "true");
+    expect(lightRadio).toHaveAttribute("aria-checked", "false");
+    expect(systemRadio).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("clicking Dark adds .dark to <html>; clicking Light removes it", () => {
+    renderTopBar();
+    fireEvent.click(screen.getByTestId("topbar-settings-button"));
+
+    const radios = screen.getAllByRole("radio");
+    const lightRadio = radios.find((r) => r.textContent?.trim() === "Light")!;
+    const darkRadio = radios.find((r) => r.textContent?.trim() === "Dark")!;
+
+    act(() => {
+      fireEvent.click(darkRadio);
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("room-cad-theme")).toBe("dark");
+
+    act(() => {
+      fireEvent.click(lightRadio);
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(localStorage.getItem("room-cad-theme")).toBe("light");
+  });
+
+  it("clicking System follows matchMedia (dark OS pref → .dark applied)", () => {
+    // System pref = dark
+    mockMatchMedia(true);
+    renderTopBar();
+    fireEvent.click(screen.getByTestId("topbar-settings-button"));
+
+    const radios = screen.getAllByRole("radio");
+    const systemRadio = radios.find((r) => r.textContent?.trim() === "System")!;
+
+    act(() => {
+      fireEvent.click(systemRadio);
+    });
+    expect(localStorage.getItem("room-cad-theme")).toBe("system");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("D-03 — popover stays open after a segment is clicked", () => {
+    renderTopBar();
+    fireEvent.click(screen.getByTestId("topbar-settings-button"));
+    expect(screen.getByText("Theme")).toBeInTheDocument();
+
+    const radios = screen.getAllByRole("radio");
+    const darkRadio = radios.find((r) => r.textContent?.trim() === "Dark")!;
+    act(() => {
+      fireEvent.click(darkRadio);
+    });
+
+    // Popover still open
+    expect(screen.queryByTestId("settings-popover")).toBeInTheDocument();
+    expect(screen.getByText("Theme")).toBeInTheDocument();
+  });
+});

--- a/tests/e2e/specs/theme-toggle.spec.ts
+++ b/tests/e2e/specs/theme-toggle.spec.ts
@@ -1,0 +1,119 @@
+// Phase 87 Plan 01 — E2E for theme toggle (THEME-03, THEME-04, THEME-05).
+//
+// Verifies:
+//  1. Click gear → click Dark → <html> gains .dark class.
+//  2. Reload → .dark persists on first paint (boot bridge).
+//     Then click Light → class removed; reload → class still absent.
+//  3. After Dark, HelpPage opens with <html class="dark"> intact (D-04 wrapper
+//     removal — no .light force-wrapper overrides token cascade).
+
+import { test, expect } from "@playwright/test";
+import { setupPage } from "../playwright-helpers/setupPage";
+
+test.describe("Theme toggle + persistence (Phase 87)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Reset theme before each test so we control initial state.
+    await page.addInitScript(() => {
+      try {
+        localStorage.removeItem("room-cad-theme");
+      } catch {
+        /* about:blank */
+      }
+    });
+  });
+
+  test("THEME-03 — click gear → Dark adds .dark; Light removes it", async ({ page }) => {
+    await setupPage(page);
+
+    const gear = page.locator('[data-testid="topbar-settings-button"]');
+    await expect(gear).toBeVisible();
+    await gear.click();
+
+    const popover = page.locator('[data-testid="settings-popover"]');
+    await expect(popover).toBeVisible();
+
+    await popover.getByRole("radio", { name: "Dark" }).click();
+    const hasDarkAfterClick = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+    expect(hasDarkAfterClick).toBe(true);
+
+    await popover.getByRole("radio", { name: "Light" }).click();
+    const hasDarkAfterLight = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+    expect(hasDarkAfterLight).toBe(false);
+  });
+
+  test("THEME-05 — choice persists across reload (no flash)", async ({ page }) => {
+    await setupPage(page);
+
+    // Set Dark
+    await page.locator('[data-testid="topbar-settings-button"]').click();
+    await page
+      .locator('[data-testid="settings-popover"]')
+      .getByRole("radio", { name: "Dark" })
+      .click();
+
+    // Reload — boot bridge in index.html should add .dark before React mounts
+    await page.reload();
+    await page.waitForLoadState("domcontentloaded");
+
+    const hasDarkOnReload = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+    expect(hasDarkOnReload).toBe(true);
+
+    // Now switch to Light, reload, verify .dark is absent
+    await page.locator('[data-testid="topbar-settings-button"]').click();
+    await page
+      .locator('[data-testid="settings-popover"]')
+      .getByRole("radio", { name: "Light" })
+      .click();
+    await page.reload();
+    await page.waitForLoadState("domcontentloaded");
+
+    const hasDarkAfterReloadLight = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+    expect(hasDarkAfterReloadLight).toBe(false);
+  });
+
+  test("THEME-04 — HelpPage inherits .dark cascade (no .light force-wrapper)", async ({
+    page,
+  }) => {
+    await setupPage(page);
+
+    // Toggle Dark
+    await page.locator('[data-testid="topbar-settings-button"]').click();
+    await page
+      .locator('[data-testid="settings-popover"]')
+      .getByRole("radio", { name: "Dark" })
+      .click();
+
+    // Close settings popover (Escape) so Help button is clickable
+    await page.keyboard.press("Escape");
+
+    // Open Help
+    await page.locator('[data-onboarding="help-button"]').click();
+
+    // <html> still has .dark, AND no descendant has .light class on root chrome
+    const hasDarkHtml = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+    expect(hasDarkHtml).toBe(true);
+
+    // Assert no node has class "light" as its standalone root-wrapper marker
+    const lightWrappers = await page.evaluate(() => {
+      // Look for any div whose className starts with "light " (force-wrapper pattern)
+      const all = document.querySelectorAll("div");
+      let count = 0;
+      all.forEach((d) => {
+        const cls = d.getAttribute("class") || "";
+        if (cls.split(" ")[0] === "light") count++;
+      });
+      return count;
+    });
+    expect(lightWrappers).toBe(0);
+  });
+});

--- a/tests/e2e/specs/theme-toggle.spec.ts
+++ b/tests/e2e/specs/theme-toggle.spec.ts
@@ -9,21 +9,17 @@
 
 import { test, expect } from "@playwright/test";
 import { setupPage } from "../playwright-helpers/setupPage";
+import { seedRoom } from "../playwright-helpers/seedRoom";
 
 test.describe("Theme toggle + persistence (Phase 87)", () => {
-  test.beforeEach(async ({ page }) => {
-    // Reset theme before each test so we control initial state.
-    await page.addInitScript(() => {
-      try {
-        localStorage.removeItem("room-cad-theme");
-      } catch {
-        /* about:blank */
-      }
-    });
-  });
+  // No beforeEach init-script reset — that would clobber localStorage on the
+  // reload step in THEME-05, defeating the persistence check. Each test sets
+  // its own theme explicitly via the gear UI and starts from a clean profile
+  // (Playwright spins up a fresh browser context per test by default).
 
   test("THEME-03 — click gear → Dark adds .dark; Light removes it", async ({ page }) => {
     await setupPage(page);
+    await seedRoom(page);
 
     const gear = page.locator('[data-testid="topbar-settings-button"]');
     await expect(gear).toBeVisible();
@@ -47,6 +43,7 @@ test.describe("Theme toggle + persistence (Phase 87)", () => {
 
   test("THEME-05 — choice persists across reload (no flash)", async ({ page }) => {
     await setupPage(page);
+    await seedRoom(page);
 
     // Set Dark
     await page.locator('[data-testid="topbar-settings-button"]').click();
@@ -63,6 +60,9 @@ test.describe("Theme toggle + persistence (Phase 87)", () => {
       document.documentElement.classList.contains("dark"),
     );
     expect(hasDarkOnReload).toBe(true);
+
+    // Re-seed for the Light leg (page reload reset hasStarted)
+    await seedRoom(page);
 
     // Now switch to Light, reload, verify .dark is absent
     await page.locator('[data-testid="topbar-settings-button"]').click();
@@ -83,6 +83,7 @@ test.describe("Theme toggle + persistence (Phase 87)", () => {
     page,
   }) => {
     await setupPage(page);
+    await seedRoom(page);
 
     // Toggle Dark
     await page.locator('[data-testid="topbar-settings-button"]').click();


### PR DESCRIPTION
## Summary

Re-adds the Settings gear button to the TopBar (which I deleted in Phase 80 audit cleanup because it had no `onClick`). Wires it to the existing `useTheme` infrastructure from Phase 71 with a working Light / Dark / System toggle. Removes the 3 dark-only force-wrappers so the toggle works everywhere.

| Task | Commit | What |
|------|--------|------|
| 1 | `99ef73d` | RED tests — unit spec for SettingsPopover + e2e for theme persistence |
| 2 | `e2be551` | `SettingsPopover.tsx` with Radix Popover + SegmentedControl (Light/Dark/System). Gear button back in TopBar with `data-testid="topbar-settings-button"` |
| 3 | `5a0c9f9` | Remove `.light` force-wrappers from WelcomeScreen.tsx + ProjectManager.tsx + HelpPage.tsx (D-04) |
| 4 | `e8659d3` | Test wiring fixes (seedRoom in e2e, addInitScript cleanup) |
| docs | `0e39249` | SUMMARY + STATE + ROADMAP |

## Closes

No GH issue tracked this work directly — surfaced from a Jessica observation tonight that the dead settings gear needed to actually do something, and the app needed a theme toggle.

## Locked decisions (CONTEXT.md D-01 through D-05)

- **D-01** Standalone polish phase (no v1.xx milestone — Polish Phases section added to ROADMAP)
- **D-02** SegmentedControl with 3 options (Light / Dark / System) — reuses existing Phase 72 primitive
- **D-03** Popover stays open until outside click / Escape (does NOT close on selection)
- **D-04** All 3 `.light` force-wrappers removed: WelcomeScreen, ProjectManager, HelpPage
- **D-05** Theme-only popover content in v1 — no placeholder rows for future settings

## Test plan

- [x] 1113 vitest tests pass (+6 new SettingsPopover specs; 0 regressions)
- [x] 3 e2e tests pass on chromium-dev (theme persistence + dark/light switching)
- [x] TypeScript clean
- [x] Verification 7/7 automated checks pass
- [ ] **Manual UAT** after merge:
  - Click gear in TopBar right slot → popover opens
  - Pick Light → app instantly switches to light mode
  - Pick Dark → app instantly switches back
  - Pick System → follows your OS preference
  - Click outside the popover → it closes; reopen → your choice is still active
  - Reload the page → theme persists
  - WelcomeScreen + ProjectManager + Help page all respect the toggle

Spec: `.planning/phases/87-theme-toggle-settings/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)