### PR TITLE
Add user-facing documentation drafts

### DIFF
--- a/docs/3D-MODEL-SOURCING.md
+++ b/docs/3D-MODEL-SOURCING.md
@@ -1,0 +1,96 @@
+# 3D Model Sourcing Guide
+
+A practical guide for finding real 3D model files of furniture and products to use in Room CAD Renderer.
+
+> **Note:** Uploading 3D models is a planned future feature, not shipped yet. Right now the app uses simple textured boxes as 3D placeholders for products. When custom 3D model upload ships, this guide is what you'll use to find the actual shapes — couches that look like couches, lamps that look like lamps, instead of generic boxes.
+
+---
+
+## What is a 3D model file?
+
+A 3D model file describes the shape of a real-world object in three dimensions — every curve, edge, and surface — so a computer can render it from any angle.
+
+Two file types you'll see most often:
+
+- **GLTF / GLB** — the modern, web-friendly format. Stands for "GL Transmission Format." Looks like `couch.glb` or `couch.gltf` plus some texture files. **This is the format the app will prefer.**
+- **OBJ** — older, very common. Looks like `chair.obj`, often paired with a `chair.mtl` material file and some image files.
+
+Other formats you might see (FBX, STL, 3DS, BLEND) — these are usually convertible to GLTF using a free tool called Blender, but you don't need to worry about that. Stick to GLTF or OBJ downloads when possible.
+
+---
+
+## Where to find free 3D models
+
+Five real sources, in rough order of "best for furniture and home design":
+
+1. **[Sketchfab](https://sketchfab.com/)** — huge community library. Use the "Downloadable" filter and the "Free" filter together. Search for things like "sofa", "armchair", "dining table". Check the license — most free models are CC-BY (you can use them, just credit the artist if you ever publish). Models here vary wildly in quality, so look at the preview before downloading.
+
+2. **[Poly Haven](https://polyhaven.com/models)** — free, CC0 (no credit required), and the quality is consistently high. Smaller library, but excellent for textures, materials, and HDRI environment maps. Less furniture-focused but worth checking.
+
+3. **[Free3D](https://free3d.com/)** — older site, big library. Mixed quality. Lots of "free" downloads, but also some paid-only listings — read carefully. Filter by file type to GLTF or OBJ.
+
+4. **[Polycam Library](https://poly.cam/explore)** — photogrammetry-based, meaning the models are made from real photos of real objects. Often very accurate. Look for the "Free" filter.
+
+5. **[CGTrader Free section](https://www.cgtrader.com/free-3d-models)** — most of CGTrader is paid, but they have a substantial free library. Furniture and interior design are well-represented.
+
+---
+
+## Where to find paid 3D models
+
+When free isn't cutting it (you need a specific brand-name couch, or you want top-tier quality):
+
+- **[TurboSquid](https://www.turbosquid.com/)** — the industry standard for professional 3D models. Anything from $5 to several hundred. Big furniture catalog. Models are usually high-quality and well-documented.
+
+- **[CGTrader](https://www.cgtrader.com/)** — similar to TurboSquid, often a little cheaper. Strong interior design section.
+
+For a personal-use tool like this one, free models will usually be plenty. Paid models make sense if you're trying to match a specific real-world product exactly and need it to look photorealistic.
+
+---
+
+## How to tell if a model is good for this app
+
+Not every 3D model is created equal. Some are beautifully optimized for web rendering; others are huge, slow, and a pain to work with. Here's what to look for:
+
+- **Low to medium polygon count.** A "poly" is the smallest triangle a 3D model is made of. For furniture in a room rendering, aim for **under 50,000 polygons per piece**. Most free model sites display the polygon count somewhere on the listing.
+- **Single mesh preferred.** Some models come as one combined shape ("single mesh"); others are split into 20 separate pieces. Single mesh is easier — the app treats the whole thing as one product.
+- **Textures included and embedded.** A GLB file with textures baked in is ideal. If textures come as a separate folder of `.jpg` and `.png` files, the app may or may not load them correctly — verify before relying on it.
+- **Correct scale / units.** The model should be sized in real-world units (meters or feet). A "chair" that's actually 50 feet tall in the file is a headache. Most listings note the unit; if not, you'll discover it the first time you import.
+- **Front of the object faces +Z (or +Y, depending on tool).** This is technical and you can mostly ignore it — but if a model loads in the wrong orientation, the fix is usually to rotate it 90 degrees on placement.
+
+---
+
+## The good-model checklist
+
+Before you click download, run through this:
+
+1. **License is permissive.** CC0, CC-BY, or "free for personal use" — anything restrictive (e.g. "editorial only") isn't worth the headache.
+2. **File format is GLTF, GLB, or OBJ.** Anything else, skip.
+3. **Polygon count under 50,000.** If the listing doesn't say, eyeball the preview — if it looks "smooth and detailed like a movie character", it's probably too high. If it looks "clean and game-ready", you're good.
+4. **Textures look good in the preview.** A model with great geometry but ugly textures will look ugly in the app too.
+5. **Real-world size feels plausible.** Listings often note dimensions — check that a chair is "around 2-3 feet wide", not "0.05 units" (no idea what that means).
+6. **It has a clean preview.** If the preview shows weird floating geometry, holes in the surface, or pieces sticking out at random angles, the model has problems — skip it.
+7. **There are at least a few other downloads / likes / comments.** Vetted by other users = lower risk.
+
+If a model passes all seven, it's a good bet.
+
+---
+
+## What to do if a model is too high-poly
+
+Sometimes you find the perfect model but the polygon count is 500,000 — way too heavy. There are tools that can "decimate" a model (reduce the polygon count while preserving the shape). The most common one is **Blender** (free, open-source). The workflow is: open the model in Blender → apply the Decimate modifier → export back to GLTF.
+
+That said: this is beyond the scope of this app, and beyond what most users should bother with. If a model is too heavy, just find a different one. The web is full of furniture models.
+
+---
+
+## Quick start when 3D upload ships
+
+When the feature lands, the flow will look like this:
+
+1. Find a model online using one of the sources above.
+2. Download the `.glb` or `.gltf` file.
+3. In Room CAD Renderer: Library → Add Product → Upload 3D Model → drop in the file.
+4. Set the real-world dimensions (width / depth / height in feet).
+5. Save. The product is now in your library, and any time you place it in a room, you'll see the real 3D shape instead of a plain box.
+
+Until then, the existing product flow (name + photo + dimensions + material) is what you've got. The 3D view shows your products as textured boxes sized to the dimensions you entered, which is enough to feel out spatial fit even without realistic shapes.

--- a/docs/MAKING-CHANGES.md
+++ b/docs/MAKING-CHANGES.md
@@ -1,0 +1,102 @@
+# Making Changes to Room CAD Renderer
+
+A plain-English guide to changing the app without writing code. Aimed at the person who *uses* the app (Jessica, or anyone in her shoes) and wants to make it work better for them.
+
+---
+
+## What you can change without any code
+
+A lot. The app is designed so the day-to-day editing — the parts you'd want to tweak as you design — all happens through the interface, not through code. Here's what's fully under your control via the UI:
+
+- **Room dimensions.** Change width, length, and ceiling height in the **Room Settings** panel in the sidebar. Type new numbers, hit Enter, the room updates instantly.
+- **Adding more rooms.** Use the **+ Add Room** button in the sidebar's Rooms section. Each project can have multiple rooms, each with their own walls and products.
+- **Walls, doors, windows.** Draw, move, delete, and resize them with the toolbar (see USER-GUIDE.md for the full list).
+- **Uploading new products.** Click **Library → Add Product**, fill in the name, category, real-world dimensions, photo, and material finish. Save. The product is now in your library and reusable across every project.
+- **Swapping materials and finishes.** Each product has a material finish field (wood / fabric / metal / etc.). Edit it in the product's properties.
+- **Labels.** Add text labels anywhere on the canvas with the Label tool (T).
+- **Renaming projects.** Click the project name at the top of the sidebar and type a new one. Auto-saves.
+- **Switching theme.** Settings gear → Light / Dark / System.
+
+If you find yourself wishing the app behaved differently in any of *those* areas, you can usually just do it in the UI — no code needed.
+
+---
+
+## What requires code changes
+
+"Requires code" means: someone (Claude, or a developer) has to edit the app's source files, test the change, and ship a new version of the app. Examples of things that fall into this bucket:
+
+- **New tools in the toolbar** (e.g. "I want a curved-wall tool").
+- **New 3D model formats** (e.g. supporting uploaded GLTF / OBJ furniture models — not built yet).
+- **New product categories** beyond the existing list.
+- **Different snap behavior** (e.g. snap to a 4-inch grid instead of 3 / 6 / 12).
+- **Visual redesign** — colors, fonts, layout, icons.
+- **Bug fixes** — anything that's broken or doesn't work as expected.
+- **New file types you can export** (PDF, DXF, etc.).
+- **Cloud sync, sharing, collaboration** — anything that involves saving outside your own browser.
+
+The good news: you don't need to learn how to code to ask for any of these. Read on.
+
+---
+
+## How to ask Claude for changes
+
+This whole project is built with **Claude Code** — an AI coding assistant. You describe what you want in plain English, Claude proposes a plan, and (if you say go) Claude writes the code, tests it, and ships it. You never have to read or write a line of TypeScript.
+
+The basic flow:
+
+1. **You describe what you want** — in your own words. "I want the door tool to default to a 30-inch door instead of 3 feet." "I want a button that exports the floor plan as a PDF." "When I drag a window, I want it to snap to the center of the wall." The more specific you are about what you'd *see* on screen, the better — but you don't need to know the technical terms.
+2. **Claude proposes a plan** — a short writeup of what it would change, where, and what could go wrong. You read it. If anything looks off, you push back ("no, I meant the door tool, not the window tool"). If it looks right, you say go.
+3. **Claude ships it** — writes the code, runs tests, opens a Pull Request (PR). You can ignore the technical details. The important part: it gives you a link to a deployed version of the change so you can click around and feel it.
+4. **You test it** — actually use the new behavior. Does it do what you wanted? Did it accidentally break something else? Take a few minutes. There's no rush.
+5. **You say "merged"** — and Claude finishes the deploy. Now the change is in your main app for good.
+
+If the change doesn't feel right, you say "back it out" and Claude undoes it. No commitment until you're happy.
+
+---
+
+## The GSD workflow (at a high level)
+
+GSD ("Get Stuff Done") is the system this project uses to keep changes organized. You don't need to learn it. But it's helpful to know a few command names so you can drop them in:
+
+- **`/gsd:fast`** — for tiny things. "Change the door default to 30 inches." A two-minute change. Claude just does it.
+- **`/gsd:quick`** — for small things that still deserve a proper test. "Add a 4-inch grid option to the snap dropdown." Claude does it, commits cleanly, opens a PR.
+- **`/gsd:plan-phase`** — for bigger things. "Add full PDF export." Claude writes a detailed plan first, asks you questions to make sure the design is right, *then* builds. Use this when the change spans more than one screen or touches multiple features.
+
+If you're not sure which to use, just describe what you want — Claude will pick the right workflow.
+
+---
+
+## How to read a PR before merging it
+
+A PR ("Pull Request") is GitHub's name for a proposed code change. Before you say "merged", you can take a quick look. Here's what to actually pay attention to — and what to safely ignore.
+
+### What to look at
+
+- **The PR title.** Should describe in plain English what changed. ("Add 4-inch snap option" — good. "WIP refactor" — ask Claude what that means.)
+- **The PR description / body.** This is where Claude explains what it did and why. Read it. It should sound like a normal human explanation.
+- **The deployed preview link** (if there is one). This is the magic — click it, you're on a live version of the change. Click around and feel it. Does it work the way you imagined?
+- **Screenshots in the PR.** If Claude attached before/after screenshots, look at them. Anything visually off?
+
+### What to safely ignore
+
+- **The "Files Changed" tab.** This shows the raw code diff. Unless you're curious, you don't need to read it. Trust the preview link and the description.
+- **The "Checks" section.** Green checks = automated tests passed. Red X = something failed. If anything's red, ask Claude "what does this red check mean?" before merging. If everything's green, you're fine.
+- **The branch names** (e.g. `claude/v1.20-phase73`). Internal naming. Doesn't matter.
+- **Lines of code statistics** ("+247 / -89"). Doesn't matter.
+
+### Red flags worth pausing on
+
+- The deploy link doesn't load or shows errors.
+- The behavior change doesn't match what you asked for.
+- Things that *used* to work are now broken (try a few old features).
+- Claude's description mentions a side-effect you didn't ask for ("also refactored the sidebar to use a different layout") — that's scope creep. Push back, ask why.
+
+If anything feels off, say so. You don't need to know what's wrong technically — "the canvas is laggy now" or "the doors look weird in 3D" is plenty of information.
+
+---
+
+## TL;DR
+
+- You can change almost everything about *the design itself* through the UI. Try the UI first.
+- For everything else, describe what you want in plain English, let Claude propose a plan, click the preview link to test, and say "merged" when it feels right.
+- You never need to read code. You do need to actually test the change before merging.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1,0 +1,113 @@
+# Room CAD Renderer — User Guide
+
+A plain-English walk-through of how to use the app. Five minutes, start to finish.
+
+---
+
+## What this app does
+
+Room CAD Renderer lets you draw a real-world-accurate floor plan of a room (in feet and inches), drop in furniture and products you've actually picked out, then flip to a 3D view to see what the space will look like. Think of it as a sketch pad for a room you're planning to design — but every wall, door, window, and couch is sized to scale, so you can tell whether things will actually fit.
+
+The magic moment: you upload a photo of a couch you found online, place it in a room with the real wall lengths, switch to 3D, and feel whether it works *before* spending money.
+
+---
+
+## Starting a new floor plan
+
+When you open the app, you'll see the **Welcome screen** with the title "Design Your Space" and two big tiles in the middle:
+
+1. **CREATE FLOOR PLAN** — click this for a brand-new project. A template picker pops up with four pre-drawn shapes (rectangle, L-shape, etc.) plus a "blank" option. Pick one and you're dropped straight into the 2D editor.
+2. **UPLOAD FLOOR PLAN** — click this if you already have a floor-plan image (a screenshot, a builder's PDF page, anything). The app drops it onto the canvas so you can trace walls on top of it.
+
+If you've saved projects before, a third tile appears: **OPEN PROJECT**. Click it and you'll see a list of saved projects with their dates — click any one to reopen it.
+
+---
+
+## The 2D canvas — what each tool does
+
+Once you're in the editor, you'll see a floating toolbar pinned to the bottom-center of the screen. The tools are grouped by what they do:
+
+### Drawing group
+
+- **Select (V)** — the arrow icon. Click any wall or object to select it. Drag to move it. Press Delete to remove it.
+- **Wall (W)** — the line icon. Click once to set the wall's start point, click again to set the end point. Hold **Shift** while drawing to lock the wall to a perfectly horizontal or vertical angle.
+- **Door (D)** — the door icon. Click on any existing wall to drop in a 3-foot door opening.
+- **Window (N)** — the rectangle icon. Click on any existing wall to drop in a 3-foot window opening.
+- **Wall cutouts** — the small chevron next to the window tool. Opens a dropdown of extra cutout types (passthrough, etc.).
+- **Product** — the box icon. Once you've picked a product from the Library (see "Placing products" below), this tool is what you use to drop it onto the canvas.
+
+### Measure group
+
+- **Measure (M)** — the ruler icon. Click two points on the canvas to draw a measurement line between them. Useful for double-checking distances without permanently placing anything.
+- **Label (T)** — the text icon. Click anywhere to drop a text label (e.g. "kitchen", "north wall").
+
+### Structure group
+
+- **Ceiling (C)** — the triangle icon. Adds a ceiling element to the active room.
+- **Stairs** — the footprints icon. Click on the canvas to place a staircase. Width and step count can be tweaked in the properties panel after placement.
+- **Column** — for placing structural support columns (rectangular pillars).
+
+### View group
+
+Four buttons that switch what you're looking at:
+
+- **2D** — the floor plan (top-down).
+- **3D** — the rendered 3D view (use your mouse to orbit the camera).
+- **Split** — 2D on the left, 3D on the right, side by side.
+- **Library** — the full-screen product and material library, where you upload new products.
+
+### Utility group
+
+- **Snap** dropdown — controls how strongly the cursor "snaps" to a grid. Choose from Off, 3 inch, 6 inch, or 1 foot. Default is 6 inch (most things you'd draw line up cleanly).
+- **Display mode** — Normal (all rooms together), Solo (only the active room), or Explode (rooms separated along an axis for inspection).
+- **Undo / Redo** — Ctrl+Z and Ctrl+Shift+Z. The app keeps the last 50 changes.
+
+---
+
+## Placing products
+
+Products are things you put *in* the room — furniture, fixtures, appliances, art. To place one:
+
+1. Click the **Library** button in the View group (or the sidebar's "Library" tab). The product library opens.
+2. Browse or filter by category. Click any product card and choose "Place".
+3. The floating toolbar's **Product** tool becomes active. Move your cursor over the 2D canvas — you'll see a preview of the product shape.
+4. Click anywhere on the canvas to drop it. The product is now placed.
+5. Switch back to the **Select** tool (V) to drag the product around, rotate it via the rotation handle, or resize it by dragging the edge handles.
+
+To add a brand-new product, click **Add Product** in the Library and fill in: name, category, real-world width / depth / height (in feet), a photo, and an optional material finish. Hit Save — it's now in your library forever and reusable across every project.
+
+---
+
+## Switching to 3D view
+
+Click the **3D** button in the View group. The 2D canvas is replaced by a rendered 3D scene of the same floor plan — walls extruded to their real height, doors and windows cut out, products placed where you put them.
+
+Mouse controls:
+
+- **Left-click + drag** — orbit the camera around the room.
+- **Right-click + drag** — pan.
+- **Scroll wheel** — zoom in / out.
+
+To see 2D and 3D at the same time (handy for editing while watching the 3D update live), click **Split**.
+
+---
+
+## Saving and re-opening projects
+
+The app **saves automatically**. Every change you make — drawing a wall, placing a product, renaming the project — is saved to your browser about 2 seconds after you stop interacting.
+
+You'll see the save state in the bottom status bar: **SAVED** when everything's safely stored, **SAVING** mid-save, **SAVE_FAILED** if something went wrong. If you ever see SAVE_FAILED, don't close the tab — the message stays up so you can investigate before you lose work.
+
+To re-open a project later: close the browser, come back, and the app will automatically restore the last project you were working on. To switch to a *different* saved project, click the sidebar's Projects section, or close the current project to return to the Welcome screen and pick from the OPEN PROJECT tile.
+
+---
+
+## Light / dark mode toggle
+
+The app supports both light and dark themes. Click the **gear icon** in the top bar to open Settings, then pick Light, Dark, or System (matches your computer's setting). The choice is remembered next time you open the app.
+
+Dark mode is the default and the more polished experience right now. Light mode works but a few screens (the Welcome screen, the Projects list) intentionally stay dark for visual consistency until a future polish pass.
+
+---
+
+That's the whole app in five minutes. If something here doesn't match what you see on screen, the screenshots in this guide may be slightly out of date — the underlying behavior is described accurately.


### PR DESCRIPTION
## Summary

First-pass drafts of three user-facing markdown docs in `docs/`. Plain English throughout, aimed at a non-developer reader (Jessica). These are starter drafts for Micah to polish in his own voice.

- `docs/USER-GUIDE.md` — Walk-through of the app: Welcome screen, 2D canvas tools by group, placing products, switching to 3D, auto-save, light/dark mode.
- `docs/MAKING-CHANGES.md` — What you can change via the UI vs. what requires code, how to ask Claude for changes, the GSD workflow at a high level, how to read a PR before merging.
- `docs/3D-MODEL-SOURCING.md` — Practical guide to finding GLTF/OBJ models when the 3D upload feature ships. Real source links (Sketchfab, Poly Haven, Free3D, Polycam, CGTrader, TurboSquid), a good-model checklist, and notes on poly-count limits.

No source code modified — docs only. Not linked from README.md or CLAUDE.md yet (Micah will do that during polish).

Closes #31
Closes #32
Closes #33

## Test plan

- [ ] Skim each doc end-to-end as a non-developer reader — does it make sense without prior context?
- [ ] Verify external links resolve (Sketchfab, Poly Haven, Free3D, Polycam, CGTrader, TurboSquid)
- [ ] Cross-check the toolbar tool list in USER-GUIDE.md against the actual FloatingToolbar groups

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>