### PR TITLE
fix(theme): default new users to light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
     <script>
       (function () {
         try {
-          var t = localStorage.getItem('room-cad-theme') || 'system';
+          // Default to 'light' for new users — no .dark class applied.
+          var t = localStorage.getItem('room-cad-theme') || 'light';
           var dark = t === 'dark' || (t === 'system' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
           if (dark) document.documentElement.classList.add('dark');
         } catch (e) {}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -16,11 +16,13 @@ export function useTheme(): {
   resolved: ResolvedTheme;
   setTheme: (t: ThemeChoice) => void;
 } {
+  // Default to "light" for new users (no stored choice).
+  // Existing users with a stored preference keep their choice.
   const [theme, setThemeState] = useState<ThemeChoice>(() => {
-    if (typeof window === "undefined") return "system";
+    if (typeof window === "undefined") return "light";
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === "light" || stored === "dark" || stored === "system") return stored;
-    return "system";
+    return "light";
   });
 
   const [systemDark, setSystemDark] = useState<boolean>(() => {


### PR DESCRIPTION
## Summary

Per user request, new users now default to light mode instead of \`system\` (follow OS).

## What changes

| File | Before | After |
|------|--------|-------|
| \`src/hooks/useTheme.ts\` | New users default to \`system\` → light if OS is light, dark if OS is dark | New users default to \`light\` regardless of OS |
| \`index.html\` boot bridge | Same — applied \`.dark\` if no choice + OS prefers dark | No \`.dark\` class on first paint for new users |

## What doesn't change

- Users with a stored preference (\`light\` / \`dark\` / \`system\`) keep their choice
- The Settings popover still offers all 3 options (Light / Dark / System)
- Picking \`System\` still follows OS preference for users who explicitly choose it

## Test plan

- [x] No new tests — single-line constants change
- [ ] Manual: open the app in a fresh browser profile (no localStorage) → should render light
- [ ] Existing dark-mode users → still in dark mode after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)