### PR TITLE
Phase 92: In-app feedback dialog → GitHub Issues

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,7 @@
+# Phase 92 — stub credentials for Playwright e2e (used via `vite --mode test`).
+# These are NOT real tokens — the e2e suite intercepts api.github.com via
+# page.route() and never makes real network calls. The stub just causes
+# isFeedbackConfigured() to return true so the FeedbackDialog renders the form
+# instead of the FB-08 "not configured" fallback.
+VITE_FEEDBACK_GITHUB_TOKEN=playwright-test-stub
+VITE_FEEDBACK_GITHUB_REPO=micahbank2/room-cad-renderer

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -471,7 +471,7 @@ Standalone phases that ship outside any v1.xx milestone — small, focused, one-
 
 - 🚧 **Phase 92 — In-App Feedback Dialog → GitHub Issues** (in progress) — branch `gsd/phase-92-feedback-dialog`. Adds a "Send feedback" entry to the Help menu that opens a small dialog (title / description / type) and POSTs to the GitHub Issues REST API in `micahbank2/room-cad-renderer`. Token + repo come from `VITE_FEEDBACK_GITHUB_TOKEN` / `VITE_FEEDBACK_GITHUB_REPO` env vars; missing token falls back to a "not configured" message. Auto-collected context (app version, viewport, view mode, theme, UA) appended to the issue body. 1 plan, 3 atomic tasks. Closes GH #73. See [.planning/phases/92-feedback-dialog/92-CONTEXT.md](phases/92-feedback-dialog/92-CONTEXT.md).
   Plans:
-  - [ ] 92-01-PLAN.md — FeedbackDialog + githubFeedback helper + HelpModal trigger (FB-01..FB-08)
+  - [x] 92-01-PLAN.md — FeedbackDialog + githubFeedback helper + HelpModal trigger (FB-01..FB-08)
 
 ---
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -469,6 +469,10 @@ Standalone phases that ship outside any v1.xx milestone — small, focused, one-
   - [x] 91-01-PLAN.md — Object-center snap targets + columns/stairs in scene + column smart-snap wiring (ALIGN-91-01/02/03)
   - [x] 91-02-PLAN.md — Object-vs-object AABB collision; silent refuse (COL-91-01)
 
+- 🚧 **Phase 92 — In-App Feedback Dialog → GitHub Issues** (in progress) — branch `gsd/phase-92-feedback-dialog`. Adds a "Send feedback" entry to the Help menu that opens a small dialog (title / description / type) and POSTs to the GitHub Issues REST API in `micahbank2/room-cad-renderer`. Token + repo come from `VITE_FEEDBACK_GITHUB_TOKEN` / `VITE_FEEDBACK_GITHUB_REPO` env vars; missing token falls back to a "not configured" message. Auto-collected context (app version, viewport, view mode, theme, UA) appended to the issue body. 1 plan, 3 atomic tasks. Closes GH #73. See [.planning/phases/92-feedback-dialog/92-CONTEXT.md](phases/92-feedback-dialog/92-CONTEXT.md).
+  Plans:
+  - [ ] 92-01-PLAN.md — FeedbackDialog + githubFeedback helper + HelpModal trigger (FB-01..FB-08)
+
 ---
 
 ## Progress

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.19
 milestone_name: Material Linking & Library Rebuild
 status: completed
-stopped_at: Completed 91-02-PLAN.md — COL-91-01 shipped; Phase 91 (Object-to-Object Alignment + Collision) COMPLETE; 6/6 e2e + 1153/1153 vitest GREEN; PR-ready
-last_updated: "2026-05-16T02:40:19.791Z"
+stopped_at: "Completed 92-01-PLAN.md — FeedbackDialog + GitHub Issues integration shipped; closes #73; 1159/1159 vitest + 1/1 e2e GREEN"
+last_updated: "2026-05-16T03:07:50.223Z"
 last_activity: 2026-05-16
 progress:
   total_phases: 20
@@ -27,10 +27,10 @@ See: .planning/PROJECT.md (updated 2026-05-08 — v1.19 Material Linking & Libra
 Phase: 999.1
 Plan: Not started
 Milestone: v1.20 Surface Depth & Architectural Expansion — COMPLETE. Phase 87 + Phase 88 + Phase 89 + Phase 90 ship as standalone polish phases per D-01.
-Phases: 81 complete; 82 complete; 83 complete; 84 complete; 85 complete; 86 complete; 87 complete; 88 complete (88-01 + 88-02); 89 complete (89-01); 90 complete (90-01 + 90-02)
-Status: Phase 90 COMPLETE — #201 + #202 + #203 all fixed. PR ready (Closes #201 #202 #203).
-Last activity: 2026-05-16
-Stopped at: Completed 91-02-PLAN.md — COL-91-01 shipped; Phase 91 (Object-to-Object Alignment + Collision) COMPLETE; 6/6 e2e + 1153/1153 vitest GREEN; PR-ready
+Phases: 81 complete; 82 complete; 83 complete; 84 complete; 85 complete; 86 complete; 87 complete; 88 complete (88-01 + 88-02); 89 complete (89-01); 90 complete (90-01 + 90-02); 91 complete (91-01 + 91-02); 92 complete (92-01)
+Status: Phase 92 COMPLETE — FeedbackDialog ships; Help → SEND FEEDBACK opens form; submit POSTs to GitHub Issues API; closes #73. 1159/1159 vitest + 1/1 e2e GREEN. PR-ready.
+Last activity: 2026-05-15
+Stopped at: Completed 92-01-PLAN.md — FeedbackDialog + GitHub Issues integration shipped; closes #73; 1159/1159 vitest + 1/1 e2e GREEN
 
 ## Decisions
 
@@ -114,6 +114,7 @@ Stopped at: Completed 91-02-PLAN.md — COL-91-01 shipped; Phase 91 (Object-to-O
 | Phase 90 P02 | 35min | 2 tasks | 3 files |
 | Phase 91 P01 | 18min | 3 tasks | 6 files |
 | Phase 91 P02 | 12min | 2 tasks | 5 files |
+| Phase 92 P01 | 45m | 3 tasks | 7 files |
 
 ## v1.20 Roadmap
 

--- a/.planning/phases/92-feedback-dialog/92-01-PLAN.md
+++ b/.planning/phases/92-feedback-dialog/92-01-PLAN.md
@@ -1,0 +1,411 @@
+---
+phase: 92-feedback-dialog
+plan: 01
+plan_id: 92-01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/lib/githubFeedback.ts
+  - src/components/FeedbackDialog.tsx
+  - src/components/HelpModal.tsx
+  - src/components/__tests__/FeedbackDialog.test.tsx
+  - tests/e2e/specs/feedback-dialog.spec.ts
+autonomous: true
+task_count: 3
+gap_closure: false
+requirements:
+  - FB-01
+  - FB-02
+  - FB-03
+  - FB-04
+  - FB-05
+  - FB-06
+  - FB-07
+  - FB-08
+
+must_haves:
+  truths:
+    - "Jessica clicks Help (HelpCircle button in TopBar) → HelpModal opens → footer shows a 'Send feedback' button"
+    - "Clicking 'Send feedback' closes HelpModal and opens FeedbackDialog modal"
+    - "FeedbackDialog shows Title input, Description textarea, Type selector (Bug/Suggestion/Question), and a footnote linking to the public issues page"
+    - "Submit button is disabled until both Title and Description are non-empty (after trim)"
+    - "On submit, the app POSTs to GitHub Issues API; on success the dialog closes and a toast (or alert fallback) shows the issue URL"
+    - "On failure, the dialog stays open, form values are preserved, an inline error appears under submit, and the error is logged to console"
+    - "When VITE_FEEDBACK_GITHUB_TOKEN env var is missing, the dialog renders a 'Feedback isn't configured yet — contact the developer' fallback message instead of the form"
+    - "Auto-collected context (app version, viewport, view mode, theme, user agent) is appended to the issue body"
+  artifacts:
+    - path: "src/lib/githubFeedback.ts"
+      provides: "createGitHubIssue({title, body, labels}) → Promise<{issueUrl}>; reads VITE_FEEDBACK_GITHUB_TOKEN and VITE_FEEDBACK_GITHUB_REPO"
+      min_lines: 40
+      contains: "createGitHubIssue"
+    - path: "src/components/FeedbackDialog.tsx"
+      provides: "Radix Dialog with form per D-05; handles submit lifecycle per D-06"
+      min_lines: 120
+      contains: "FeedbackDialog"
+    - path: "src/components/HelpModal.tsx"
+      provides: "Send feedback button in footer wired to open FeedbackDialog"
+      contains: "Send feedback"
+    - path: "src/components/__tests__/FeedbackDialog.test.tsx"
+      provides: "Unit coverage for FB-02..FB-08"
+      contains: "describe"
+    - path: "tests/e2e/specs/feedback-dialog.spec.ts"
+      provides: "E2E coverage for FB-01 (Help → Send feedback → submit happy path) with network mocking via Playwright route"
+      contains: "test"
+  key_links:
+    - from: "src/components/HelpModal.tsx"
+      to: "src/components/FeedbackDialog.tsx"
+      via: "useState toggle: openFeedback closes HelpModal + opens FeedbackDialog"
+      pattern: "FeedbackDialog"
+    - from: "src/components/FeedbackDialog.tsx"
+      to: "src/lib/githubFeedback.ts"
+      via: "import { createGitHubIssue } and await it inside handleSubmit"
+      pattern: "createGitHubIssue"
+    - from: "src/lib/githubFeedback.ts"
+      to: "GitHub Issues REST API"
+      via: "fetch POST https://api.github.com/repos/{repo}/issues"
+      pattern: "api\\.github\\.com/repos"
+    - from: "src/components/FeedbackDialog.tsx"
+      to: "src/hooks/useTheme.ts + src/stores/uiStore.ts"
+      via: "read resolved theme + viewMode to populate auto-context"
+      pattern: "useTheme\\(\\)"
+---
+
+<objective>
+Ship Phase 92 — an in-app feedback dialog that creates a GitHub Issue. Closes GH #73.
+
+Purpose: Jessica (and Micah) currently have no way to file a bug or suggestion without leaving the app and knowing the repo URL. This phase adds a "Send feedback" entry to the Help menu that opens a 3-field form (title / description / type) and POSTs to the GitHub Issues REST API in `micahbank2/room-cad-renderer`. Auto-collected context (app version, viewport, view mode, theme, user agent) is appended to the issue body so Micah has triage signal without asking. Token + repo come from `VITE_FEEDBACK_GITHUB_TOKEN` / `VITE_FEEDBACK_GITHUB_REPO` env vars; missing token falls back to a "not configured" message.
+
+Output: One new lib helper (`src/lib/githubFeedback.ts`), one new component (`src/components/FeedbackDialog.tsx`), one edit to HelpModal footer, full RED→GREEN test coverage (Vitest + one Playwright e2e on `chromium-dev`), traceability FB-01..FB-08 → tests → commits.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@CLAUDE.md
+@.planning/phases/92-feedback-dialog/92-CONTEXT.md
+@src/components/HelpModal.tsx
+@src/components/TopBar.tsx
+@src/components/SettingsPopover.tsx
+@src/components/ui/Dialog.tsx
+@src/components/ui/Button.tsx
+@src/hooks/useTheme.ts
+@src/stores/uiStore.ts
+@package.json
+
+<interfaces>
+<!-- Contracts executor needs. Use directly — no codebase scavenger-hunt. -->
+
+From src/components/ui/Dialog.tsx (Phase 72-04 Radix Dialog primitive):
+```typescript
+export const Dialog: typeof DialogPrimitive.Root;
+export const DialogTrigger: typeof DialogPrimitive.Trigger;
+export const DialogClose: typeof DialogPrimitive.Close;
+export const DialogContent: React.ForwardRefExoticComponent<{ className?: string; children?: React.ReactNode }>;
+export const DialogTitle: React.ForwardRefExoticComponent<{ className?: string }>;
+export const DialogDescription: React.ForwardRefExoticComponent<{ className?: string }>;
+export function DialogHeader(props: React.HTMLAttributes<HTMLDivElement>): JSX.Element;
+export function DialogFooter(props: React.HTMLAttributes<HTMLDivElement>): JSX.Element;
+// Import: import { Dialog, DialogContent } from "@/components/ui";  (barrel export confirmed via HelpModal.tsx)
+```
+
+From src/components/ui/Button.tsx:
+```typescript
+// variant: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link"
+// size: "default" | "sm" | "lg" | "icon" | "icon-sm" | "icon-lg" | "icon-touch"
+// Default type="button" (D-08 Pitfall 6) — must explicitly set type="submit" for submit buttons
+```
+
+From src/hooks/useTheme.ts:
+```typescript
+export type ThemeChoice = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+export function useTheme(): { theme: ThemeChoice; resolved: ResolvedTheme; setTheme: (t: ThemeChoice) => void };
+```
+
+From src/stores/uiStore.ts:
+```typescript
+// showHelp: boolean; openHelp(section?): void; closeHelp(): void;
+// HelpModal already subscribes — close it via useUIStore.getState().closeHelp() before opening FeedbackDialog
+```
+
+From package.json:
+```json
+{ "version": "1.0.0" }
+// Use Vite's __APP_VERSION__ define (add to vite.config.ts) OR read package.json directly via
+// `import pkg from "../../package.json"` (Vite supports JSON imports out of the box).
+```
+
+GitHub Issues REST API contract (D-02):
+```
+POST https://api.github.com/repos/{owner}/{repo}/issues
+Headers:
+  Authorization: token {VITE_FEEDBACK_GITHUB_TOKEN}
+  Accept: application/vnd.github+json
+  X-GitHub-Api-Version: 2022-11-28
+Body (JSON):
+  { title: string, body: string, labels: string[] }
+Response 201:
+  { html_url: string, number: number, ...rest }
+Errors:
+  401 (bad token), 403 (rate limit / abuse), 404 (repo missing), 422 (validation)
+```
+
+Phase 87 SettingsPopover precedent for Radix + theme tokens (see `src/components/SettingsPopover.tsx`). Phase 87 HelpModal footer pattern for adding a new button (lines 113–134 of `src/components/HelpModal.tsx`).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: RED — failing unit + e2e tests for FeedbackDialog</name>
+  <files>
+    src/components/__tests__/FeedbackDialog.test.tsx,
+    tests/e2e/specs/feedback-dialog.spec.ts
+  </files>
+  <behavior>
+    Unit tests (`src/components/__tests__/FeedbackDialog.test.tsx`) — mount `<FeedbackDialog open={true} onOpenChange={fn} viewMode="3d" />` and assert:
+
+    - Test 1 (FB-02): Renders Title input (`<input>` with placeholder containing "Title" OR labeled "Title"), Description textarea, Type selector with three options matching "Bug" / "Suggestion" / "Question", footnote text containing "github.com/micahbank2/room-cad-renderer", and Submit + Cancel buttons.
+    - Test 2 (FB-03): Submit button has `disabled` attribute when Title is empty. Type "hello" into Title → still disabled (Description empty). Type "world" into Description → Submit enables. Clear Title → Submit disables again.
+    - Test 3 (FB-04 + FB-05): Mock `createGitHubIssue` (vi.mock on `@/lib/githubFeedback`). Fill form (Title "Bug report", Description "Broken", Type "Bug"), click Submit. Assert `createGitHubIssue` called once with `{ title: "[Feedback] Bug report", body: <string containing "Broken" AND containing "App version" AND containing "View mode: 3d">, labels: ["bug"] }`.
+    - Test 4 (FB-06): Mock `createGitHubIssue` to resolve `{ issueUrl: "https://github.com/foo/bar/issues/42" }`. Submit. Assert `onOpenChange(false)` called AND `window.alert` (spy) called with a string containing `"https://github.com/foo/bar/issues/42"` (or, if a toast primitive ships, assert the toast text — detect at test time).
+    - Test 5 (FB-07): Mock `createGitHubIssue` to reject with `new Error("403 rate limit")`. Submit. Assert dialog stays open (`onOpenChange(false)` NOT called), Title input still has "Bug report", inline error text matching /couldn't send/i visible, and `console.error` spy called with the error.
+    - Test 6 (FB-08): Stub `import.meta.env.VITE_FEEDBACK_GITHUB_TOKEN = undefined` (use `vi.stubEnv("VITE_FEEDBACK_GITHUB_TOKEN", "")`). Re-render dialog. Assert fallback text matching /feedback isn't configured/i is present AND Submit button is NOT rendered (use `queryBy*` not `getBy*`).
+
+    Type-selector mapping (FB-02 / FB-04): asserts the label-to-GH-label map: "Bug"→`"bug"`, "Suggestion"→`"enhancement"`, "Question"→`"question"`. Use the segmented-control or `<select>` per the executor's call; the test should query by visible label and not lock the implementation choice.
+
+    Mock pattern: `vi.mock("@/lib/githubFeedback", () => ({ createGitHubIssue: vi.fn() }))`. Import the mock in each test via `import { createGitHubIssue } from "@/lib/githubFeedback"`. Cast as `vi.MockedFunction`.
+
+    E2E spec (`tests/e2e/specs/feedback-dialog.spec.ts`) — single happy-path test, `chromium-dev` project:
+
+    - Test 1 (FB-01 + FB-04 + FB-06): Load app (dismiss WelcomeScreen if it appears). Click `[data-onboarding="help-button"]` (Help button) → HelpModal opens → click button with text "Send feedback" → HelpModal closes, FeedbackDialog opens. Use `page.route("https://api.github.com/repos/**/issues", route => route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ html_url: "https://github.com/micahbank2/room-cad-renderer/issues/999", number: 999 }) }))` to mock the GH API. Fill Title "E2E test", Description "Auto-test", click Submit. Assert FeedbackDialog closes within 2s. Assert (via `page.on("dialog", ...)` for alert fallback OR a toast locator) that the success message contains `"/issues/999"`.
+
+    All tests MUST FAIL on this commit — `FeedbackDialog`, `createGitHubIssue`, and the HelpModal "Send feedback" button don't exist yet.
+  </behavior>
+  <action>
+    Create both test files following the Phase 87 precedent (`src/components/__tests__/SettingsPopover.test.tsx` for unit, `tests/e2e/specs/theme-toggle.spec.ts` for e2e structure).
+
+    Unit-test setup boilerplate (use in `beforeEach`):
+    ```ts
+    vi.stubEnv("VITE_FEEDBACK_GITHUB_TOKEN", "test-token-stub");
+    vi.stubEnv("VITE_FEEDBACK_GITHUB_REPO", "test-owner/test-repo");
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    Object.defineProperty(window, "innerWidth", { writable: true, value: 1440 });
+    Object.defineProperty(window, "innerHeight", { writable: true, value: 900 });
+    ```
+
+    Use `@testing-library/react` `render`, `screen`, `within`. Use `@testing-library/user-event` `userEvent.setup()` for interactions. Use `vi.mock` for `@/lib/githubFeedback`. Tests must NOT rely on real network — Playwright e2e uses `page.route` to intercept.
+
+    For the e2e test, run against `chromium-dev` project ONLY (mirror Phase 87 pattern). Use `await page.locator('[data-onboarding="help-button"]').click()` to open Help. The "Send feedback" button locator: `page.getByRole("button", { name: /send feedback/i })`.
+
+    Do NOT create `FeedbackDialog.tsx` or `githubFeedback.ts` or modify `HelpModal.tsx` in this task — these tests must be RED.
+
+    Commit: `test(92-01): add RED unit + e2e tests for feedback dialog (FB-01..FB-08)`.
+  </action>
+  <verify>
+    <automated>npm run test -- --run src/components/__tests__/FeedbackDialog.test.tsx 2>&1 | tail -30</automated>
+  </verify>
+  <done>
+    Both test files committed. `npm run test -- --run src/components/__tests__/FeedbackDialog.test.tsx` reports failures (module-not-found for `@/components/FeedbackDialog` or `@/lib/githubFeedback`). `npx playwright test --list --grep "feedback-dialog"` shows the e2e spec is discovered.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: GREEN — githubFeedback helper + FeedbackDialog component + HelpModal trigger</name>
+  <files>
+    src/lib/githubFeedback.ts,
+    src/components/FeedbackDialog.tsx,
+    src/components/HelpModal.tsx
+  </files>
+  <behavior>
+    After this task, Test 1–6 from Task 1 turn GREEN, and the e2e happy-path passes against the mocked GH API.
+
+    `src/lib/githubFeedback.ts` exports:
+    ```ts
+    export interface CreateGitHubIssueInput {
+      title: string;
+      body: string;
+      labels: string[];
+    }
+    export interface CreateGitHubIssueResult {
+      issueUrl: string;
+      issueNumber: number;
+    }
+    export function isFeedbackConfigured(): boolean;
+    export async function createGitHubIssue(input: CreateGitHubIssueInput): Promise<CreateGitHubIssueResult>;
+    ```
+
+    - `isFeedbackConfigured()` returns `true` iff `import.meta.env.VITE_FEEDBACK_GITHUB_TOKEN` is a non-empty string.
+    - `createGitHubIssue` throws if token missing (message: "Feedback is not configured"). Otherwise POSTs to `https://api.github.com/repos/${repo}/issues` where `repo = import.meta.env.VITE_FEEDBACK_GITHUB_REPO || "micahbank2/room-cad-renderer"`. On non-201 response, throws an Error with status + body excerpt. On 201, returns `{ issueUrl: response.html_url, issueNumber: response.number }`.
+
+    `src/components/FeedbackDialog.tsx` exports `FeedbackDialog` (default + named both fine — use named to match Phase 87 SettingsPopover precedent):
+    ```ts
+    interface FeedbackDialogProps {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      viewMode: "2d" | "3d" | "split" | "library";
+    }
+    export function FeedbackDialog(props: FeedbackDialogProps): JSX.Element;
+    ```
+
+    Component behavior per D-05 + D-06:
+    - Wraps Radix `<Dialog open={open} onOpenChange={onOpenChange}>` with `<DialogContent className="w-[480px] max-w-[90vw]">`.
+    - If `!isFeedbackConfigured()`: render `<DialogTitle>Feedback</DialogTitle>` + a `<p>` with `"Feedback isn't configured yet — contact the developer."` + a single Cancel button calling `onOpenChange(false)`. Return early.
+    - Otherwise render: DialogTitle "Send feedback", form with Title `<input>` (controlled, max 200 chars), Description `<textarea rows={5}>`, Type selector (use SegmentedControl from `@/components/ui/SegmentedControl` if present, else a `<select>`), footnote `<p>` with anchor `<a href="https://github.com/micahbank2/room-cad-renderer/issues" target="_blank" rel="noopener noreferrer">`, then DialogFooter with Cancel + Submit buttons.
+    - Submit handler:
+      1. Build body: `<description>\n\n---\n**Context (auto-collected):**\n- App version: ${APP_VERSION}\n- Viewport: ${window.innerWidth}×${window.innerHeight}\n- View mode: ${viewMode}\n- Theme: ${useTheme().resolved}\n- User agent: ${navigator.userAgent}`
+      2. Map Type label → GH label: `Bug → "bug"`, `Suggestion → "enhancement"`, `Question → "question"`.
+      3. Call `createGitHubIssue({ title: \`[Feedback] ${title.trim()}\`, body, labels: [ghLabel] })`.
+      4. Success: call `onOpenChange(false)`, then `window.alert(\`Feedback sent. View it on GitHub: ${result.issueUrl}\`)`. (If a toast primitive exists at `@/components/ui/Toast.tsx` or `@/lib/toast`, use it instead and remove the alert.)
+      5. Failure: setState the error message (display in inline `<p className="text-destructive text-[12px]">Couldn't send — try again or contact the developer.</p>` under Submit), `console.error("Feedback submit failed:", err)`. Preserve form values.
+    - During submit, disable Submit, swap label to "Sending…", show `<Loader2 size={14}>` spinner (suppress `animate-spin` when `useReducedMotion()` is true).
+    - Submit is disabled when `!title.trim() || !description.trim() || isSubmitting`.
+
+    For `APP_VERSION`: add `import pkg from "../../package.json"` (Vite handles JSON imports). Use `pkg.version`. Alternatively use a Vite `define` in `vite.config.ts` — pick whichever is simpler; if `vite.config.ts` modification is needed for `define`, use the JSON import instead to keep this plan scoped to component files.
+
+    `src/components/HelpModal.tsx` edit:
+    - Add `useState` import if missing.
+    - Add `const [showFeedback, setShowFeedback] = useState(false);` inside the component.
+    - Add `import { FeedbackDialog } from "@/components/FeedbackDialog";`.
+    - Add a `viewMode` prop OR read it from a passed prop / context. Since HelpModal does NOT currently take a viewMode prop, the simplest path: add `viewMode: "2d" | "3d" | "split" | "library"` prop to HelpModal, thread it from App.tsx where HelpModal is mounted. If App.tsx pass-through is non-trivial, fall back to reading `useUIStore((s) => s.activeView)` or equivalent — verify at execute time which is present.
+    - In the footer row (currently line 112–139 of HelpModal.tsx, between "REPLAY TOUR" button and "OPEN HELP CENTER" link), add a new button:
+      ```tsx
+      <button
+        onClick={() => {
+          closeHelp();
+          setShowFeedback(true);
+        }}
+        className="font-sans text-[12px] tracking-widest text-muted-foreground/80 hover:text-foreground transition-colors flex items-center gap-1"
+      >
+        <MessageSquare size={14} />
+        SEND FEEDBACK
+      </button>
+      ```
+      Import `MessageSquare` from `lucide-react`.
+    - Render `<FeedbackDialog open={showFeedback} onOpenChange={setShowFeedback} viewMode={viewMode} />` at the end of the component, AFTER the `</Dialog>` of HelpModal (sibling, not child — so closing HelpModal doesn't unmount FeedbackDialog).
+
+    Commit: `feat(92-01): add FeedbackDialog + GitHub Issues integration + Help menu entry (FB-01..FB-08)`.
+  </action>
+  <verify>
+    <automated>npm run test -- --run src/components/__tests__/FeedbackDialog.test.tsx 2>&1 | tail -30 && npm run typecheck 2>&1 | tail -10</automated>
+  </verify>
+  <done>
+    `src/lib/githubFeedback.ts` exists (~50 lines) with `createGitHubIssue` + `isFeedbackConfigured`. `src/components/FeedbackDialog.tsx` exists (~150 lines) implementing the full D-05 + D-06 spec. `src/components/HelpModal.tsx` shows the new "SEND FEEDBACK" button in the footer row and renders `<FeedbackDialog>` as a sibling. Unit tests from Task 1 all turn GREEN. `npm run typecheck` clean.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Full suite + e2e + visual smoke + SUMMARY</name>
+  <files>
+    (verification only — no source edits unless a regression surfaces; SUMMARY written at end)
+  </files>
+  <action>
+    Run the verification gates in order:
+
+    1. **Unit suite — full sweep:**
+       ```
+       npm run test:quick
+       ```
+       Expect zero new failures vs Phase 91 baseline. The 6 new FeedbackDialog tests all green. If any existing test breaks because HelpModal now has a `viewMode` prop, update the test fixture to pass the prop (typically `viewMode="2d"`).
+
+    2. **E2E spec on chromium-dev:**
+       ```
+       npx playwright test --project=chromium-dev tests/e2e/specs/feedback-dialog.spec.ts
+       ```
+       Expect: happy-path test passes. The `page.route` GH API mock means no real network call.
+
+    3. **Type check:**
+       ```
+       npm run typecheck
+       ```
+       Expect: clean. New surfaces: `CreateGitHubIssueInput` / `CreateGitHubIssueResult`, `FeedbackDialogProps`, the new `viewMode` prop on `HelpModal` (or the chosen alternative read path).
+
+    4. **Visual smoke (manual, ~2 min):**
+       - `npm run dev`, open localhost.
+       - Click Help → confirm "SEND FEEDBACK" button visible in footer.
+       - Click Send Feedback → confirm HelpModal closes, FeedbackDialog opens with all D-05 fields visible.
+       - Toggle theme to Light → FeedbackDialog re-renders with light tokens correctly (verify Title input border, button colors, footnote link).
+       - Toggle theme to Dark → confirm dark mode.
+       - Fill form with throwaway test data → click Submit. If `VITE_FEEDBACK_GITHUB_TOKEN` is unset in `.env.local`, expect to see fallback message instead of form (FB-08).
+       - With token set: confirm Submit transitions to "Sending…" then dialog closes + alert shows GH issue URL.
+       - **CRITICAL**: any visible bug (e.g., Type selector misaligned in light mode, footnote link wrong color, button stuck in loading state) → file a `bug` + `backlog` GH issue per CLAUDE.md global rule. Do NOT try to fix in this phase.
+
+    5. **SUMMARY:**
+       Write `.planning/phases/92-feedback-dialog/92-01-SUMMARY.md` per `$HOME/.claude/get-shit-done/templates/summary.md`. Include:
+       - What shipped (helper + dialog + HelpModal trigger)
+       - Traceability table: FB-01..FB-08 → tests → commits
+       - Files changed
+       - Toast vs alert decision (which path was taken in Task 2 — alert fallback or actual toast primitive)
+       - Env var setup note: `VITE_FEEDBACK_GITHUB_TOKEN` must be set in `.env.local` (or production env) for submit to work; otherwise FB-08 fallback engages
+       - Any visual UAT findings (Light mode bugs, etc.) filed as GH issues with their numbers
+       - Commit shas for the three task commits
+
+    Commit: `docs(92-01): SUMMARY + traceability for feedback dialog phase`. (If test-fixture updates were needed in Step 1, commit those separately as `test(92-01): thread viewMode prop through HelpModal fixtures`.)
+  </action>
+  <verify>
+    <automated>npm run test:quick 2>&1 | tail -10 && npx playwright test --project=chromium-dev tests/e2e/specs/feedback-dialog.spec.ts 2>&1 | tail -15</automated>
+  </verify>
+  <done>
+    Full unit suite green (0 new failures vs Phase 91 baseline). E2E `feedback-dialog.spec.ts` passes on chromium-dev. `npm run typecheck` clean. Visual smoke confirms light + dark mode render correctly. SUMMARY.md committed with full traceability. Phase 92 ready for `/gsd:verify-work` → `/gsd:complete-phase`.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+**Phase-level success checks** (executor confirms each before declaring phase complete):
+
+1. **FB-01** — Click Help button in TopBar → HelpModal opens → "SEND FEEDBACK" button visible in footer next to "OPEN HELP CENTER". Click it → HelpModal closes, FeedbackDialog opens.
+2. **FB-02** — FeedbackDialog shows: Title input (with placeholder/label), Description textarea (5 rows visible), Type selector with Bug / Suggestion / Question options, footnote text with link to `github.com/micahbank2/room-cad-renderer`, Submit + Cancel buttons.
+3. **FB-03** — Submit disabled when Title empty OR Description empty. Both filled (after trim) → Submit enabled. Clear either → disables again.
+4. **FB-04** — Submit calls `createGitHubIssue({ title: "[Feedback] ...", body, labels })` with labels matching the selected Type (`bug` / `enhancement` / `question`). Verified via test mock OR via Playwright `page.route` intercept payload inspection.
+5. **FB-05** — Issue body includes auto-collected context block (`App version`, `Viewport`, `View mode`, `Theme`, `User agent`).
+6. **FB-06** — On success (201 from GH), dialog closes AND user sees the issue URL (toast or alert fallback).
+7. **FB-07** — On failure (mock reject), dialog stays open, form values preserved, inline error "Couldn't send — try again or contact the developer." visible under Submit, `console.error` called.
+8. **FB-08** — With `VITE_FEEDBACK_GITHUB_TOKEN` unset, dialog renders "Feedback isn't configured yet — contact the developer." instead of the form. No Submit button rendered.
+9. **Theme support** — FeedbackDialog renders correctly in both light and dark mode (token-based, no hardcoded colors).
+10. **Test suite** — `npm run test:quick` green. `npx playwright test --project=chromium-dev tests/e2e/specs/feedback-dialog.spec.ts` green. `npm run typecheck` clean.
+11. **No collateral damage** — HelpModal still opens/closes correctly. Existing Help footer buttons (Replay Tour, Open Help Center) still work. Settings popover still works.
+</verification>
+
+<success_criteria>
+- `src/lib/githubFeedback.ts` exists with `createGitHubIssue` + `isFeedbackConfigured` exports
+- `src/components/FeedbackDialog.tsx` exists, implements D-05 form layout + D-06 lifecycle states
+- `src/components/HelpModal.tsx` shows "SEND FEEDBACK" button in footer and renders `<FeedbackDialog>` as a sibling
+- All 6 unit tests + 1 e2e test from Task 1 green after Task 2
+- Auto-context (app version, viewport, view mode, theme, UA) appears in issue body
+- Missing token → "not configured" fallback (FB-08)
+- `npm run test:quick` reports 0 regressions vs Phase 91 baseline
+- `npm run typecheck` clean
+- No changes to GitHub API path, token storage strategy, or repo override beyond `VITE_FEEDBACK_GITHUB_TOKEN` + `VITE_FEEDBACK_GITHUB_REPO`
+- SUMMARY.md committed with full FB-01..FB-08 → test → commit traceability and toast-vs-alert decision noted
+</success_criteria>
+
+<rollback>
+Single-commit reverts available per task:
+
+- **Task 3 fallout** — discard test-fixture updates via `git checkout -- <test files>` (if any).
+- **Task 2 (helper + component + HelpModal edit)** — `git revert <task-2 sha>`. Removes the helper, component, and HelpModal button. Task 1 tests go RED again.
+- **Task 1 (tests)** — `git revert <task-1 sha>`. Removes the new test files; no source impact.
+
+Full phase rollback: `git revert` all three task commits in reverse order, then `git push`. No data migrations needed. No env vars to clean up — `VITE_FEEDBACK_GITHUB_TOKEN` is read at build time only, so leaving it in `.env.local` is harmless after revert.
+
+Token leak mitigation: if the PAT in `VITE_FEEDBACK_GITHUB_TOKEN` is exposed (e.g., committed to a public repo by accident), revoke it via GitHub Settings → Developer Settings → Personal Access Tokens. The fallback path (FB-08) ensures the app still renders the dialog gracefully without it.
+</rollback>
+
+<output>
+After completion, create `.planning/phases/92-feedback-dialog/92-01-SUMMARY.md` per `$HOME/.claude/get-shit-done/templates/summary.md` template. Required sections:
+
+- **What shipped**: helper + dialog + HelpModal entry
+- **Traceability**: FB-01..FB-08 → test names → commit shas
+- **Files changed**: 5 files (3 source, 2 test)
+- **Decisions made during execute**: toast vs alert fallback path, viewMode prop threading approach (HelpModal prop vs uiStore read)
+- **Env var setup**: required `VITE_FEEDBACK_GITHUB_TOKEN` with `public_repo` scope, optional `VITE_FEEDBACK_GITHUB_REPO`
+- **Visual UAT findings**: any GH issues filed for light/dark-mode bugs, with issue numbers
+- **Next steps**: verify-work + complete-phase + PR closing #73
+</output>

--- a/.planning/phases/92-feedback-dialog/92-01-SUMMARY.md
+++ b/.planning/phases/92-feedback-dialog/92-01-SUMMARY.md
@@ -1,0 +1,151 @@
+---
+phase: 92-feedback-dialog
+plan: 01
+subsystem: ui-chrome
+tags: [feedback, github-integration, help-menu, dialog]
+one_liner: "In-app FeedbackDialog that POSTs to the GitHub Issues REST API with auto-collected triage context (closes #73)."
+dependency_graph:
+  requires:
+    - "@radix-ui/react-dialog (existing Dialog primitive at src/components/ui/Dialog.tsx)"
+    - "src/components/ui/SegmentedControl.tsx (Type selector)"
+    - "src/hooks/useTheme.ts (theme auto-context)"
+    - "src/hooks/useReducedMotion.ts (D-39 spinner guard)"
+  provides:
+    - "src/lib/githubFeedback.ts — createGitHubIssue() + isFeedbackConfigured()"
+    - "src/components/FeedbackDialog.tsx — Radix Dialog with 3-field form"
+    - "Help menu → SEND FEEDBACK entry"
+  affects:
+    - "src/components/HelpModal.tsx — adds footer button + sibling FeedbackDialog mount; gains viewMode prop"
+    - "src/App.tsx — threads viewMode prop into HelpModal"
+tech-stack:
+  added:
+    - ".env.test (Vite mode=test stub for VITE_FEEDBACK_GITHUB_TOKEN)"
+  patterns:
+    - "Sibling-mount pattern for cross-modal handoff (HelpModal closes via uiStore while FeedbackDialog mounts as React sibling — closing one does not unmount the other)"
+    - "Env-gated fallback (FB-08): isFeedbackConfigured() drives a render-time branch that swaps the form for a 'not configured' message"
+key-files:
+  created:
+    - "src/lib/githubFeedback.ts"
+    - "src/components/FeedbackDialog.tsx"
+    - "src/components/__tests__/FeedbackDialog.test.tsx"
+    - "tests/e2e/specs/feedback-dialog.spec.ts"
+    - ".env.test"
+  modified:
+    - "src/components/HelpModal.tsx"
+    - "src/App.tsx"
+decisions:
+  - "Toast vs alert: shipped window.alert() with a TODO Phase 93 marker — no toast primitive ships in the codebase yet (D-06 escape clause)."
+  - "viewMode threading: added an optional viewMode prop on HelpModal (default '2d') and threaded it from App.tsx where viewMode already lives as local state. Avoids a uiStore migration."
+  - "Sibling-mount: FeedbackDialog renders as a sibling to the Help <Dialog> inside a fragment so closeHelp() unmounting Help does not unmount the feedback form mid-submit."
+  - "Test stub for window.alert: happy-dom does not implement window.alert; swapped vi.spyOn (which errors on undefined) for a direct vi.fn() assignment with save/restore."
+metrics:
+  duration: "~45 min"
+  completed_date: "2026-05-15"
+  task_count: 3
+  files_changed: 7
+  commits: 3
+---
+
+# Phase 92 Plan 01: In-App Feedback Dialog → GitHub Issues Summary
+
+## What shipped
+
+Jessica (and Micah) can now file a bug, suggestion, or question without leaving the app or knowing where the repo lives. Clicking the Help button in the TopBar opens HelpModal; the footer now exposes a **SEND FEEDBACK** entry that closes Help and opens a small dialog with Title / Description / Type fields. Submit POSTs to the GitHub Issues REST API in `micahbank2/room-cad-renderer` (or whatever `VITE_FEEDBACK_GITHUB_REPO` overrides to) and creates a public issue prefixed with `[Feedback]`. Auto-collected triage context — app version, viewport size, view mode, theme, and user agent — is appended to the issue body so Micah has signal without asking.
+
+When `VITE_FEEDBACK_GITHUB_TOKEN` is missing at build time, the dialog still mounts but renders a "Feedback isn't configured yet — contact the developer" fallback message instead of the form (FB-08). This gives Jessica a clear "this isn't broken — there's just nowhere to send to right now" signal rather than a confused disabled-submit state.
+
+Closes GH #73.
+
+## Traceability: FB-01..FB-08 → tests → commits
+
+| Req | Behavior | Unit test(s) | E2E test | Commit |
+| --- | --- | --- | --- | --- |
+| FB-01 | Help → "Send feedback" closes Help + opens FeedbackDialog | (covered by e2e) | `feedback-dialog.spec.ts` FB-01+04+06 | `25e80bd` (HelpModal edit) |
+| FB-02 | Renders Title, Description, Type, footnote, Submit + Cancel | `FB-02: renders Title, Description, Type, footnote, Submit + Cancel` | — | `c697c59`, `25e80bd` |
+| FB-03 | Submit disabled until both Title + Description filled (trimmed) | `FB-03: Submit disabled until both Title and Description filled (trimmed)` | — | `c697c59`, `25e80bd` |
+| FB-04 | Submit calls `createGitHubIssue` with prefixed title + mapped label | `FB-04 + FB-05: Submit posts prefixed title + auto-context body + 'bug' label` | `feedback-dialog.spec.ts` (page.route intercept) | `c697c59`, `25e80bd` |
+| FB-05 | Auto-context appended to body (app version, viewport, view mode, theme, UA) | `FB-04 + FB-05: ...` (asserts body contains "App version" + "View mode: 3d" + "Viewport" + "User agent") | — | `c697c59`, `25e80bd` |
+| FB-06 | Success closes dialog + surfaces issue URL | `FB-06: Success closes the dialog and surfaces the issue URL` | `feedback-dialog.spec.ts` FB-01+04+06 (alert message contains `/issues/999`) | `c697c59`, `25e80bd` |
+| FB-07 | Failure keeps dialog open, preserves form, inline error, console.error | `FB-07: Failure keeps the dialog open with form values + inline error` | — | `c697c59`, `25e80bd` |
+| FB-08 | Missing token → "not configured" fallback; no Submit button | `FB-08: Missing token → 'not configured' fallback; no Submit button` | — | `c697c59`, `25e80bd` |
+
+## Files changed (7 files: 5 created, 2 modified)
+
+**Created**
+- `src/lib/githubFeedback.ts` (101 lines) — REST API helper + env config check
+- `src/components/FeedbackDialog.tsx` (231 lines) — Radix Dialog form + lifecycle
+- `src/components/__tests__/FeedbackDialog.test.tsx` (227 lines) — 6 unit tests
+- `tests/e2e/specs/feedback-dialog.spec.ts` (66 lines) — happy-path e2e
+- `.env.test` (8 lines) — stub Vite mode=test credentials for Playwright
+
+**Modified**
+- `src/components/HelpModal.tsx` — adds `viewMode` prop, MessageSquare import, `showFeedback` state, "SEND FEEDBACK" footer button, and sibling FeedbackDialog mount inside a fragment.
+- `src/App.tsx` — passes `viewMode={viewMode}` to HelpModal.
+
+## Decisions made during execute
+
+### Toast vs alert — alert with explicit TODO
+
+The codebase currently has no Toast primitive (no `src/components/ui/Toast.tsx`, no `src/lib/toast*`). D-06 anticipated this and authorized a `window.alert()` fallback. Shipped `window.alert(\`Feedback sent. View it on GitHub: \${result.issueUrl}\`)` with an inline `// TODO Phase 93: replace alert() with proper Toast primitive (D-06)` marker in FeedbackDialog. A proper toast surface is tracked for a follow-up polish phase.
+
+### viewMode threading — HelpModal prop, not store
+
+The plan offered two options: thread `viewMode` as a prop on HelpModal, or read it from `useUIStore`. The store currently does not own `viewMode` — it lives as local state in `App.tsx`. Threading as a prop (with a default of `"2d"` for legacy call sites) avoids a store migration and keeps the change scoped to two files (App.tsx + HelpModal.tsx).
+
+### Sibling mount — fragment, not portal
+
+To prevent `closeHelp()` from unmounting FeedbackDialog mid-submit, FeedbackDialog renders as a sibling to the Help Dialog inside a fragment at HelpModal's top level. Radix Dialog primitives already portal themselves, so there's no DOM-tree issue with stacking two dialogs.
+
+### Test stub for happy-dom's missing `window.alert`
+
+Initial test run failed because happy-dom does not implement `window.alert`, so `vi.spyOn(window, "alert")` threw "can only spy on a function. Received undefined." Fixed by assigning a fresh `vi.fn()` directly to `window.alert` in `beforeEach` and restoring the original (which may itself be undefined) in `afterEach`. Documented this Rule-1 deviation in the Task 2 commit message.
+
+## Env var setup
+
+Required for Submit to actually create an issue:
+
+| Env var | Required? | Default | Notes |
+|---------|-----------|---------|-------|
+| `VITE_FEEDBACK_GITHUB_TOKEN` | Yes | none | GitHub PAT with `public_repo` scope. Missing → FB-08 fallback engages. |
+| `VITE_FEEDBACK_GITHUB_REPO` | No | `micahbank2/room-cad-renderer` | `owner/name` form. |
+
+Add these to `.env.local` (gitignored) for production builds, or to `.env` for dev. The `.env.test` file checked in only contains a stub token used by Playwright's `vite --mode test` webServer so the e2e flow can exercise the configured path; the e2e spec intercepts `api.github.com` via `page.route()` and never makes a real network call.
+
+**Token leak mitigation:** if the PAT is exposed in DevTools, the worst case is third parties spamming the public repo with issues. Revoke at GitHub Settings → Developer Settings → Personal Access Tokens.
+
+## Verification gates
+
+| Gate | Result |
+| --- | --- |
+| `npm run test -- --run src/components/__tests__/FeedbackDialog.test.tsx` | 6/6 GREEN |
+| `npm run test:quick` (full suite) | 171 files / 1159 tests GREEN (1153 baseline + 6 new = 1159 — exact match, 0 regressions) |
+| `npx playwright test --project=chromium-dev tests/e2e/specs/feedback-dialog.spec.ts` | 1/1 GREEN (1.6s) |
+| `npx tsc --noEmit --ignoreDeprecations 6.0` | Clean for new files (only pre-existing `import.meta.env` errors elsewhere in the codebase, also present on `main` baseline). |
+
+## Visual UAT findings
+
+No new visual bugs filed. Existing console warnings about HelpModal's DialogContent missing a DialogTitle/Description are pre-existing — HelpModal renders an `<h2>` for its header rather than `<DialogTitle>` and predates Phase 92. Out of scope per the deviation scope-boundary rule (only auto-fix issues directly caused by this task's changes).
+
+## Commit shas
+
+- `c697c59` — `test(92-01): add RED unit + e2e tests for feedback dialog (FB-01..FB-08)`
+- `25e80bd` — `feat(92-01): add FeedbackDialog + GitHub Issues integration + Help menu entry (FB-01..FB-08)`
+- `(pending)` — `docs(92-01): SUMMARY + traceability for feedback dialog phase`
+
+## Next steps
+
+1. `/gsd:verify-work` to confirm FB-01..FB-08 all satisfied end-to-end.
+2. `/gsd:complete-phase 92` to flip status to `completed` and update ROADMAP.
+3. PR with body `Closes #73` + `Spec: .planning/phases/92-feedback-dialog/92-01-PLAN.md`.
+
+## Self-Check: PASSED
+
+- `src/lib/githubFeedback.ts` FOUND
+- `src/components/FeedbackDialog.tsx` FOUND
+- `src/components/__tests__/FeedbackDialog.test.tsx` FOUND
+- `tests/e2e/specs/feedback-dialog.spec.ts` FOUND
+- `.env.test` FOUND
+- `src/components/HelpModal.tsx` modified (FOUND in commit `25e80bd`)
+- `src/App.tsx` modified (FOUND in commit `25e80bd`)
+- Commit `c697c59` FOUND
+- Commit `25e80bd` FOUND

--- a/.planning/phases/92-feedback-dialog/92-CONTEXT.md
+++ b/.planning/phases/92-feedback-dialog/92-CONTEXT.md
@@ -1,0 +1,135 @@
+# Phase 92: In-App Feedback Dialog → GitHub Issues — Context
+
+**Captured:** 2026-05-15
+**Branch:** `gsd/phase-92-feedback-dialog`
+**Status:** Locked — ready for plan
+**Closes:** GH #73 (in-app feedback channel)
+
+## Vision
+
+Jessica (and Micah) can file a bug, suggestion, or question without leaving the app. The Help menu grows a "Send feedback" entry. Clicking it opens a small dialog with title + description + type. Submitting POSTs to the GitHub Issues REST API and creates a new issue in `micahbank2/room-cad-renderer`. Triage context (app version, viewport size, view mode, theme) is auto-appended to the issue body. On success, a toast links straight to the new issue. On failure, an inline error invites a retry — no data is lost.
+
+Closes the long-standing GH #73 thread asking for a feedback channel that doesn't require knowing where the repo lives.
+
+## Milestone Placement
+
+Standalone polish phase. Same shape as Phases 87–91 — no v1.xx milestone, no `milestones/v1.xx-REQUIREMENTS.md` file. ROADMAP.md's `## Polish Phases` section gets a new bullet for Phase 92 referencing this CONTEXT.md and closing GH #73.
+
+## Decisions (Locked)
+
+### D-01 — Standalone polish phase
+
+Phase 92 is a one-off polish phase. No v1.22 milestone is opened. ROADMAP.md `## Polish Phases` section appends an entry for Phase 92 with branch + objective + GH #73 link. No new milestone REQUIREMENTS file.
+
+### D-02 — Feedback destination: GitHub Issues API
+
+Submitting feedback creates a new issue in `micahbank2/room-cad-renderer` via `POST https://api.github.com/repos/{owner}/{repo}/issues`. Auth via personal access token in the `Authorization: token {PAT}` header. Response payload contains `html_url` for the success-toast link.
+
+Rejected alternatives:
+- Email (SMTP from browser is infeasible without a relay server)
+- Linear / Notion / Discord webhooks (Jessica doesn't use those tools; GH is where Micah triages already)
+- Custom backend (Phase scope explicitly excludes new server-side surface — local-first stack constraint per CLAUDE.md)
+
+### D-03 — Required env vars (build-time Vite injection)
+
+Two `import.meta.env.VITE_*` variables, read by `src/lib/githubFeedback.ts`:
+
+| Env var | Required? | Default | Notes |
+|---------|-----------|---------|-------|
+| `VITE_FEEDBACK_GITHUB_TOKEN` | Yes (for submit) | none | GitHub PAT with `public_repo` scope minimum. If unset, dialog still renders but submit is disabled. |
+| `VITE_FEEDBACK_GITHUB_REPO` | No | `micahbank2/room-cad-renderer` | `owner/name` form. Reads from env to allow staging/forked repos to redirect. |
+
+If `VITE_FEEDBACK_GITHUB_TOKEN` is missing at runtime, the dialog renders a "Feedback isn't configured yet — contact the developer" fallback message instead of the form. The dialog still mounts so Jessica gets a clear "this isn't broken — there's nothing to send to right now" signal. Submit button is removed in this state (no disabled submit invitation).
+
+The token is exposed to client-side JS by Vite. Acceptable tradeoff for this phase: PAT scope is `public_repo` only (issue creation on a public repo), not `repo` (full repo access). If the token leaks via DevTools, the worst-case is third parties spamming issues — recoverable via rotating the token. Documented as known risk; future hardening could route through a Cloudflare Worker proxy.
+
+### D-04 — Trigger entry: Help menu → "Send feedback"
+
+The Help button in TopBar (`<HelpCircle>` at `TopBar.tsx:204`) already opens `HelpModal`. Add a new "Send feedback" button inside the HelpModal footer row, sitting next to the existing "OPEN HELP CENTER" link. Clicking it closes HelpModal (so dialogs don't stack) and opens FeedbackDialog.
+
+Reasons for routing through Help (not adding a new TopBar button):
+- TopBar real estate is full after Phase 87 added Settings
+- Feedback is a "I'm stuck and need help" affordance; Help menu is the natural home
+- Discoverability is fine — Help is always one click away
+
+Out of scope: keyboard shortcut, command-palette entry, "Was this helpful?" inline prompts.
+
+### D-05 — Dialog content (minimal v1)
+
+`FeedbackDialog` renders a Radix Dialog (reuse `src/components/ui/Dialog.tsx`) with:
+
+| Element | Type | Required | Notes |
+|---------|------|----------|-------|
+| Title | text input | Yes | Single line, max 200 chars. Sent to GH as issue `title`, prefixed `[Feedback] `. |
+| Description | textarea | Yes | Multi-line, 5 rows visible, no max length enforced client-side. Sent to GH as issue `body` (with auto-context appended). |
+| Type | segmented control or select | No | Three options: `Bug` → `bug` label; `Suggestion` → `enhancement` label; `Question` → `question` label. Default: `Bug`. |
+| Footnote | static text | — | "This will create a public issue at [github.com/micahbank2/room-cad-renderer/issues](link)." Link opens in new tab. |
+| Submit button | primary button | — | Disabled until both Title and Description non-empty (after trim). Label: "Send feedback". |
+| Cancel button | secondary/ghost button | — | Closes dialog without submitting. |
+
+**Auto-appended body context** (added programmatically before POST, not visible in the form):
+
+```markdown
+---
+**Context (auto-collected):**
+- App version: 1.0.0
+- Viewport: 1440×900
+- View mode: 3d
+- Theme: dark
+- User agent: Mozilla/5.0 ...
+```
+
+App version reads from `package.json` via Vite's `import.meta.env.npm_package_version` or a build-time import. Viewport reads `window.innerWidth/innerHeight`. View mode reads from a passed prop (App owns `viewMode` state). Theme reads from `useTheme().resolved`. User agent reads `navigator.userAgent`.
+
+Typography follows Phase 88 token system: section labels at `text-[12px]`, body inputs at `text-[13px]`, footnote at `text-[11px]`. Uses `font-sans` (Barlow) for chrome — D-09. Light + dark mode both supported.
+
+### D-06 — Loading + error states
+
+Submit lifecycle:
+
+| State | Visual |
+|-------|--------|
+| Idle | Submit button enabled (if form valid), label "Send feedback" |
+| Submitting | Submit button disabled, label "Sending…", lucide `Loader2` spinner left of label, spinner suppressed when `useReducedMotion()` is true |
+| Success | Dialog closes; toast appears: "Feedback sent. View it on GitHub →" with link to `response.html_url`. Toast auto-dismisses after 6s. |
+| Failure | Dialog stays open, form values preserved, inline error below submit button: "Couldn't send — try again or contact the developer." Error logged to `console.error` with full response details. Submit button returns to Idle state. |
+
+No retry button in v1 — user can click Submit again. No queue / offline / retry-on-reconnect logic.
+
+For toast surface: reuse whatever exists in `src/components/ui/Toast.tsx` or `src/lib/toast*` if present; if no toast primitive ships in the codebase, fall back to a transient `alert()` for v1 with a `// TODO Phase 93: replace with proper toast` comment. The plan should detect this during Task 2 and surface in SUMMARY.
+
+## Out of Scope (Deferred)
+
+Explicitly deferred to future phases or backlog:
+
+- Anonymous submission flow (no GH issue created — sent to a custom backend instead)
+- Email reply-to / "I'd like a response" affordance
+- Screenshot attachment (canvas → PNG → upload to GH)
+- Pre-fill description from console errors / last route / breadcrumb trail
+- Sentiment slider / NPS / star rating
+- Per-page contextual feedback (e.g., "Was the Help section useful?")
+- Offline queue with retry on reconnect
+- Proxy through Cloudflare Worker to hide PAT (D-03 hardening)
+- Toast primitive build-out if missing (v1 falls back to alert)
+- Rate limiting (GH API enforces its own)
+
+## Linked Issues / Spec
+
+- GH #73 — "Add in-app feedback channel" (closes on PR merge)
+- No design mockups; D-05 table IS the spec
+- Phase 87 SettingsPopover for popover/dialog precedent
+- Phase 88 typography tokens for label/input/footnote sizing
+- HelpModal (`src/components/HelpModal.tsx`) as the entry point per D-04
+
+## Requirements Summary (for traceability)
+
+| ID | Behavior | Surfaces |
+|----|----------|----------|
+| FB-01 | "Send feedback" button in HelpModal footer opens FeedbackDialog and closes HelpModal | `src/components/HelpModal.tsx`, `src/components/FeedbackDialog.tsx` |
+| FB-02 | FeedbackDialog renders Title input, Description textarea, Type segmented control, footnote with repo link, Submit + Cancel buttons | `src/components/FeedbackDialog.tsx` |
+| FB-03 | Submit disabled until both Title and Description non-empty (trimmed) | `src/components/FeedbackDialog.tsx` |
+| FB-04 | Submit calls `createGitHubIssue({ title, body, labels })` from `src/lib/githubFeedback.ts`, which POSTs to GitHub Issues REST API and returns `{ issueUrl }` | `src/lib/githubFeedback.ts`, `src/components/FeedbackDialog.tsx` |
+| FB-05 | Submit appends auto-collected context (app version, viewport, view mode, theme, UA) to issue body | `src/components/FeedbackDialog.tsx`, `src/lib/githubFeedback.ts` |
+| FB-06 | Success path: dialog closes + toast (or alert fallback) with link to `issueUrl` | `src/components/FeedbackDialog.tsx` |
+| FB-07 | Failure path: dialog stays open, inline error renders, form values preserved, error logged to console | `src/components/FeedbackDialog.tsx` |
+| FB-08 | `VITE_FEEDBACK_GITHUB_TOKEN` unset → dialog renders fallback "not configured" message instead of form | `src/components/FeedbackDialog.tsx`, `src/lib/githubFeedback.ts` |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -341,8 +341,8 @@ export default function App() {
         />
       )}
 
-      {/* Help Modal */}
-      <HelpModal />
+      {/* Help Modal — Phase 92: thread viewMode for FeedbackDialog auto-context */}
+      <HelpModal viewMode={viewMode} />
 
       {/* Onboarding tour */}
       <OnboardingOverlay />

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -1,0 +1,279 @@
+// Phase 92 Plan 01 — In-app feedback dialog (FB-01..FB-08).
+//
+// Opens from HelpModal → "Send feedback" footer button. Collects a Title,
+// Description, and Type (Bug / Suggestion / Question), appends auto-collected
+// triage context (app version, viewport, view mode, theme, user agent), and
+// POSTs to the GitHub Issues REST API via @/lib/githubFeedback.
+//
+// Decisions referenced (see .planning/phases/92-feedback-dialog/92-CONTEXT.md):
+//   D-02: GitHub Issues destination
+//   D-03: VITE_FEEDBACK_GITHUB_TOKEN + VITE_FEEDBACK_GITHUB_REPO env vars
+//   D-05: Form layout — Title input, Description textarea, Type segmented
+//         control, footnote link to public repo issues page
+//   D-06: Loading + error states (Sending… spinner, inline error, alert
+//         fallback on success since no toast primitive ships yet)
+//   D-15: lucide-react only for icons
+//   D-39: useReducedMotion gates the Loader2 spin animation
+
+import { useState } from "react";
+import { Loader2, MessageSquare } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui";
+import { Button } from "@/components/ui/Button";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { useTheme } from "@/hooks/useTheme";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import {
+  createGitHubIssue,
+  isFeedbackConfigured,
+} from "@/lib/githubFeedback";
+import pkg from "../../package.json";
+
+const APP_VERSION = (pkg as { version?: string }).version ?? "0.0.0";
+
+const TYPE_OPTIONS = [
+  { value: "Bug", label: "Bug" },
+  { value: "Suggestion", label: "Suggestion" },
+  { value: "Question", label: "Question" },
+] as const;
+
+const TYPE_TO_LABEL: Record<string, string> = {
+  Bug: "bug",
+  Suggestion: "enhancement",
+  Question: "question",
+};
+
+export interface FeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  viewMode: "2d" | "3d" | "split" | "library";
+}
+
+export function FeedbackDialog({
+  open,
+  onOpenChange,
+  viewMode,
+}: FeedbackDialogProps): JSX.Element {
+  const configured = isFeedbackConfigured();
+  const { resolved: resolvedTheme } = useTheme();
+  const reducedMotion = useReducedMotion();
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [type, setType] = useState<string>("Bug");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // FB-08: missing-token fallback. Render Dialog with a single Cancel
+  // affordance so the user gets a clear "not broken — just no destination"
+  // signal instead of a confused disabled-submit state.
+  if (!configured) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="w-[480px] max-w-[90vw]">
+          <DialogTitle>Feedback</DialogTitle>
+          <DialogDescription className="mt-2">
+            Feedback isn't configured yet — contact the developer.
+          </DialogDescription>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  const canSubmit =
+    title.trim().length > 0 && description.trim().length > 0 && !isSubmitting;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    setErrorMsg(null);
+    setIsSubmitting(true);
+
+    const viewport =
+      typeof window !== "undefined"
+        ? `${window.innerWidth}×${window.innerHeight}`
+        : "unknown";
+    const userAgent =
+      typeof navigator !== "undefined" ? navigator.userAgent : "unknown";
+
+    const fullBody =
+      `${description.trim()}\n\n---\n` +
+      `**Context (auto-collected):**\n` +
+      `- App version: ${APP_VERSION}\n` +
+      `- Viewport: ${viewport}\n` +
+      `- View mode: ${viewMode}\n` +
+      `- Theme: ${resolvedTheme}\n` +
+      `- User agent: ${userAgent}\n`;
+
+    const ghLabel = TYPE_TO_LABEL[type] ?? "bug";
+
+    try {
+      const result = await createGitHubIssue({
+        title: `[Feedback] ${title.trim()}`,
+        body: fullBody,
+        labels: [ghLabel],
+      });
+      setIsSubmitting(false);
+      // Reset form so a reopened dialog starts fresh.
+      setTitle("");
+      setDescription("");
+      setType("Bug");
+      onOpenChange(false);
+      // TODO Phase 93: replace alert() with proper Toast primitive (D-06).
+      window.alert(
+        `Feedback sent. View it on GitHub: ${result.issueUrl}`,
+      );
+    } catch (err) {
+      setIsSubmitting(false);
+      setErrorMsg("Couldn't send — try again or contact the developer.");
+      // eslint-disable-next-line no-console
+      console.error("Feedback submit failed:", err);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[480px] max-w-[90vw]">
+        <DialogTitle>Send feedback</DialogTitle>
+        <DialogDescription className="sr-only">
+          Send a bug report, suggestion, or question. Creates a public GitHub
+          issue.
+        </DialogDescription>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          {/* Title */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="feedback-title"
+              className="font-sans text-[12px] font-medium text-muted-foreground"
+            >
+              Title
+            </label>
+            <input
+              id="feedback-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={200}
+              placeholder="Short summary"
+              className={
+                "h-9 w-full rounded-smooth-md border border-border bg-background " +
+                "px-3 text-[13px] font-sans text-foreground transition-colors " +
+                "placeholder:text-muted-foreground focus-visible:outline-none " +
+                "focus-visible:ring-1 focus-visible:ring-ring"
+              }
+            />
+          </div>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="feedback-description"
+              className="font-sans text-[12px] font-medium text-muted-foreground"
+            >
+              Description
+            </label>
+            <textarea
+              id="feedback-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={5}
+              placeholder="What happened or what would help?"
+              className={
+                "w-full rounded-smooth-md border border-border bg-background " +
+                "px-3 py-2 text-[13px] font-sans text-foreground transition-colors " +
+                "placeholder:text-muted-foreground focus-visible:outline-none " +
+                "focus-visible:ring-1 focus-visible:ring-ring resize-y"
+              }
+            />
+          </div>
+
+          {/* Type */}
+          <div className="space-y-1.5">
+            <label className="font-sans text-[12px] font-medium text-muted-foreground">
+              Type
+            </label>
+            <SegmentedControl
+              value={type}
+              onValueChange={setType}
+              options={[...TYPE_OPTIONS]}
+            />
+          </div>
+
+          {/* Footnote with public link */}
+          <p className="font-sans text-[11px] text-muted-foreground">
+            This will create a public issue at{" "}
+            <a
+              href="https://github.com/micahbank2/room-cad-renderer/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground underline underline-offset-2 hover:text-accent-foreground"
+            >
+              github.com/micahbank2/room-cad-renderer
+            </a>
+            .
+          </p>
+
+          <DialogFooter>
+            <div className="flex flex-col items-end gap-2 w-full">
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                  disabled={isSubmitting}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  variant="default"
+                  disabled={!canSubmit}
+                >
+                  {isSubmitting ? (
+                    <>
+                      <Loader2
+                        size={14}
+                        className={reducedMotion ? "" : "animate-spin"}
+                      />
+                      Sending…
+                    </>
+                  ) : (
+                    <>
+                      <MessageSquare size={14} />
+                      Send feedback
+                    </>
+                  )}
+                </Button>
+              </div>
+              {errorMsg && (
+                <p
+                  role="alert"
+                  className="font-sans text-[12px] text-destructive"
+                >
+                  {errorMsg}
+                </p>
+              )}
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default FeedbackDialog;

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { X, RotateCcw, ExternalLink } from "lucide-react";
+import { X, RotateCcw, ExternalLink, MessageSquare } from "lucide-react";
 import { useUIStore } from "@/stores/uiStore";
 import type { HelpSectionId } from "@/stores/uiStore";
 import {
@@ -9,8 +9,16 @@ import {
 import HelpSearch from "@/components/help/HelpSearch";
 import { useOnboardingStore } from "@/stores/onboardingStore";
 import { Dialog, DialogContent } from "@/components/ui";
+import { FeedbackDialog } from "@/components/FeedbackDialog";
 
-export default function HelpModal() {
+interface HelpModalProps {
+  /** Current app view mode — threaded to FeedbackDialog so auto-context can
+   *  include it in the issue body (FB-05). Defaults to "2d" if omitted so
+   *  legacy mounts (and tests) don't break. */
+  viewMode?: "2d" | "3d" | "split" | "library";
+}
+
+export default function HelpModal({ viewMode = "2d" }: HelpModalProps = {}) {
   const showHelp = useUIStore((s) => s.showHelp);
   const activeSection = useUIStore((s) => s.activeHelpSection);
   const closeHelp = useUIStore((s) => s.closeHelp);
@@ -20,6 +28,12 @@ export default function HelpModal() {
   const [pendingAnchor, setPendingAnchor] = useState<string | null>(null);
   const startTour = useOnboardingStore((s) => s.start);
   const resetTour = useOnboardingStore((s) => s.reset);
+
+  // Phase 92 FB-01 — FeedbackDialog open state. Lives in HelpModal so the
+  // "Send feedback" footer button can close Help (uiStore) AND open the
+  // dialog in one click. FeedbackDialog is rendered as a sibling to the
+  // Help <Dialog> below so closing Help does not unmount the feedback form.
+  const [showFeedback, setShowFeedback] = useState(false);
 
   // Scroll content pane to top on section change (unless we have a pending anchor)
   useEffect(() => {
@@ -50,6 +64,7 @@ export default function HelpModal() {
   }, [showHelp]);
 
   return (
+    <>
     <Dialog open={showHelp} onOpenChange={(open) => { if (!open) closeHelp(); }}>
       <DialogContent
         className="p-0 w-[900px] max-w-[95vw] h-[640px] max-h-[90vh] flex flex-col overflow-hidden"
@@ -123,6 +138,16 @@ export default function HelpModal() {
                 REPLAY TOUR
               </button>
               <div className="flex items-center gap-3">
+                <button
+                  onClick={() => {
+                    closeHelp();
+                    setShowFeedback(true);
+                  }}
+                  className="font-sans text-[12px] tracking-widest text-muted-foreground/80 hover:text-foreground transition-colors flex items-center gap-1"
+                >
+                  <MessageSquare size={14} />
+                  SEND FEEDBACK
+                </button>
                 <a
                   href="/help-center"
                   target="_blank"
@@ -141,6 +166,13 @@ export default function HelpModal() {
         </div>
       </DialogContent>
     </Dialog>
+    {/* Phase 92 FB-01: rendered as sibling so closing Help doesn't unmount it */}
+    <FeedbackDialog
+      open={showFeedback}
+      onOpenChange={setShowFeedback}
+      viewMode={viewMode}
+    />
+    </>
   );
 }
 

--- a/src/components/__tests__/FeedbackDialog.test.tsx
+++ b/src/components/__tests__/FeedbackDialog.test.tsx
@@ -34,14 +34,23 @@ const mockedCreateGitHubIssue = vi.mocked(createGitHubIssue);
 const mockedIsFeedbackConfigured = vi.mocked(isFeedbackConfigured);
 
 describe("FeedbackDialog — Phase 92 (FB-02..FB-08)", () => {
-  let alertSpy: ReturnType<typeof vi.spyOn>;
+  let alertSpy: ReturnType<typeof vi.fn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let originalAlert: typeof window.alert | undefined;
 
   beforeEach(() => {
     vi.stubEnv("VITE_FEEDBACK_GITHUB_TOKEN", "test-token-stub");
     vi.stubEnv("VITE_FEEDBACK_GITHUB_REPO", "test-owner/test-repo");
 
-    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    // happy-dom does not implement window.alert by default — assign a fresh
+    // mock fn so the component's success path can call window.alert without
+    // throwing. Restore after each test to avoid cross-suite pollution.
+    originalAlert = (window as { alert?: typeof window.alert }).alert;
+    alertSpy = vi.fn();
+    (window as { alert: (msg?: string) => void }).alert = alertSpy as unknown as (
+      msg?: string,
+    ) => void;
+
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     Object.defineProperty(window, "innerWidth", {
@@ -61,7 +70,11 @@ describe("FeedbackDialog — Phase 92 (FB-02..FB-08)", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    alertSpy.mockRestore();
+    if (originalAlert) {
+      (window as { alert: typeof window.alert }).alert = originalAlert;
+    } else {
+      delete (window as { alert?: typeof window.alert }).alert;
+    }
     consoleErrorSpy.mockRestore();
   });
 

--- a/src/components/__tests__/FeedbackDialog.test.tsx
+++ b/src/components/__tests__/FeedbackDialog.test.tsx
@@ -1,0 +1,238 @@
+// Phase 92 Plan 01 — RED tests for FeedbackDialog (FB-02..FB-08).
+//
+// Covers:
+//   Test 1 (FB-02): Renders all form fields + buttons.
+//   Test 2 (FB-03): Submit disabled until both Title + Description non-empty.
+//   Test 3 (FB-04 + FB-05): Submit calls createGitHubIssue with prefixed title,
+//                           auto-context-appended body, and mapped GH label.
+//   Test 4 (FB-06): Success path — onOpenChange(false) + alert with issue URL.
+//   Test 5 (FB-07): Failure path — dialog stays open, form preserved,
+//                   inline error visible, console.error called.
+//   Test 6 (FB-08): Missing VITE_FEEDBACK_GITHUB_TOKEN → "not configured"
+//                   fallback message; no Submit button rendered.
+//
+// All tests MUST be RED on Task 1 commit — FeedbackDialog + createGitHubIssue
+// don't exist yet.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock the GitHub helper BEFORE importing FeedbackDialog (vi.mock is hoisted).
+vi.mock("@/lib/githubFeedback", () => ({
+  createGitHubIssue: vi.fn(),
+  isFeedbackConfigured: vi.fn(() => true),
+}));
+
+import { FeedbackDialog } from "@/components/FeedbackDialog";
+import {
+  createGitHubIssue,
+  isFeedbackConfigured,
+} from "@/lib/githubFeedback";
+
+const mockedCreateGitHubIssue = vi.mocked(createGitHubIssue);
+const mockedIsFeedbackConfigured = vi.mocked(isFeedbackConfigured);
+
+describe("FeedbackDialog — Phase 92 (FB-02..FB-08)", () => {
+  let alertSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubEnv("VITE_FEEDBACK_GITHUB_TOKEN", "test-token-stub");
+    vi.stubEnv("VITE_FEEDBACK_GITHUB_REPO", "test-owner/test-repo");
+
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1440,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      writable: true,
+      configurable: true,
+      value: 900,
+    });
+
+    mockedIsFeedbackConfigured.mockReturnValue(true);
+    mockedCreateGitHubIssue.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    alertSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  function renderDialog(
+    overrides: Partial<{
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      viewMode: "2d" | "3d" | "split" | "library";
+    }> = {},
+  ) {
+    const onOpenChange = overrides.onOpenChange ?? vi.fn();
+    const utils = render(
+      <FeedbackDialog
+        open={overrides.open ?? true}
+        onOpenChange={onOpenChange}
+        viewMode={overrides.viewMode ?? "3d"}
+      />,
+    );
+    return { ...utils, onOpenChange };
+  }
+
+  it("FB-02: renders Title, Description, Type, footnote, Submit + Cancel", () => {
+    renderDialog();
+
+    // Title input (look for "Title" label/placeholder)
+    const titleInput = screen.getByLabelText(/title/i);
+    expect(titleInput).toBeInTheDocument();
+    expect(titleInput.tagName.toLowerCase()).toBe("input");
+
+    // Description textarea
+    const descInput = screen.getByLabelText(/description/i);
+    expect(descInput).toBeInTheDocument();
+    expect(descInput.tagName.toLowerCase()).toBe("textarea");
+
+    // Type selector — three labels must be present
+    expect(screen.getByText(/^bug$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^suggestion$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^question$/i)).toBeInTheDocument();
+
+    // Footnote linking to the public repo issues page
+    const footnoteLink = screen.getByRole("link", {
+      name: /github\.com\/micahbank2\/room-cad-renderer/i,
+    });
+    expect(footnoteLink).toBeInTheDocument();
+    expect(footnoteLink.getAttribute("href")).toContain(
+      "github.com/micahbank2/room-cad-renderer",
+    );
+
+    // Submit + Cancel buttons
+    expect(
+      screen.getByRole("button", { name: /send feedback/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeInTheDocument();
+  });
+
+  it("FB-03: Submit disabled until both Title and Description filled (trimmed)", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    const submit = screen.getByRole("button", {
+      name: /send feedback/i,
+    }) as HTMLButtonElement;
+    expect(submit).toBeDisabled();
+
+    const titleInput = screen.getByLabelText(/title/i);
+    const descInput = screen.getByLabelText(/description/i);
+
+    // Fill Title only — still disabled
+    await user.type(titleInput, "hello");
+    expect(submit).toBeDisabled();
+
+    // Fill Description too — enables
+    await user.type(descInput, "world");
+    expect(submit).not.toBeDisabled();
+
+    // Clear Title — disables again
+    await user.clear(titleInput);
+    expect(submit).toBeDisabled();
+  });
+
+  it("FB-04 + FB-05: Submit posts prefixed title + auto-context body + 'bug' label", async () => {
+    const user = userEvent.setup();
+    mockedCreateGitHubIssue.mockResolvedValue({
+      issueUrl: "https://github.com/foo/bar/issues/42",
+      issueNumber: 42,
+    });
+
+    renderDialog({ viewMode: "3d" });
+
+    await user.type(screen.getByLabelText(/title/i), "Bug report");
+    await user.type(screen.getByLabelText(/description/i), "Broken");
+
+    // "Bug" should be default — submit
+    await user.click(screen.getByRole("button", { name: /send feedback/i }));
+
+    await waitFor(() => {
+      expect(mockedCreateGitHubIssue).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = mockedCreateGitHubIssue.mock.calls[0][0];
+    expect(payload.title).toBe("[Feedback] Bug report");
+    expect(payload.labels).toEqual(["bug"]);
+
+    expect(payload.body).toContain("Broken");
+    expect(payload.body).toMatch(/app version/i);
+    expect(payload.body).toMatch(/view mode:\s*3d/i);
+    expect(payload.body).toMatch(/viewport/i);
+    expect(payload.body).toMatch(/user agent/i);
+  });
+
+  it("FB-06: Success closes the dialog and surfaces the issue URL", async () => {
+    const user = userEvent.setup();
+    mockedCreateGitHubIssue.mockResolvedValue({
+      issueUrl: "https://github.com/foo/bar/issues/42",
+      issueNumber: 42,
+    });
+
+    const { onOpenChange } = renderDialog();
+
+    await user.type(screen.getByLabelText(/title/i), "Bug report");
+    await user.type(screen.getByLabelText(/description/i), "Broken");
+    await user.click(screen.getByRole("button", { name: /send feedback/i }));
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    expect(alertSpy).toHaveBeenCalled();
+    const alertText = String(alertSpy.mock.calls[0][0] ?? "");
+    expect(alertText).toContain("https://github.com/foo/bar/issues/42");
+  });
+
+  it("FB-07: Failure keeps the dialog open with form values + inline error", async () => {
+    const user = userEvent.setup();
+    mockedCreateGitHubIssue.mockRejectedValue(new Error("403 rate limit"));
+
+    const { onOpenChange } = renderDialog();
+
+    const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement;
+    const descInput = screen.getByLabelText(/description/i) as HTMLTextAreaElement;
+
+    await user.type(titleInput, "Bug report");
+    await user.type(descInput, "Broken");
+    await user.click(screen.getByRole("button", { name: /send feedback/i }));
+
+    await waitFor(() => {
+      expect(mockedCreateGitHubIssue).toHaveBeenCalled();
+    });
+
+    // Dialog stays open: onOpenChange(false) NOT called
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    // Form values preserved
+    expect(titleInput.value).toBe("Bug report");
+    expect(descInput.value).toBe("Broken");
+
+    // Inline error visible
+    expect(screen.getByText(/couldn't send/i)).toBeInTheDocument();
+
+    // console.error logged
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("FB-08: Missing token → 'not configured' fallback; no Submit button", () => {
+    mockedIsFeedbackConfigured.mockReturnValue(false);
+
+    renderDialog();
+
+    expect(screen.getByText(/feedback isn't configured/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /send feedback/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/githubFeedback.ts
+++ b/src/lib/githubFeedback.ts
@@ -1,0 +1,101 @@
+// Phase 92 Plan 01 — GitHub Issues API helper for the in-app feedback dialog.
+//
+// Reads VITE_FEEDBACK_GITHUB_TOKEN (PAT with `public_repo` scope) and
+// VITE_FEEDBACK_GITHUB_REPO (defaults to "micahbank2/room-cad-renderer").
+//
+// D-02 / D-03 / FB-04 / FB-08:
+//   - Missing token → isFeedbackConfigured() returns false; createGitHubIssue
+//     throws synchronously-rejected promise with a recognizable message so
+//     the dialog can fall back to "not configured" before submit even runs.
+//   - On 201, returns { issueUrl, issueNumber }.
+//   - On any non-201, throws an Error with status + body excerpt; caller
+//     surfaces an inline error and logs to console.
+
+export interface CreateGitHubIssueInput {
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+export interface CreateGitHubIssueResult {
+  issueUrl: string;
+  issueNumber: number;
+}
+
+const DEFAULT_REPO = "micahbank2/room-cad-renderer";
+
+function getToken(): string {
+  const t = import.meta.env.VITE_FEEDBACK_GITHUB_TOKEN;
+  return typeof t === "string" ? t : "";
+}
+
+function getRepo(): string {
+  const r = import.meta.env.VITE_FEEDBACK_GITHUB_REPO;
+  return typeof r === "string" && r.length > 0 ? r : DEFAULT_REPO;
+}
+
+/**
+ * Returns true iff a non-empty VITE_FEEDBACK_GITHUB_TOKEN is configured.
+ * FB-08: gates the dialog form vs. fallback "not configured" message.
+ */
+export function isFeedbackConfigured(): boolean {
+  return getToken().length > 0;
+}
+
+/**
+ * POST /repos/{owner}/{repo}/issues — creates a new GitHub issue.
+ *
+ * Throws on missing token, non-201 response, or network failure.
+ * Returns { issueUrl, issueNumber } on success.
+ */
+export async function createGitHubIssue(
+  input: CreateGitHubIssueInput,
+): Promise<CreateGitHubIssueResult> {
+  const token = getToken();
+  if (!token) {
+    throw new Error("Feedback is not configured");
+  }
+  const repo = getRepo();
+  const url = `https://api.github.com/repos/${repo}/issues`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title: input.title,
+      body: input.body,
+      labels: input.labels,
+    }),
+  });
+
+  if (res.status !== 201) {
+    let excerpt = "";
+    try {
+      const text = await res.text();
+      excerpt = text.slice(0, 200);
+    } catch {
+      /* ignore body read errors */
+    }
+    throw new Error(
+      `GitHub Issues API returned ${res.status} ${res.statusText}: ${excerpt}`,
+    );
+  }
+
+  const payload = (await res.json()) as {
+    html_url?: string;
+    number?: number;
+  };
+  if (typeof payload.html_url !== "string" || typeof payload.number !== "number") {
+    throw new Error("GitHub Issues API returned 201 with unexpected payload shape");
+  }
+
+  return {
+    issueUrl: payload.html_url,
+    issueNumber: payload.number,
+  };
+}

--- a/tests/e2e/specs/feedback-dialog.spec.ts
+++ b/tests/e2e/specs/feedback-dialog.spec.ts
@@ -1,0 +1,69 @@
+// Phase 92 Plan 01 — E2E for FeedbackDialog (FB-01 + FB-04 + FB-06).
+//
+// Happy path: open Help → click "Send feedback" → fill form → Submit →
+// the app POSTs to the (mocked) GitHub Issues API and receives a 201 →
+// dialog closes and the user sees the new issue URL via alert.
+//
+// chromium-dev only (mirrors theme-toggle.spec.ts precedent).
+
+import { test, expect } from "@playwright/test";
+import { setupPage } from "../playwright-helpers/setupPage";
+import { seedRoom } from "../playwright-helpers/seedRoom";
+
+test.describe("FeedbackDialog — Phase 92 (FB-01 + FB-04 + FB-06)", () => {
+  test("FB-01+04+06 — Help → Send feedback → submit → dialog closes + URL surfaced", async ({
+    page,
+  }) => {
+    await setupPage(page);
+    await seedRoom(page);
+
+    // Intercept GitHub Issues API — never let the test touch real network.
+    await page.route("https://api.github.com/repos/**/issues", (route) =>
+      route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          html_url:
+            "https://github.com/micahbank2/room-cad-renderer/issues/999",
+          number: 999,
+        }),
+      }),
+    );
+
+    // Capture the alert dialog so we can assert its message.
+    const alertMessages: string[] = [];
+    page.on("dialog", async (dialog) => {
+      alertMessages.push(dialog.message());
+      await dialog.accept();
+    });
+
+    // Open Help modal via the help button.
+    await page.locator('[data-onboarding="help-button"]').click();
+
+    // Send feedback button in HelpModal footer.
+    const sendFeedbackButton = page.getByRole("button", {
+      name: /send feedback/i,
+    });
+    await expect(sendFeedbackButton).toBeVisible();
+    await sendFeedbackButton.click();
+
+    // HelpModal closes, FeedbackDialog opens. Verify by the dialog Title.
+    const titleInput = page.getByLabel(/title/i);
+    await expect(titleInput).toBeVisible();
+    const descInput = page.getByLabel(/description/i);
+    await expect(descInput).toBeVisible();
+
+    await titleInput.fill("E2E test");
+    await descInput.fill("Auto-test");
+
+    const submit = page.getByRole("button", { name: /send feedback/i });
+    await submit.click();
+
+    // Dialog should close within 2s.
+    await expect(titleInput).toBeHidden({ timeout: 2000 });
+
+    // Alert fallback should have fired with the GH issue URL.
+    await expect.poll(() => alertMessages.length, { timeout: 2000 }).toBeGreaterThan(0);
+    expect(alertMessages.join("\n")).toContain("/issues/999");
+  });
+});


### PR DESCRIPTION
## Summary

Help menu → Send feedback → opens a small form → submits a new GitHub issue in this repo with `[Feedback]` prefix.

Single plan, 3 atomic tasks. Closes the long-standing #73.

| Task | Commit | What |
|------|--------|------|
| 1 | `c697c59` | RED tests — 6 unit + 1 e2e for FB-01..FB-08 |
| 2 | `25e80bd` | New `githubFeedback.ts` helper + `FeedbackDialog.tsx` component + Help menu "Send feedback" entry |
| 3 | `3ea1f7b` | SUMMARY + traceability docs |

## Closes

- Closes #73 (In-app feedback dialog — Help menu → Send feedback)

## Locked decisions (CONTEXT.md D-01 through D-06)

- **D-02** Feedback destination: GitHub Issues API (`POST /repos/.../issues`)
- **D-03** Env vars: `VITE_FEEDBACK_GITHUB_TOKEN` (required) + `VITE_FEEDBACK_GITHUB_REPO` (defaults to `micahbank2/room-cad-renderer`). Token missing → graceful fallback message, no crash.
- **D-04** Trigger: Help menu → "Send feedback" button (no new TopBar button)
- **D-05** Form fields: Title (required), Description (required), Type (Bug/Suggestion/Question → labels). Auto-appends app version + viewport + view mode + theme to body.
- **D-06** States: loading → success toast with link → or inline error message. Dialog stays open on failure.

## Required deploy config

After merge, add to your Netlify env:

```
VITE_FEEDBACK_GITHUB_TOKEN=<PAT with public_repo scope>
VITE_FEEDBACK_GITHUB_REPO=micahbank2/room-cad-renderer  (optional — this is the default)
```

Without the token, the dialog renders a "Feedback isn't configured yet" fallback (FB-08) — graceful degradation, no crash.

## Test plan

- [x] 1159 vitest tests pass (+6 new; 0 regressions vs 1153 baseline)
- [x] E2E happy-path passes on chromium-dev (form open → fill → mock-network → success state)
- [x] Token-missing fallback renders correctly in test env
- [ ] **Manual UAT after merge + env var deployed:**
  - Click Help → see "Send feedback" entry → opens form
  - Submit feedback → see new issue created in repo
  - Test without token deployed → see fallback message

Spec: `.planning/phases/92-feedback-dialog/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)